### PR TITLE
feat: support environment variables for Qdrant and Neo4j configuration

### DIFF
--- a/headroom/memory/backends/direct_mem0.py
+++ b/headroom/memory/backends/direct_mem0.py
@@ -85,14 +85,14 @@ class Mem0Config:
 
     mode: str = "local"
 
-    # Neo4j settings
-    neo4j_uri: str = "neo4j://localhost:7687"
-    neo4j_user: str = "neo4j"
-    neo4j_password: str = "password"
+    # Neo4j settings (overridable via HEADROOM_NEO4J_URI, etc.)
+    neo4j_uri: str = ""
+    neo4j_user: str = ""
+    neo4j_password: str = ""
 
-    # Qdrant settings
-    qdrant_host: str = "localhost"
-    qdrant_port: int = 6333
+    # Qdrant settings (overridable via HEADROOM_QDRANT_HOST, HEADROOM_QDRANT_PORT)
+    qdrant_host: str = ""
+    qdrant_port: int = 0
 
     # Embedding settings
     embedder_model: str = "text-embedding-3-small"
@@ -103,6 +103,23 @@ class Mem0Config:
     # Feature flags
     enable_graph: bool = True
     async_writes: bool = False  # If True, saves return immediately
+
+
+    def __post_init__(self) -> None:
+        """Resolve defaults from environment variables."""
+        import os
+
+        if not self.neo4j_uri:
+            self.neo4j_uri = os.environ.get("HEADROOM_NEO4J_URI", "neo4j://localhost:7687")
+        if not self.neo4j_user:
+            self.neo4j_user = os.environ.get("HEADROOM_NEO4J_USER", "neo4j")
+        if not self.neo4j_password:
+            self.neo4j_password = os.environ.get("HEADROOM_NEO4J_PASSWORD", "password")
+        if not self.qdrant_host:
+            self.qdrant_host = os.environ.get("HEADROOM_QDRANT_HOST", "localhost")
+        if not self.qdrant_port:
+            port_str = os.environ.get("HEADROOM_QDRANT_PORT", "6333")
+            self.qdrant_port = int(port_str)
 
 
 class DirectMem0Adapter:

--- a/headroom/memory/easy.py
+++ b/headroom/memory/easy.py
@@ -33,6 +33,7 @@ Backends:
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -93,11 +94,11 @@ class Memory:
         self,
         backend: str = "local",
         db_path: str | Path | None = None,
-        qdrant_host: str = "localhost",
-        qdrant_port: int = 6333,
-        neo4j_uri: str = "neo4j://localhost:7687",
-        neo4j_user: str = "neo4j",
-        neo4j_password: str = "password",
+        qdrant_host: str | None = None,
+        qdrant_port: int | None = None,
+        neo4j_uri: str | None = None,
+        neo4j_user: str | None = None,
+        neo4j_password: str | None = None,
     ) -> None:
         self._backend_type = backend
         self._backend: Any = None
@@ -111,12 +112,33 @@ class Memory:
             db_path = default_dir / "memory.db"
         self._db_path = Path(db_path)
 
-        # Config for qdrant-neo4j backend
-        self._qdrant_host = qdrant_host
-        self._qdrant_port = qdrant_port
-        self._neo4j_uri = neo4j_uri
-        self._neo4j_user = neo4j_user
-        self._neo4j_password = neo4j_password
+        # Config for qdrant-neo4j backend.
+        # Priority: explicit argument > environment variable > hardcoded default.
+        self._qdrant_host = (
+            qdrant_host
+            or os.environ.get("HEADROOM_QDRANT_HOST")
+            or "localhost"
+        )
+        self._qdrant_port = (
+            qdrant_port
+            or int(os.environ.get("HEADROOM_QDRANT_PORT", "0"))
+            or 6333
+        )
+        self._neo4j_uri = (
+            neo4j_uri
+            or os.environ.get("HEADROOM_NEO4J_URI")
+            or "neo4j://localhost:7687"
+        )
+        self._neo4j_user = (
+            neo4j_user
+            or os.environ.get("HEADROOM_NEO4J_USER")
+            or "neo4j"
+        )
+        self._neo4j_password = (
+            neo4j_password
+            or os.environ.get("HEADROOM_NEO4J_PASSWORD")
+            or "password"
+        )
 
     async def _ensure_initialized(self) -> None:
         """Initialize the backend on first use."""

--- a/tests/test_memory/test_easy.py
+++ b/tests/test_memory/test_easy.py
@@ -123,6 +123,34 @@ class TestMemoryInitialization:
         assert mem.backend_type == "local"
         assert not mem._initialized  # Lazy initialization
 
+    def test_qdrant_env_vars(self, monkeypatch):
+        """Test that Qdrant/Neo4j settings can be configured via environment variables."""
+        monkeypatch.setenv("HEADROOM_QDRANT_HOST", "qdrant.example.com")
+        monkeypatch.setenv("HEADROOM_QDRANT_PORT", "16333")
+        monkeypatch.setenv("HEADROOM_NEO4J_URI", "neo4j://neo4j.example.com:7687")
+        monkeypatch.setenv("HEADROOM_NEO4J_USER", "admin")
+        monkeypatch.setenv("HEADROOM_NEO4J_PASSWORD", "secret")
+
+        mem = Memory(backend="qdrant-neo4j")
+        assert mem._qdrant_host == "qdrant.example.com"
+        assert mem._qdrant_port == 16333
+        assert mem._neo4j_uri == "neo4j://neo4j.example.com:7687"
+        assert mem._neo4j_user == "admin"
+        assert mem._neo4j_password == "secret"
+
+    def test_explicit_args_override_env_vars(self, monkeypatch):
+        """Test that explicit arguments take priority over environment variables."""
+        monkeypatch.setenv("HEADROOM_QDRANT_HOST", "env-host")
+        monkeypatch.setenv("HEADROOM_QDRANT_PORT", "9999")
+
+        mem = Memory(
+            backend="qdrant-neo4j",
+            qdrant_host="explicit-host",
+            qdrant_port=7777,
+        )
+        assert mem._qdrant_host == "explicit-host"
+        assert mem._qdrant_port == 7777
+
     def test_explicit_local_backend(self, temp_db_path):
         """Test explicit local backend initialization."""
         mem = Memory(backend="local", db_path=temp_db_path)


### PR DESCRIPTION
## Description

Add support for configuring Qdrant host/port and Neo4j connection settings via environment variables, making it easy to deploy Headroom in Docker/Kubernetes environments without code changes.

Fixes #31

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `Memory` class (`easy.py`): Constructor now accepts `None` for Qdrant/Neo4j params and falls back to environment variables, then hardcoded defaults
- `Mem0Config` (`direct_mem0.py`): Added `__post_init__` to resolve env vars when fields are left at empty/zero defaults
- Added two unit tests verifying env var resolution and explicit-arg priority

### Environment Variables

| Variable | Default | Description |
|---|---|---|
| `HEADROOM_QDRANT_HOST` | `localhost` | Qdrant server hostname |
| `HEADROOM_QDRANT_PORT` | `6333` | Qdrant server port |
| `HEADROOM_NEO4J_URI` | `neo4j://localhost:7687` | Neo4j connection URI |
| `HEADROOM_NEO4J_USER` | `neo4j` | Neo4j username |
| `HEADROOM_NEO4J_PASSWORD` | `password` | Neo4j password |

### Priority Order

`explicit argument > environment variable > hardcoded default`

## Testing

- [x] New tests added for environment variable resolution
- [x] New tests added for explicit argument priority over env vars
- [x] Existing API is fully backward compatible (no breaking changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes