### PR TITLE
fix(openclaw): preserve toolCall linkage for streaming tool outputs

### DIFF
--- a/plugins/openclaw/src/convert.ts
+++ b/plugins/openclaw/src/convert.ts
@@ -54,7 +54,8 @@ export function agentToOpenAI(messages: any[]): OpenAIMessage[] {
         continue;
       }
 
-      // Content blocks: extract text and tool_use blocks
+      // Content blocks: extract text and tool call blocks.
+      // OpenClaw uses `toolCall`; some adapters still emit legacy `tool_use`.
       if (Array.isArray(content)) {
         const textParts: string[] = [];
         const toolCalls: any[] = [];
@@ -64,16 +65,20 @@ export function agentToOpenAI(messages: any[]): OpenAIMessage[] {
             textParts.push(block);
           } else if (block.type === "text") {
             textParts.push(block.text);
-          } else if (block.type === "tool_use") {
+          } else if (block.type === "tool_use" || block.type === "toolCall") {
+            const args =
+              block.type === "toolCall"
+                ? block.arguments
+                : block.input;
             toolCalls.push({
               id: block.id,
               type: "function",
               function: {
                 name: block.name,
                 arguments:
-                  typeof block.input === "string"
-                    ? block.input
-                    : JSON.stringify(block.input ?? {}),
+                  typeof args === "string"
+                    ? args
+                    : JSON.stringify(args ?? {}),
               },
             });
           }
@@ -155,11 +160,12 @@ export function openAIToAgent(messages: OpenAIMessage[]): any[] {
           } catch {
             input = tc.function.arguments ?? {};
           }
+          // Emit OpenClaw-native block shape so downstream transports keep call linkage.
           blocks.push({
-            type: "tool_use",
+            type: "toolCall",
             id: tc.id,
             name: tc.function.name,
-            input,
+            arguments: input,
           });
         }
       }
@@ -174,10 +180,19 @@ export function openAIToAgent(messages: OpenAIMessage[]): any[] {
     }
 
     if (msg.role === "tool") {
+      const textContent =
+        typeof msg.content === "string"
+          ? msg.content
+          : msg.content == null
+            ? ""
+            : JSON.stringify(msg.content);
+      const toolCallId = msg.tool_call_id ?? "unknown";
       result.push({
         role: "toolResult",
-        content: msg.content ?? "",
-        tool_use_id: msg.tool_call_id ?? "unknown",
+        // OpenClaw transport layers expect toolResult content blocks, not a raw string.
+        content: [{ type: "text", text: textContent }],
+        toolCallId,
+        tool_use_id: toolCallId,
         timestamp: Date.now(),
       });
       continue;

--- a/plugins/openclaw/test/convert.test.ts
+++ b/plugins/openclaw/test/convert.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { openAIToAgent, type OpenAIMessage } from "../src/convert";
+
+describe("openAIToAgent", () => {
+  it("emits toolResult content as blocks so transports can safely filter", () => {
+    const messages: OpenAIMessage[] = [
+      {
+        role: "tool",
+        content: "tool output",
+        tool_call_id: "call_123",
+      },
+    ];
+
+    const result = openAIToAgent(messages);
+    const toolResult = result[0] as {
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+      toolCallId: string;
+      tool_use_id: string;
+    };
+
+    expect(toolResult.role).toBe("toolResult");
+    expect(Array.isArray(toolResult.content)).toBe(true);
+    expect(toolResult.content).toEqual([{ type: "text", text: "tool output" }]);
+    expect(toolResult.toolCallId).toBe("call_123");
+    expect(toolResult.tool_use_id).toBe("call_123");
+  });
+});

--- a/plugins/openclaw/test/engine.test.ts
+++ b/plugins/openclaw/test/engine.test.ts
@@ -46,6 +46,25 @@ describe("AgentMessage conversion", () => {
     expect(openai[0].tool_calls![0].function.name).toBe("search");
   });
 
+  it("converts assistant with toolCall blocks", () => {
+    const agent = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me search" },
+          { type: "toolCall", id: "call_1|fc_1", name: "search", arguments: { q: "test" } },
+        ],
+        timestamp: Date.now(),
+      },
+    ];
+    const openai = agentToOpenAI(agent);
+    expect(openai[0].role).toBe("assistant");
+    expect(openai[0].content).toBe("Let me search");
+    expect(openai[0].tool_calls).toHaveLength(1);
+    expect(openai[0].tool_calls![0].id).toBe("call_1|fc_1");
+    expect(openai[0].tool_calls![0].function.name).toBe("search");
+  });
+
   it("converts toolResult message", () => {
     const agent = [
       {
@@ -92,7 +111,7 @@ describe("AgentMessage conversion", () => {
         role: "assistant",
         content: [
           { type: "text", text: "Searching..." },
-          { type: "tool_use", id: "tu_1", name: "search", input: { q: "test" } },
+          { type: "toolCall", id: "call_1|fc_1", name: "search", arguments: { q: "test" } },
         ],
         timestamp: Date.now(),
       },
@@ -104,7 +123,7 @@ describe("AgentMessage conversion", () => {
     expect(Array.isArray(content)).toBe(true);
     expect(content).toContainEqual(expect.objectContaining({ type: "text", text: "Searching..." }));
     expect(content).toContainEqual(
-      expect.objectContaining({ type: "tool_use", id: "tu_1", name: "search" }),
+      expect.objectContaining({ type: "toolCall", id: "call_1|fc_1", name: "search" }),
     );
   });
 
@@ -120,7 +139,7 @@ describe("AgentMessage conversion", () => {
     const openai = agentToOpenAI(original);
     const back = openAIToAgent(openai);
     expect(back[0].role).toBe("toolResult");
-    expect(back[0].content).toBe('{"data": true}');
+    expect(back[0].content).toEqual([{ type: "text", text: '{"data": true}' }]);
     expect(back[0].tool_use_id).toBe("tu_1");
   });
 });


### PR DESCRIPTION
## Description

Fixes OpenClaw plugin message conversion so streaming tool outputs remain correctly linked to prior tool calls after Headroom compression/round-trip.

Fixes #97

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Preserve OpenClaw-native assistant tool-call blocks (`type: "toolCall"`) during OpenAI <-> agent conversion.
- Accept both `toolCall` and legacy `tool_use` input shapes when converting agent messages to OpenAI messages.
- Ensure converted tool results always emit block-array content and both `toolCallId` and `tool_use_id` for transport compatibility.
- Add regression test coverage for tool-result block shape and toolCall linkage round-trip behavior.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

## Test Output

```text
# Plugin tests
> headroom-openclaw@0.1.0 test
> vitest run

Test Files  3 passed (3)
Tests      30 passed (30)

# Plugin build
> headroom-openclaw@0.1.0 build
> tsup
ESM Build success
DTS Build success

# Local OpenClaw verification
openclaw plugins inspect headroom
Status: loaded
Source: ~\.openclaw\extensions\headroom\dist\index.js
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

This fixes two user-visible OpenClaw failures caused by converter shape mismatches:

- `msg.content.filter is not a function`
- `Cannot read properties of undefined (reading 'split')`

and the streaming linkage error:

- `No tool call found for function call output with call_id ...`

Scope is intentionally limited to `plugins/openclaw` conversion + tests.