### PR TITLE
fix: move extract_user_query import out of conditional scope

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2410,10 +2410,9 @@ class HeadroomProxy:
         original_tokens = tokenizer.count_messages(messages)
 
         # Hook: pre_compress — let hooks modify messages before compression
+        from headroom.transforms.query_echo import extract_user_query
         if self.config.hooks:
             from headroom.hooks import CompressContext
-            from headroom.transforms.query_echo import extract_user_query
-
             _hook_ctx = CompressContext(
                 model=model,
                 user_query=extract_user_query(messages),


### PR DESCRIPTION
## Description
When `self.config.hooks` is falsy, the conditional import of `extract_user_query` 
never runs. But Python has already marked it as a local variable in the function 
scope, causing:

`cannot access free variable 'extract_user_query' where it is not associated with a value in enclosing scope`

This silently falls back to a no-op (`transforms=none`, `tok_saved=0`), meaning 
compression never runs at all.

Fix: move the import out of the conditional so it is always bound.

Fixes #59

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Moved `from headroom.transforms.query_echo import extract_user_query` out of 
  the `if self.config.hooks` block in `headroom/proxy/server.py`

## Testing
- [x] Manual testing performed

## Test Output
Before fix:
`WARNING - Optimization failed: cannot access free variable 'extract_user_query'`
`transforms=none tok_saved=0`

After fix:
`transforms=content_router tok_saved=90777`
Cost reduced from $0.84 → $0.24 (71.8% savings)

## Additional Notes
The fix was verified on headroom-ai 0.5.7 with claude-sonnet-4-6.