### PR TITLE
fix: handle OpenAI response decoding errors gracefully

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -1968,6 +1968,26 @@ class HeadroomProxy:
                 tags[tag_name] = value
         return tags
 
+    @staticmethod
+    def _prepare_forwarding_headers(request: Request) -> dict:
+        """Prepare headers for forwarding to upstream APIs.
+
+        Strips hop-by-hop headers and accept-encoding to prevent
+        content-encoding mismatches. When a client (e.g. Codex GUI) sends
+        Accept-Encoding values the proxy's HTTP client doesn't support
+        (like zstd), the upstream may return compressed data that cannot
+        be decoded, causing UnicodeDecodeError crashes.
+
+        By removing accept-encoding, httpx negotiates its own supported
+        encodings with the upstream API.
+        """
+        headers = dict(request.headers.items())
+        headers.pop("host", None)
+        headers.pop("content-length", None)
+        headers.pop("accept-encoding", None)
+        headers.pop("transfer-encoding", None)
+        return headers
+
     def _inject_system_context(
         self,
         messages: list[dict[str, Any]],
@@ -2118,9 +2138,7 @@ class HeadroomProxy:
                     )
 
         # Extract headers and tags
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
         tags = self._extract_tags(headers)
 
         # Rate limiting
@@ -2545,7 +2563,7 @@ class HeadroomProxy:
                 resp_json = None
                 try:
                     resp_json = response.json()
-                except (json.JSONDecodeError, ValueError) as e:
+                except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
                     logger.debug(
                         f"[{request_id}] Failed to parse response JSON for CCR handling: {e}"
                     )
@@ -2908,9 +2926,7 @@ class HeadroomProxy:
             )
 
         # Extract headers
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
 
         # Track compression stats across all batch requests
         total_original_tokens = 0
@@ -3089,8 +3105,7 @@ class HeadroomProxy:
         if request.url.query:
             url = f"{url}?{request.url.query}"
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
+        headers = self._prepare_forwarding_headers(request)
 
         body = await request.body()
 
@@ -3184,8 +3199,7 @@ class HeadroomProxy:
         if request.url.query:
             url = f"{url}?{request.url.query}"
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
+        headers = self._prepare_forwarding_headers(request)
 
         response = await self.http_client.get(url, headers=headers)  # type: ignore[union-attr]
 
@@ -3201,7 +3215,7 @@ class HeadroomProxy:
             )
 
         # Parse results - Anthropic batch results are JSONL format
-        raw_content = response.content.decode("utf-8")
+        raw_content = response.content.decode("utf-8", errors="replace")
         results = []
         for line in raw_content.strip().split("\n"):
             if line.strip():
@@ -3343,9 +3357,7 @@ class HeadroomProxy:
             return await self._google_batch_passthrough(request, model, body)
 
         # Extract headers
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
 
         # Track compression stats
         total_original_tokens = 0
@@ -3556,9 +3568,7 @@ class HeadroomProxy:
         """Pass through Google batch request without modification."""
         start_time = time.time()
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
 
         url = f"{self.GEMINI_API_URL}/v1beta/models/{model}:batchGenerateContent"
 
@@ -3619,8 +3629,7 @@ class HeadroomProxy:
         if request.url.query:
             url = f"{url}?{request.url.query}"
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
+        headers = self._prepare_forwarding_headers(request)
 
         # Handle API key
         api_key = headers.pop("x-goog-api-key", None)
@@ -3734,8 +3743,7 @@ class HeadroomProxy:
         if request.url.query:
             url = f"{url}?{request.url.query}"
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
+        headers = self._prepare_forwarding_headers(request)
 
         # Handle API key
         api_key = headers.pop("x-goog-api-key", None)
@@ -3761,7 +3769,7 @@ class HeadroomProxy:
         # Parse response
         try:
             response_data = response.json()
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             # Not JSON - pass through
             response_headers = dict(response.headers)
             response_headers.pop("content-encoding", None)
@@ -4709,9 +4717,7 @@ class HeadroomProxy:
                         f"{compressor.last_result.compressed_tokens} tokens)"
                     )
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
         tags = self._extract_tags(headers)
 
         # Rate limiting
@@ -4996,7 +5002,13 @@ class HeadroomProxy:
                     # These are charged at 50% of the input price
                     prompt_details = usage.get("prompt_tokens_details", {})
                     cache_read_tokens = prompt_details.get("cached_tokens", 0)
