### PR TITLE
fix(docs): fix Docker example and document hnswlib C++ build requirement

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -248,7 +248,12 @@ Or with Docker:
 
 ```dockerfile
 FROM python:3.11-slim
-RUN pip install headroom[proxy]
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && pip install "headroom-ai[proxy]" \
+    && apt-get purge -y build-essential && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 EXPOSE 8787
 CMD ["headroom", "proxy", "--host", "0.0.0.0"]
 ```
+
+> **Note:** `build-essential` is required at install time because `headroom-ai` includes `hnswlib`, a C++ extension that must be compiled from source. It is removed after installation to keep the image slim.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -219,6 +219,39 @@ client = HeadroomClient(
 
 ## Import/Installation Issues
 
+### "pip install fails with C++ compilation error"
+
+**Symptom**: Installation fails with an error like:
+
+```
+RuntimeError: Unsupported compiler -- at least C++11 support is needed!
+ERROR: Failed building wheel for hnswlib
+```
+
+**Cause**: `headroom-ai` depends on `hnswlib`, a C++ extension that must be compiled from source. Slim environments (Docker slim images, minimal CI runners) lack the required build tools.
+
+**Solutions**:
+
+```bash
+# Linux / Debian-based (including Docker)
+apt-get install -y build-essential && pip install headroom-ai
+
+# macOS (Xcode command line tools)
+xcode-select --install && pip install headroom-ai
+```
+
+In a Dockerfile, install and remove build tools in one layer to keep the image slim:
+
+```dockerfile
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && pip install "headroom-ai[proxy]" \
+    && apt-get purge -y build-essential && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+---
+
 ### "ModuleNotFoundError: No module named 'headroom'"
 
 ```bash


### PR DESCRIPTION
## Problem

The Docker example in `docs/proxy.md` has two issues that cause installation to fail on slim images:

1. Wrong package name — `pip install headroom[proxy]` installs an unrelated PyPI package; the correct name is `headroom-ai`
2. Missing `build-essential` — `headroom-ai` depends on `hnswlib`, a C++ extension that must be compiled from source. Slim Docker images don't include a C++ compiler, so the install fails with:

```
RuntimeError: Unsupported compiler -- at least C++11 support is needed!
ERROR: Failed building wheel for hnswlib
```

## Changes

- **`docs/proxy.md`**: fix the Docker example with the correct package name and `build-essential` install/cleanup pattern
- **`docs/troubleshooting.md`**: add a new installation issue entry covering the C++ compilation error with solutions for Linux and macOS

## Notes

The repo's own `Dockerfile` (for building from source) already handles this correctly with `build-essential`. This PR aligns the user-facing docs example to match.