### PR TITLE
Fix OpenClaw local link installs for headroom plugin

### DIFF
--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -13,13 +13,20 @@ This plugin can auto-start a local `headroom proxy` when needed. OpenClaw treats
 
 ## Local Development Install (Detection-Friendly)
 
-If you are testing from this repo, run npm install/build from the plugin directory so local launcher detection aligns with runtime paths. The build now emits a self-contained `dist/` plugin root, so either of these linked installs works:
+If you are testing from this repo, run npm install/build from the plugin directory so local launcher detection aligns with runtime paths. These linked installs are supported:
 
 ```bash
 cd plugins/openclaw
 npm install
 npm run build
+openclaw plugins install --dangerously-force-unsafe-install --link .
 openclaw plugins install --dangerously-force-unsafe-install --link dist
+```
+
+From the repo root, install the plugin directory explicitly:
+
+```bash
+openclaw plugins install --dangerously-force-unsafe-install --link ./plugins/openclaw
 ```
 
 Or, from inside `dist/`:
@@ -33,6 +40,7 @@ Why this matters:
 - The plugin checks launchers in this order: PATH -> local npm bin -> global npm -> python.
 - "local npm bin" means `plugins/openclaw/node_modules/.bin/headroom` relative to the source checkout.
 - Using `--link dist` (or `--link .` from `dist/`) still keeps runtime code adjacent to the checkout, and launcher detection falls back to PATH/global/python if a local npm bin is not present under the installed root.
+- `plugins/openclaw` also carries a no-op hook shim so OpenClaw's hook-pack fallback treats the path as valid instead of emitting a misleading `package.json missing openclaw.hooks` warning.
 - If you install from a `.tgz`, local npm bin may not exist in the installed extension and detection will fall back to PATH/global/python.
 
 ## Configure

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -45,6 +45,8 @@ Why this matters:
 
 ## Configure
 
+Install automatically selects the `contextEngine` slot for `headroom` on current OpenClaw releases. If you need to switch back manually, set `plugins.slots.contextEngine` to `"legacy"` or another engine id.
+
 ```json
 {
   "plugins": {

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -13,19 +13,26 @@ This plugin can auto-start a local `headroom proxy` when needed. OpenClaw treats
 
 ## Local Development Install (Detection-Friendly)
 
-If you are testing from this repo, run npm install/build from the plugin directory so local launcher detection aligns with runtime paths:
+If you are testing from this repo, run npm install/build from the plugin directory so local launcher detection aligns with runtime paths. The build now emits a self-contained `dist/` plugin root, so either of these linked installs works:
 
 ```bash
 cd plugins/openclaw
 npm install
 npm run build
