### PR TITLE
feat: read Qdrant connection settings from environment variables

### DIFF
--- a/headroom/memory/backends/direct_mem0.py
+++ b/headroom/memory/backends/direct_mem0.py
@@ -50,8 +50,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import os
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
@@ -91,8 +92,15 @@ class Mem0Config:
     neo4j_password: str = "password"
 
     # Qdrant settings
-    qdrant_host: str = "localhost"
-    qdrant_port: int = 6333
+    qdrant_host: str = field(
+        default_factory=lambda: os.environ.get("QDRANT_URL", "localhost")
+    )
+    qdrant_port: int = field(
+        default_factory=lambda: int(os.environ.get("QDRANT_PORT", "6333"))
+    )
+    qdrant_api_key: str | None = field(
+        default_factory=lambda: os.environ.get("QDRANT_API_KEY") or None
+    )
 
     # Embedding settings
     embedder_model: str = "text-embedding-3-small"
@@ -163,10 +171,14 @@ class DirectMem0Adapter:
         try:
             from qdrant_client import QdrantClient
 
-            self._qdrant_client = QdrantClient(
-                host=self._config.qdrant_host,
-                port=self._config.qdrant_port,
-            )
+            qdrant_kwargs: dict[str, Any] = {
+                "host": self._config.qdrant_host,
+                "port": self._config.qdrant_port,
+            }
+            if self._config.qdrant_api_key:
+                qdrant_kwargs["api_key"] = self._config.qdrant_api_key
+
+            self._qdrant_client = QdrantClient(**qdrant_kwargs)
         except ImportError:
             raise ImportError(
                 "qdrant-client not installed. Install with: pip install qdrant-client"
@@ -189,14 +201,18 @@ class DirectMem0Adapter:
         try:
             from mem0 import Memory as Mem0Memory
 
+            mem0_qdrant_cfg: dict[str, Any] = {
+                "host": self._config.qdrant_host,
+                "port": self._config.qdrant_port,
+                "collection_name": self._config.collection_name,
+            }
+            if self._config.qdrant_api_key:
+                mem0_qdrant_cfg["api_key"] = self._config.qdrant_api_key
+
             mem0_config: dict[str, Any] = {
                 "vector_store": {
                     "provider": "qdrant",
-                    "config": {
-                        "host": self._config.qdrant_host,
-                        "port": self._config.qdrant_port,
-                        "collection_name": self._config.collection_name,
-                    },
+                    "config": mem0_qdrant_cfg,
                 },
                 "llm": {
                     "provider": "openai",

--- a/headroom/memory/backends/direct_mem0.py
+++ b/headroom/memory/backends/direct_mem0.py
@@ -58,6 +58,7 @@ from typing import Any
 
 from headroom.memory.models import Memory
 from headroom.memory.ports import MemorySearchResult
+from headroom.utils import safe_int
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,7 @@ class Mem0Config:
         neo4j_password: Neo4j password for local mode.
         qdrant_host: Qdrant host for local mode.
         qdrant_port: Qdrant port for local mode.
+        qdrant_api_key: API key for Qdrant Cloud authentication (optional).
         embedder_model: Embedding model for vector search.
         collection_name: Name of the collection in Qdrant.
         enable_graph: Whether to enable graph storage (Neo4j).
@@ -96,7 +98,7 @@ class Mem0Config:
         default_factory=lambda: os.environ.get("QDRANT_URL", "localhost")
     )
     qdrant_port: int = field(
-        default_factory=lambda: int(os.environ.get("QDRANT_PORT", "6333"))
+        default_factory=lambda: safe_int(os.environ.get("QDRANT_PORT"), 6333)
     )
     qdrant_api_key: str | None = field(
         default_factory=lambda: os.environ.get("QDRANT_API_KEY") or None

--- a/headroom/memory/backends/mem0.py
+++ b/headroom/memory/backends/mem0.py
@@ -12,8 +12,9 @@ Supports both local mode (embedded services) and cloud mode (Mem0 API).
 from __future__ import annotations
 
 import asyncio
+import os
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
@@ -47,8 +48,15 @@ class Mem0Config:
     neo4j_uri: str = "neo4j://localhost:7687"
     neo4j_user: str = "neo4j"
     neo4j_password: str = "password"
-    qdrant_host: str = "localhost"
-    qdrant_port: int = 6333
+    qdrant_host: str = field(
+        default_factory=lambda: os.environ.get("QDRANT_URL", "localhost")
+    )
+    qdrant_port: int = field(
+        default_factory=lambda: int(os.environ.get("QDRANT_PORT", "6333"))
+    )
+    qdrant_api_key: str | None = field(
+        default_factory=lambda: os.environ.get("QDRANT_API_KEY") or None
+    )
 
     # Common settings
     llm_model: str = "gpt-4o-mini"  # For entity extraction
@@ -117,14 +125,18 @@ class Mem0Backend:
                 self._client = await asyncio.to_thread(Mem0Memory, api_key=self._config.api_key)
             else:
                 # Local mode with configuration
+                qdrant_cfg: dict[str, Any] = {
+                    "host": self._config.qdrant_host,
+                    "port": self._config.qdrant_port,
+                    "collection_name": self._config.collection_name,
+                }
+                if self._config.qdrant_api_key:
+                    qdrant_cfg["api_key"] = self._config.qdrant_api_key
+
                 config: dict[str, Any] = {
                     "vector_store": {
                         "provider": "qdrant",
-                        "config": {
-                            "host": self._config.qdrant_host,
-                            "port": self._config.qdrant_port,
-                            "collection_name": self._config.collection_name,
-                        },
+                        "config": qdrant_cfg,
                     },
                     "llm": {
                         "provider": "openai",

--- a/headroom/memory/backends/mem0.py
+++ b/headroom/memory/backends/mem0.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from headroom.memory.models import Memory
 from headroom.memory.ports import MemoryFilter, VectorFilter, VectorSearchResult
+from headroom.utils import safe_int
 
 
 @dataclass
@@ -34,6 +35,7 @@ class Mem0Config:
         neo4j_password: Neo4j password for local mode.
         qdrant_host: Qdrant host for local mode.
         qdrant_port: Qdrant port for local mode.
+        qdrant_api_key: API key for Qdrant Cloud authentication (optional).
         llm_model: LLM model for entity extraction.
         embedder_model: Embedding model for vector search.
         collection_name: Name of the collection/namespace in Mem0.
@@ -52,7 +54,7 @@ class Mem0Config:
         default_factory=lambda: os.environ.get("QDRANT_URL", "localhost")
     )
     qdrant_port: int = field(
-        default_factory=lambda: int(os.environ.get("QDRANT_PORT", "6333"))
+        default_factory=lambda: safe_int(os.environ.get("QDRANT_PORT"), 6333)
     )
     qdrant_api_key: str | None = field(
         default_factory=lambda: os.environ.get("QDRANT_API_KEY") or None

--- a/headroom/memory/easy.py
+++ b/headroom/memory/easy.py
@@ -38,6 +38,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from headroom.utils import safe_int
+
 if TYPE_CHECKING:
     from headroom.memory.ports import MemorySearchResult
 
@@ -116,7 +118,7 @@ class Memory:
         # Config for qdrant-neo4j backend
         # Explicit constructor args take priority over environment variables
         self._qdrant_host = qdrant_host or os.environ.get("QDRANT_URL", "localhost")
-        self._qdrant_port = qdrant_port if qdrant_port is not None else int(os.environ.get("QDRANT_PORT", "6333"))
+        self._qdrant_port = qdrant_port if qdrant_port is not None else safe_int(os.environ.get("QDRANT_PORT"), 6333)
         self._qdrant_api_key = qdrant_api_key or os.environ.get("QDRANT_API_KEY") or None
         self._neo4j_uri = neo4j_uri
         self._neo4j_user = neo4j_user

--- a/headroom/memory/easy.py
+++ b/headroom/memory/easy.py
@@ -33,6 +33,7 @@ Backends:
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -93,8 +94,9 @@ class Memory:
         self,
         backend: str = "local",
         db_path: str | Path | None = None,
-        qdrant_host: str = "localhost",
-        qdrant_port: int = 6333,
+        qdrant_host: str | None = None,
+        qdrant_port: int | None = None,
+        qdrant_api_key: str | None = None,
         neo4j_uri: str = "neo4j://localhost:7687",
         neo4j_user: str = "neo4j",
         neo4j_password: str = "password",
@@ -112,8 +114,10 @@ class Memory:
         self._db_path = Path(db_path)
 
         # Config for qdrant-neo4j backend
-        self._qdrant_host = qdrant_host
-        self._qdrant_port = qdrant_port
+        # Explicit constructor args take priority over environment variables
+        self._qdrant_host = qdrant_host or os.environ.get("QDRANT_URL", "localhost")
+        self._qdrant_port = qdrant_port if qdrant_port is not None else int(os.environ.get("QDRANT_PORT", "6333"))
+        self._qdrant_api_key = qdrant_api_key or os.environ.get("QDRANT_API_KEY") or None
         self._neo4j_uri = neo4j_uri
         self._neo4j_user = neo4j_user
         self._neo4j_password = neo4j_password
@@ -139,6 +143,7 @@ class Memory:
                 mem0_config = Mem0Config(
                     qdrant_host=self._qdrant_host,
                     qdrant_port=self._qdrant_port,
+                    qdrant_api_key=self._qdrant_api_key,
                     neo4j_uri=self._neo4j_uri,
                     neo4j_user=self._neo4j_user,
                     neo4j_password=self._neo4j_password,

--- a/headroom/proxy/memory_handler.py
+++ b/headroom/proxy/memory_handler.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+from headroom.utils import safe_int
+
 if TYPE_CHECKING:
     from headroom.memory.backends.local import LocalBackend
 
@@ -68,7 +70,7 @@ class MemoryConfig:
         default_factory=lambda: os.environ.get("QDRANT_URL", "localhost")
     )
     qdrant_port: int = field(
-        default_factory=lambda: int(os.environ.get("QDRANT_PORT", "6333"))
+        default_factory=lambda: safe_int(os.environ.get("QDRANT_PORT"), 6333)
     )
     qdrant_api_key: str | None = field(
         default_factory=lambda: os.environ.get("QDRANT_API_KEY") or None

--- a/headroom/proxy/memory_handler.py
+++ b/headroom/proxy/memory_handler.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -63,8 +64,15 @@ class MemoryConfig:
     use_native_tool: bool = False
     native_memory_dir: str = ""  # Directory for native memory files (default: ~/.headroom/memories)
     # Qdrant+Neo4j config
-    qdrant_host: str = "localhost"
-    qdrant_port: int = 6333
+    qdrant_host: str = field(
+        default_factory=lambda: os.environ.get("QDRANT_URL", "localhost")
+    )
+    qdrant_port: int = field(
+        default_factory=lambda: int(os.environ.get("QDRANT_PORT", "6333"))
+    )
+    qdrant_api_key: str | None = field(
+        default_factory=lambda: os.environ.get("QDRANT_API_KEY") or None
+    )
     neo4j_uri: str = "neo4j://localhost:7687"
     neo4j_user: str = "neo4j"
     neo4j_password: str = "password"
@@ -150,6 +158,7 @@ class MemoryHandler:
                 mem0_config = Mem0Config(
                     qdrant_host=self.config.qdrant_host,
                     qdrant_port=self.config.qdrant_port,
+                    qdrant_api_key=self.config.qdrant_api_key,
                     neo4j_uri=self.config.neo4j_uri,
                     neo4j_user=self.config.neo4j_user,
                     neo4j_password=self.config.neo4j_password,

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -703,8 +703,15 @@ class ProxyConfig:
     memory_top_k: int = 10  # Number of memories to inject
     memory_min_similarity: float = 0.3  # Minimum similarity threshold
     # Qdrant+Neo4j config (only used when memory_backend="qdrant-neo4j")
-    memory_qdrant_host: str = "localhost"
-    memory_qdrant_port: int = 6333
+    memory_qdrant_host: str = field(
+        default_factory=lambda: os.environ.get("QDRANT_URL", "localhost")
+    )
+    memory_qdrant_port: int = field(
+        default_factory=lambda: int(os.environ.get("QDRANT_PORT", "6333"))
+    )
+    memory_qdrant_api_key: str | None = field(
+        default_factory=lambda: os.environ.get("QDRANT_API_KEY") or None
+    )
     memory_neo4j_uri: str = "neo4j://localhost:7687"
     memory_neo4j_user: str = "neo4j"
     memory_neo4j_password: str = "password"
@@ -1729,6 +1736,7 @@ class HeadroomProxy:
                 min_similarity=config.memory_min_similarity,
                 qdrant_host=config.memory_qdrant_host,
                 qdrant_port=config.memory_qdrant_port,
+                qdrant_api_key=config.memory_qdrant_api_key,
                 neo4j_uri=config.memory_neo4j_uri,
                 neo4j_user=config.memory_neo4j_user,
                 neo4j_password=config.memory_neo4j_password,

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -58,6 +58,7 @@ except ImportError:
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from headroom import __version__
+from headroom.utils import safe_int
 from headroom.backends import AnyLLMBackend, LiteLLMBackend
 from headroom.backends.base import Backend
 from headroom.cache.compression_feedback import get_compression_feedback
@@ -707,7 +708,7 @@ class ProxyConfig:
         default_factory=lambda: os.environ.get("QDRANT_URL", "localhost")
     )
     memory_qdrant_port: int = field(
-        default_factory=lambda: int(os.environ.get("QDRANT_PORT", "6333"))
+        default_factory=lambda: safe_int(os.environ.get("QDRANT_PORT"), 6333)
     )
     memory_qdrant_api_key: str | None = field(
         default_factory=lambda: os.environ.get("QDRANT_API_KEY") or None

--- a/headroom/utils.py
+++ b/headroom/utils.py
@@ -213,3 +213,16 @@ def deep_copy_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Create a deep copy of messages list."""
     result: list[dict[str, Any]] = json.loads(json.dumps(messages))
     return result
+
+
+def safe_int(val: Any, default: int) -> int:
+    """Safely parse *val* as an integer, returning *default* on failure.
+
+    Handles ``None``, empty strings, and non-numeric strings without
+    raising ``TypeError`` or ``ValueError`` — useful for environment
+    variables that may contain unexpected values.
+    """
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return default


### PR DESCRIPTION
## Summary

Replaces hardcoded `localhost` / `6333` Qdrant defaults with environment variable reads across all Qdrant-aware config dataclasses and the public Memory API:

- `QDRANT_URL` — host/URL (default: `localhost`)
- `QDRANT_PORT` — port (default: `6333`)
- `QDRANT_API_KEY` — optional auth key (default: unset)

### Files changed
- `headroom/memory/backends/mem0.py` — Mem0Config dataclass
- `headroom/memory/backends/direct_mem0.py` — Mem0Config dataclass + QdrantClient init
- `headroom/memory/easy.py` — Memory() constructor
- `headroom/proxy/memory_handler.py` — MemoryConfig dataclass
- `headroom/proxy/server.py` — ProxyConfig dataclass

Explicit constructor/config arguments still override env vars — no breaking change for callers that pass values directly.

## Test plan

- [ ] Set `QDRANT_URL=my-qdrant-host` and verify Headroom connects to that host
- [ ] Unset all env vars and verify defaults (`localhost:6333`) still work
- [ ] Set `QDRANT_API_KEY` and verify it's passed to QdrantClient

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)