-                except (KeyError, TypeError, AttributeError) as e:
+                except (
+                    KeyError,
+                    TypeError,
+                    AttributeError,
+                    UnicodeDecodeError,
+                    json.JSONDecodeError,
+                ) as e:
                     logger.debug(
                         f"[{request_id}] Failed to extract cached tokens from OpenAI response: {e}"
                     )
@@ -5095,8 +5107,7 @@ class HeadroomProxy:
         if request.url.query:
             url = f"{url}?{request.url.query}"
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
+        headers = self._prepare_forwarding_headers(request)
 
         body = await request.body()
 
@@ -5252,9 +5263,7 @@ class HeadroomProxy:
             # Pass through for other endpoints
             return await self._batch_passthrough(request, body)
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
 
         try:
             # Step 1: Download the input file from OpenAI
@@ -5533,9 +5542,7 @@ class HeadroomProxy:
 
     async def _batch_passthrough(self, request: Request, body: dict) -> Response:
         """Pass through batch request to OpenAI without compression."""
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
 
         url = f"{self.OPENAI_API_URL}/v1/batches"
         response = await self.http_client.post(url, json=body, headers=headers)  # type: ignore[union-attr]
@@ -5718,9 +5725,7 @@ class HeadroomProxy:
             # Input is already an array of message objects
             messages.extend(input_data)
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
         tags = self._extract_tags(headers)
 
         # Rate limiting
@@ -5774,7 +5779,13 @@ class HeadroomProxy:
                     usage = resp_json.get("usage", {})
                     total_input_tokens = usage.get("input_tokens", original_tokens)
                     output_tokens = usage.get("output_tokens", 0)
-                except (KeyError, TypeError, AttributeError) as e:
+                except (
+                    KeyError,
+                    TypeError,
+                    AttributeError,
+                    UnicodeDecodeError,
+                    json.JSONDecodeError,
+                ) as e:
                     logger.debug(
                         f"[{request_id}] Failed to extract cached tokens from OpenAI passthrough response: {e}"
                     )
@@ -5863,9 +5874,7 @@ class HeadroomProxy:
 
         contents = body.get("contents", [])
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
         tags = self._extract_tags(headers)
 
         # Rate limiting (use Gemini API key)
@@ -6030,7 +6039,13 @@ class HeadroomProxy:
                     # Gemini returns cachedContentTokenCount for context-cached tokens
                     # These are charged at 10-25% of the input price depending on model
                     cache_read_tokens = usage.get("cachedContentTokenCount", 0)
-                except (KeyError, TypeError, AttributeError) as e:
+                except (
+                    KeyError,
+                    TypeError,
+                    AttributeError,
+                    UnicodeDecodeError,
+                    json.JSONDecodeError,
+                ) as e:
                     logger.debug(
                         f"[{request_id}] Failed to extract cached tokens from Gemini response: {e}"
                     )
@@ -6116,9 +6131,7 @@ class HeadroomProxy:
 
         contents = body.get("contents", [])
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
         tags = self._extract_tags(headers)
 
         # Token counting
@@ -6185,9 +6198,7 @@ class HeadroomProxy:
 
         contents = body.get("contents", [])
 
-        headers = dict(request.headers.items())
-        headers.pop("host", None)
-        headers.pop("content-length", None)
+        headers = self._prepare_forwarding_headers(request)
 
         # Convert Gemini format to messages for optimization
         system_instruction = body.get("systemInstruction")
@@ -6273,7 +6284,7 @@ class HeadroomProxy:
             try:
                 resp_json = response.json()
                 compressed_tokens = resp_json.get("totalTokens", 0)
-            except (json.JSONDecodeError, ValueError) as e:
+            except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
                 logger.debug(f"[{request_id}] Failed to parse Gemini token count response: {e}")
 
             # Track stats

--- a/tests/test_proxy_compression_headers.py
+++ b/tests/test_proxy_compression_headers.py
@@ -3,12 +3,18 @@
 These tests verify that the proxy correctly removes Content-Encoding headers
 from responses after httpx automatically decompresses them, preventing
 double-decompression errors (ZlibError) in clients.