+openclaw plugins install --dangerously-force-unsafe-install --link dist
+```
+
+Or, from inside `dist/`:
+
+```bash
+cd plugins/openclaw/dist
 openclaw plugins install --dangerously-force-unsafe-install --link .
 ```
 
 Why this matters:
 - The plugin checks launchers in this order: PATH -> local npm bin -> global npm -> python.
-- "local npm bin" means `plugins/openclaw/node_modules/.bin/headroom` relative to the installed plugin root.
-- Using `--link .` from `plugins/openclaw` keeps that local path aligned for detection.
+- "local npm bin" means `plugins/openclaw/node_modules/.bin/headroom` relative to the source checkout.
+- Using `--link dist` (or `--link .` from `dist/`) still keeps runtime code adjacent to the checkout, and launcher detection falls back to PATH/global/python if a local npm bin is not present under the installed root.
 - If you install from a `.tgz`, local npm bin may not exist in the installed extension and detection will fall back to PATH/global/python.
 
 ## Configure

--- a/plugins/openclaw/hook-shim/HOOK.md
+++ b/plugins/openclaw/hook-shim/HOOK.md
@@ -1,0 +1,21 @@
+---
+name: headroom-link-shim
+description: "No-op hook shim so local plugin source paths are also valid OpenClaw hook-pack paths."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🪝",
+        "events": ["command"],
+      },
+  }
+---
+
+# Headroom Link Shim
+
+This hook intentionally does nothing.
+
+OpenClaw currently falls back to validating local plugin paths as hook packs when a
+plugin install cannot proceed, such as when the plugin is already installed.
+Including this no-op hook keeps `--link` installs from reporting a misleading
+`package.json missing openclaw.hooks` error for valid Headroom plugin paths.

--- a/plugins/openclaw/hook-shim/handler.js
+++ b/plugins/openclaw/hook-shim/handler.js
@@ -1,0 +1,3 @@
+export default async function headroomLinkShim() {
+  return undefined;
+}

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "headroom",
+  "kind": "context-engine",
   "uiHints": {
     "proxyUrl": {
       "label": "Proxy URL",

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "hook-shim",
     "openclaw.plugin.json",
     "README.md"
   ],
@@ -34,6 +35,9 @@
     "vitest": "^2.0.0"
   },
   "openclaw": {
+    "hooks": [
+      "./hook-shim"
+    ],
     "extensions": [
       "./dist/index.js"
     ],

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node prepare-dist.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
@@ -34,12 +34,6 @@
     "vitest": "^2.0.0"
   },
   "openclaw": {
-    "hooks": {
-      "contextEngine": "dist/index.js",
-      "tools": [
-        "dist/index.js"
-      ]
-    },
     "extensions": [
       "./dist/index.js"
     ],

--- a/plugins/openclaw/prepare-dist.mjs
+++ b/plugins/openclaw/prepare-dist.mjs
@@ -22,6 +22,7 @@ const distPackage = {
   peerDependencies: rootPackage.peerDependencies,
   peerDependenciesMeta: rootPackage.peerDependenciesMeta,
   openclaw: {
+    hooks: ["./hook-shim"],
     extensions: ["./index.js"],
     capabilities: rootPackage.openclaw?.capabilities ?? {},
   },
@@ -40,4 +41,16 @@ await Promise.all([
     path.join(distDir, "openclaw.plugin.json"),
   ),
   fs.copyFile(path.join(rootDir, "README.md"), path.join(distDir, "README.md")),
+  fs.mkdir(path.join(distDir, "hook-shim"), { recursive: true }),
+]);
+
+await Promise.all([
+  fs.copyFile(
+    path.join(rootDir, "hook-shim", "HOOK.md"),
+    path.join(distDir, "hook-shim", "HOOK.md"),
+  ),
+  fs.copyFile(
+    path.join(rootDir, "hook-shim", "handler.js"),
+    path.join(distDir, "hook-shim", "handler.js"),
+  ),
 ]);

--- a/plugins/openclaw/prepare-dist.mjs
+++ b/plugins/openclaw/prepare-dist.mjs
@@ -1,0 +1,43 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = __dirname;
+const distDir = path.join(rootDir, "dist");
+
+const rootPackage = JSON.parse(
+  await fs.readFile(path.join(rootDir, "package.json"), "utf8"),
+);
+
+const distPackage = {
+  name: rootPackage.name,
+  version: rootPackage.version,
+  description: rootPackage.description,
+  type: rootPackage.type,
+  main: "./index.js",
+  types: "./index.d.ts",
+  license: rootPackage.license,
+  dependencies: rootPackage.dependencies,
+  peerDependencies: rootPackage.peerDependencies,
+  peerDependenciesMeta: rootPackage.peerDependenciesMeta,
+  openclaw: {
+    extensions: ["./index.js"],
+    capabilities: rootPackage.openclaw?.capabilities ?? {},
+  },
+};
+
+await fs.mkdir(distDir, { recursive: true });
+await fs.writeFile(
+  path.join(distDir, "package.json"),
+  `${JSON.stringify(distPackage, null, 2)}\n`,
+  "utf8",
+);
+
+await Promise.all([
+  fs.copyFile(
+    path.join(rootDir, "openclaw.plugin.json"),
+    path.join(distDir, "openclaw.plugin.json"),
+  ),
+  fs.copyFile(path.join(rootDir, "README.md"), path.join(distDir, "README.md")),
+]);


### PR DESCRIPTION
## Summary
- make local linked installs work from `plugins/openclaw`, `plugins/openclaw/dist`, and repo-root `./plugins/openclaw`
- generate a self-contained `dist` plugin package during build so `--link .` from `dist` installs as a plugin
- add a no-op hook shim so valid plugin source paths also satisfy OpenClaw's hook-pack fallback validation instead of emitting `package.json missing openclaw.hooks`
- declare the plugin as a `context-engine` so a clean plugin install selects `plugins.slots.contextEngine = "headroom"`

## Why
OpenClaw 2026.4.5 currently falls back from local plugin install to hook-pack install when plugin install fails. That caused two problems for this plugin:
- `plugins/openclaw/dist` was not a valid plugin root, so `--link .` from `dist` failed plugin validation
- once the path became a valid plugin source, duplicate installs still printed a misleading hook-pack warning because the fallback path required `openclaw.hooks`

This change makes both plugin roots valid and makes the fallback path non-misleading, while keeping the shim hook as a no-op.

## Verified
- `npm run build`
- `npm test`
- `npm run typecheck`
- `openclaw plugins install --dangerously-force-unsafe-install --link .` from `plugins/openclaw`
- `openclaw plugins install --dangerously-force-unsafe-install --link .` from `plugins/openclaw/dist`
- `openclaw plugins install --dangerously-force-unsafe-install --link ./plugins/openclaw` from repo root
- repeated installs no longer emit `package.json missing openclaw.hooks`
- clean plugin install auto-selects `plugins.slots.contextEngine = "headroom"`

## Real-world validation notes
On a real `~/.openclaw` state, install only failed to select the engine when a stale `~/.openclaw/extensions/headroom` directory caused plugin install to fail first. In that case OpenClaw fell through to hook-pack linking, which correctly does not set plugin slots.

After removing the stale extension directory and stale hook fallback records, the normal install flow completed successfully and the resulting config had:
- `plugins.entries.headroom.enabled = true`
- `plugins.installs.headroom.sourcePath = "C:\\git\\headroom\\plugins\\openclaw"`
- `plugins.load.paths = ["C:\\git\\headroom\\plugins\\openclaw"]`
- `plugins.slots.contextEngine = "headroom"`
- `hooks.internal.load.extraDirs = []`
