### PR TITLE
feat: Add Anthropic url overrides via env vars and cli flags

### DIFF
--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -95,6 +95,11 @@ from .main import main
     help="Provider for any-llm backend: openai, mistral, groq, ollama, etc. (default: openai)",
 )
 @click.option(
+    "--anthropic-api-url",
+    default=None,
+    help="Custom Anthropic API URL for passthrough endpoints (env: ANTHROPIC_TARGET_API_URL)",
+)
+@click.option(
     "--openai-api-url",
     default=None,
     help="Custom OpenAI API URL for passthrough endpoints (env: OPENAI_TARGET_API_URL)",
@@ -149,6 +154,7 @@ def proxy(
     no_learn: bool,
     backend: str,
     anyllm_provider: str,
+    anthropic_api_url: str | None,
     openai_api_url: str | None,
     gemini_api_url: str | None,
     region: str,
@@ -181,6 +187,7 @@ def proxy(
         raise SystemExit(1) from None
 
     # Resolve API URL overrides: CLI flag > env var > None
+    effective_anthropic_api_url = anthropic_api_url or os.environ.get("ANTHROPIC_TARGET_API_URL")
     effective_openai_api_url = openai_api_url or os.environ.get("OPENAI_TARGET_API_URL")
     effective_gemini_api_url = gemini_api_url or os.environ.get("GEMINI_TARGET_API_URL")
 
@@ -200,6 +207,7 @@ def proxy(
     config = ProxyConfig(
         host=host,
         port=port,
+        anthropic_api_url=effective_anthropic_api_url,
         openai_api_url=effective_openai_api_url,
         gemini_api_url=effective_gemini_api_url,
         mode=effective_mode,

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -685,6 +685,7 @@ class ProxyConfig:
     # Server
     host: str = "127.0.0.1"
     port: int = 8787
+    anthropic_api_url: str | None = None  # Custom Anthropic API URL override
     openai_api_url: str | None = None  # Custom OpenAI API URL override
     gemini_api_url: str | None = None  # Custom Gemini API URL override
 
@@ -1687,6 +1688,14 @@ class HeadroomProxy:
 
     def __init__(self, config: ProxyConfig):
         self.config = config
+
+        # Override ANTHROPIC_API_URL with config if set
+        # Strip trailing /v1 or /v1/ to avoid double-path (e.g., .../v1/v1/models)
+        if config.anthropic_api_url:
+            url = config.anthropic_api_url.rstrip("/")
+            if url.endswith("/v1"):
+                url = url[:-3]
+            HeadroomProxy.ANTHROPIC_API_URL = url
 
         # Override OPENAI_API_URL with config if set
         # Strip trailing /v1 or /v1/ to avoid double-path (e.g., .../v1/v1/models)


### PR DESCRIPTION
Currently only the official anthropic endpoints are supported (or Bedrock) in proxy mode, but the user has no possibility of specifying a custom URL for this.

This PR adds support for  an ANTHROPIC_TARGET_URL environment var and  a --anthropic-api-url flag when running in proxy mode