### PR TITLE
feat: allow overriding proxy telemetry sdk via HEADROOM_SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Proxy telemetry SDK override** via `HEADROOM_SDK`
+  - Downstream apps can override the anonymous telemetry `sdk` field without patching installed files
+  - Blank values fall back to the default `proxy` label
 - **`headroom learn`** — Offline failure learning for coding agents
   - Analyzes past conversation history (Claude Code, extensible to Cursor/Codex)
   - **Success correlation**: for each failure, finds what succeeded after and extracts the specific correction

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -21,6 +21,8 @@ headroom proxy \
   --budget 100.0
 ```
 
+Telemetry is enabled by default. Opt out with `HEADROOM_TELEMETRY=off` or `headroom proxy --no-telemetry`. Downstream apps can set `HEADROOM_SDK=headroom-app` to override the anonymous telemetry `sdk` label; the default remains `proxy`.
+
 ## Command Line Options
 
 ### Core Options

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -6966,7 +6966,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
     _beacon = TelemetryBeacon(
         port=config.port if hasattr(config, "port") else 8787,
-        sdk="proxy",
+        sdk=os.environ.get("HEADROOM_SDK", "proxy").strip() or "proxy",
         backend=config.backend if hasattr(config, "backend") else "anthropic",
     )
 

--- a/tests/test_proxy_telemetry_env.py
+++ b/tests/test_proxy_telemetry_env.py
@@ -1,0 +1,58 @@
+"""Tests for proxy telemetry environment variable handling."""
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from headroom.proxy.server import ProxyConfig, create_app
+
+
+class TestProxyTelemetrySDKEnv:
+    """Test HEADROOM_SDK handling when the proxy builds telemetry beacons."""
+
+    def test_proxy_telemetry_sdk_defaults_to_proxy(self, monkeypatch):
+        """Telemetry beacon uses the default SDK label when env var is unset."""
+        monkeypatch.delenv("HEADROOM_SDK", raising=False)
+
+        with patch("headroom.telemetry.beacon.TelemetryBeacon") as mock_beacon:
+            create_app(
+                ProxyConfig(
+                    cache_enabled=False,
+                    rate_limit_enabled=False,
+                    cost_tracking_enabled=False,
+                )
+            )
+
+        assert mock_beacon.call_args.kwargs["sdk"] == "proxy"
+
+    def test_proxy_telemetry_sdk_uses_env_override(self, monkeypatch):
+        """Telemetry beacon uses HEADROOM_SDK when it is non-empty."""
+        monkeypatch.setenv("HEADROOM_SDK", "headroom-app")
+
+        with patch("headroom.telemetry.beacon.TelemetryBeacon") as mock_beacon:
+            create_app(
+                ProxyConfig(
+                    cache_enabled=False,
+                    rate_limit_enabled=False,
+                    cost_tracking_enabled=False,
+                )
+            )
+
+        assert mock_beacon.call_args.kwargs["sdk"] == "headroom-app"
+
+    def test_proxy_telemetry_sdk_empty_env_falls_back_to_proxy(self, monkeypatch):
+        """Telemetry beacon falls back to proxy when HEADROOM_SDK is blank."""
+        monkeypatch.setenv("HEADROOM_SDK", "   ")
+
+        with patch("headroom.telemetry.beacon.TelemetryBeacon") as mock_beacon:
+            create_app(
+                ProxyConfig(
+                    cache_enabled=False,
+                    rate_limit_enabled=False,
+                    cost_tracking_enabled=False,
+                )
+            )
+
+        assert mock_beacon.call_args.kwargs["sdk"] == "proxy"


### PR DESCRIPTION
## Description

Add minimal upstream support for overriding Headroom proxy telemetry's `sdk` field via `HEADROOM_SDK`, so downstream apps can report a custom SDK label without patching installed files.

Fixes #N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Read `HEADROOM_SDK` when creating the proxy `TelemetryBeacon`, with whitespace-aware fallback to the existing default `"proxy"`
- Added focused proxy telemetry tests covering default behavior, explicit override, and blank-value fallback
- Documented `HEADROOM_SDK` in proxy docs and added an Unreleased changelog entry

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

## Test Output

```text
$ .venv/bin/pytest tests/test_proxy_telemetry_env.py
============================= test session starts ==============================
collected 3 items

tests/test_proxy_telemetry_env.py::TestProxyTelemetrySDKEnv::test_proxy_telemetry_sdk_defaults_to_proxy PASSED [ 33%]
tests/test_proxy_telemetry_env.py::TestProxyTelemetrySDKEnv::test_proxy_telemetry_sdk_uses_env_override PASSED [ 66%]
tests/test_proxy_telemetry_env.py::TestProxyTelemetrySDKEnv::test_proxy_telemetry_sdk_empty_env_falls_back_to_proxy PASSED [100%]

============================== 3 passed in 11.96s ==============================

$ .venv/bin/ruff check .
All checks passed!

$ .venv/bin/mypy headroom --ignore-missing-imports
Success: no issues found in 230 source files
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

- Default behavior is unchanged unless `HEADROOM_SDK` is set.
- Telemetry opt-out behavior remains unchanged: `HEADROOM_TELEMETRY=off` and `--no-telemetry` still disable telemetry.
- I intentionally kept this as a minimal upstream change and did not add a new CLI flag.
