### PR TITLE
fix(ci): add sqlite-vec to dev deps to fix memory tests on CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ dev = [
     "ollama>=0.4.0",  # For Ollama integration tests (local LLM, no API key needed)
     "langchain-ollama>=0.2.0",  # For LangChain+Ollama integration tests
     "hnswlib>=0.8.0",  # For memory system tests
+    "sqlite-vec>=0.1.6",  # Fallback vector backend for CI runners without AVX support
 ]
 # All optional dependencies
 all = [


### PR DESCRIPTION
## Problem

`tests/test_memory_bridge.py` errors on CI with:

```
ValueError: hnswlib is not available. Install with: pip install hnswlib
```

The `AUTO` vector backend in `factory.py` prefers `sqlite-vec`, falling back to `hnswlib`. On GitHub Actions `ubuntu-latest` runners, hnswlib's subprocess AVX probe fails because the virtual CPU lacks AVX support — so both backends appear unavailable and the tests error at collection time.

## Root Cause

`[dev]` includes `hnswlib` but not `sqlite-vec`. Since `sqlite-vec` isn't installed, `AUTO` falls through to HNSW. Since the AVX probe fails on the runner, `HNSW_AVAILABLE = False` and the `ValueError` is raised.

## Fix

Add `sqlite-vec>=0.1.6` to `[dev]`. It ships pre-built wheels for all platforms, requires no C++ compilation, and has no AVX dependency. With it installed, `AUTO` selects `sqlite-vec` and the tests pass.

## Notes

`hnswlib` stays in `[dev]` — it's still tested where AVX is available and is used at runtime outside CI.