+
+Also tests _prepare_forwarding_headers to prevent accept-encoding forwarding
+that causes UnicodeDecodeError crashes (GitHub issue #45).
 """
 
 import gzip
 import json
+from unittest.mock import MagicMock
 
 import pytest
+
+from headroom.proxy.server import HeadroomProxy
 
 
 @pytest.fixture
@@ -148,3 +154,177 @@ class TestNoRegressionForUncompressedResponses:
         # All headers preserved
         assert converted == original_headers
         assert converted is not original_headers  # New object
+
+
+class TestPrepareForwardingHeaders:
+    """Tests for _prepare_forwarding_headers (fix for GitHub issue #45).
+
+    When a client (e.g. Codex GUI) sends Accept-Encoding values the proxy's
+    HTTP client doesn't support (like zstd), the upstream may return compressed
+    data that cannot be decoded, causing UnicodeDecodeError crashes.
+
+    _prepare_forwarding_headers strips these problematic headers so httpx
+    negotiates its own supported encodings with the upstream API.
+    """
+
+    @staticmethod
+    def _make_mock_request(headers: dict) -> MagicMock:
+        """Create a mock Starlette Request with the given headers."""
+        mock_request = MagicMock()
+        mock_request.headers = MagicMock()
+        mock_request.headers.items.return_value = list(headers.items())
+        return mock_request
+
+    def test_strips_accept_encoding(self):
+        """Accept-Encoding must be stripped to prevent unsupported encoding responses."""
+        request = self._make_mock_request(
+            {
+                "host": "localhost:8787",
+                "content-type": "application/json",
+                "accept-encoding": "gzip, deflate, br, zstd",
+                "authorization": "Bearer sk-test",
+            }
+        )
+
+        headers = HeadroomProxy._prepare_forwarding_headers(request)
+
+        assert "accept-encoding" not in headers
+        assert "host" not in headers
+        assert headers["authorization"] == "Bearer sk-test"
+        assert headers["content-type"] == "application/json"
+
+    def test_strips_host_and_content_length(self):
+        """Host and content-length must always be stripped for forwarding."""
+        request = self._make_mock_request(
+            {
+                "host": "localhost:8787",
+                "content-length": "1234",
+                "content-type": "application/json",
+            }
+        )
+
+        headers = HeadroomProxy._prepare_forwarding_headers(request)
+
+        assert "host" not in headers
+        assert "content-length" not in headers
+        assert headers["content-type"] == "application/json"
+
+    def test_strips_transfer_encoding(self):
+        """Transfer-encoding is hop-by-hop and must not be forwarded."""
+        request = self._make_mock_request(
+            {
+                "host": "localhost",
+                "transfer-encoding": "chunked",
+                "content-type": "application/json",
+            }
+        )
+
+        headers = HeadroomProxy._prepare_forwarding_headers(request)
+
+        assert "transfer-encoding" not in headers
+
+    def test_preserves_authorization_headers(self):
+        """Authorization and API key headers must be preserved."""
+        request = self._make_mock_request(
+            {
+                "host": "localhost",
+                "authorization": "Bearer sk-test",
+                "x-api-key": "test-key",
+                "x-goog-api-key": "goog-key",
+            }
+        )
+
+        headers = HeadroomProxy._prepare_forwarding_headers(request)
+
+        assert headers["authorization"] == "Bearer sk-test"
+        assert headers["x-api-key"] == "test-key"
+        assert headers["x-goog-api-key"] == "goog-key"
+
+    def test_preserves_headroom_tags(self):
+        """Custom Headroom headers (x-headroom-*) must be preserved."""
+        request = self._make_mock_request(
+            {
+                "host": "localhost",
+                "x-headroom-tag": "my-tag",
+                "x-headroom-session": "abc123",
+            }
+        )
+
+        headers = HeadroomProxy._prepare_forwarding_headers(request)
+
+        assert headers["x-headroom-tag"] == "my-tag"
+        assert headers["x-headroom-session"] == "abc123"
+
+    def test_handles_codex_gui_headers(self):
+        """Simulate typical Codex GUI request headers.
+
+        Codex GUI sends Accept-Encoding with zstd which httpx cannot
+        decompress, causing UnicodeDecodeError when the upstream responds
+        with zstd-compressed data. This is the exact scenario from issue #45.
+        """
+        request = self._make_mock_request(
+            {
+                "host": "127.0.0.1:8787",
+                "content-type": "application/json",
+                "accept-encoding": "gzip, deflate, br, zstd",
+                "authorization": "Bearer sk-proj-test",
+                "content-length": "500",
+                "user-agent": "codex-gui/1.0",
+            }
+        )
+
+        headers = HeadroomProxy._prepare_forwarding_headers(request)
+
+        # Problematic headers stripped
+        assert "accept-encoding" not in headers
+        assert "host" not in headers
+        assert "content-length" not in headers
+
+        # Important headers preserved
+        assert headers["authorization"] == "Bearer sk-proj-test"
+        assert headers["content-type"] == "application/json"
+        assert headers["user-agent"] == "codex-gui/1.0"
+
+    def test_safe_when_headers_already_missing(self):
+        """No error when stripped headers are not present in the request."""
+        request = self._make_mock_request(
+            {
+                "content-type": "application/json",
+            }
+        )
+
+        headers = HeadroomProxy._prepare_forwarding_headers(request)
+
+        assert headers == {"content-type": "application/json"}
+
+
+class TestResponseDecodeErrorHandling:
+    """Tests verifying that compressed/binary response data doesn't crash json.loads.
+
+    When a compressed response body reaches json.loads() as bytes, Python's json
+    module calls detect_encoding() + .decode('utf-8', 'surrogatepass'), which
+    raises UnicodeDecodeError on binary data like zstd-compressed content.
+    """
+
+    def test_json_loads_on_zstd_bytes_raises_unicode_error(self):
+        """Demonstrate the exact crash from issue #45: json.loads on compressed bytes."""
+        # Simulate zstd-compressed data (magic bytes: 0x28 0xb5 0x2f 0xfd)
+        zstd_data = b"\x28\xb5\x2f\xfd\x00\x00\x00\x00\x00"
+
+        with pytest.raises(UnicodeDecodeError):
+            json.loads(zstd_data)
+
+    def test_json_loads_on_gzip_bytes_raises_error(self):
+        """json.loads on gzip bytes raises either UnicodeDecodeError or JSONDecodeError."""
+        gzip_data = gzip.compress(b'{"key": "value"}')
+
+        with pytest.raises((UnicodeDecodeError, json.JSONDecodeError)):
+            json.loads(gzip_data)
+
+    def test_utf8_decode_with_replace_handles_binary(self):
+        """bytes.decode('utf-8', errors='replace') safely handles binary data."""
+        zstd_data = b"\x28\xb5\x2f\xfd\x00\x00\x00\x00\x00"
+
+        # Should not raise - replaces invalid bytes with replacement character
+        result = zstd_data.decode("utf-8", errors="replace")
+        assert isinstance(result, str)


### PR DESCRIPTION
## Summary
- **Root cause**: The proxy forwarded the client's `Accept-Encoding` header verbatim to upstream APIs. When Codex GUI sends `Accept-Encoding: gzip, deflate, br, zstd` but httpx doesn't support zstd decompression, the upstream responds with zstd-compressed data that `json.loads()` cannot decode, crashing with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb5 in position 1`.
- **Primary fix**: Added `_prepare_forwarding_headers()` helper method that strips `accept-encoding` and `transfer-encoding` (hop-by-hop headers) from all forwarded requests, letting httpx negotiate its own supported encodings with the upstream API. Replaced all 16 manual header-stripping call sites with this centralized helper.
- **Defense-in-depth**: Added `UnicodeDecodeError` to `except` clauses on all `response.json()` calls so that even if compressed data somehow reaches the JSON parser, it is handled gracefully instead of crashing the proxy. Also switched a raw `bytes.decode("utf-8")` call to use `errors="replace"`.
- **Tests**: Added 10 new tests covering the header stripping behavior, Codex GUI header simulation, and compressed data decode error scenarios.

## Test plan
- [x] All 2332 non-integration unit tests pass (0 failures)
- [x] 16 compression header tests pass (6 existing + 10 new)
- [ ] Manual test: Run `headroom proxy` with `OPENAI_BASE_URL=http://127.0.0.1:8787/v1` and Codex GUI to confirm no crash on `/v1/responses` endpoint
- [ ] Manual test: Verify streaming responses from OpenAI Responses API work correctly through the proxy
- [ ] Manual test: Verify non-streaming responses still return correct JSON

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)