### PR TITLE
Add OTEL metrics and Langfuse tracing support

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -145,27 +145,112 @@ curl http://localhost:8787/metrics
 ```
 
 ```prometheus
-# HELP headroom_requests_total Total requests processed
-headroom_requests_total{mode="optimize"} 1234
+# HELP headroom_requests_total Total number of requests
+headroom_requests_total 1234
 
-# HELP headroom_tokens_saved_total Total tokens saved
+# HELP headroom_latency_ms_count Count of observed request latencies
+headroom_latency_ms_count 1234
+
+# HELP headroom_tokens_saved_total Tokens saved by optimization
 headroom_tokens_saved_total 5678900
 
-# HELP headroom_compression_ratio Compression ratio histogram
-headroom_compression_ratio_bucket{le="0.5"} 890
-headroom_compression_ratio_bucket{le="0.7"} 1100
-headroom_compression_ratio_bucket{le="0.9"} 1200
+# HELP headroom_requests_by_provider Requests by provider
+headroom_requests_by_provider{provider="anthropic"} 800
+headroom_requests_by_provider{provider="openai"} 434
 
-# HELP headroom_latency_seconds Request latency histogram
-headroom_latency_seconds_bucket{le="0.01"} 800
-headroom_latency_seconds_bucket{le="0.1"} 1150
+# HELP headroom_transform_timing_ms_sum Sum of transform timing in milliseconds
+headroom_transform_timing_ms_sum{transform="router"} 5123.7
 
-# HELP headroom_cache_hits_total Cache hit counter
-headroom_cache_hits_total 456
-
-# HELP headroom_cache_misses_total Cache miss counter
-headroom_cache_misses_total 778
+# HELP headroom_cache_write_ttl_tokens_total Provider cache write tokens by observed TTL bucket
+headroom_cache_write_ttl_tokens_total{provider="anthropic",ttl="5m"} 20000
+headroom_cache_write_ttl_tokens_total{provider="anthropic",ttl="1h"} 50000
 ```
+
+The built-in Prometheus endpoint exposes the proxy's in-memory operational state, including:
+
+- request counters
+- token totals and savings
+- latency / overhead / TTFB summaries
+- per-provider and per-model request counts
+- per-stage pipeline timing
+- waste signal token totals
+- provider cache read/write and TTL-bucket counters
+- cache bust counters
+
+### OTEL Metrics
+
+Headroom now emits the same operational events through a shared OTEL metrics facade.
+
+There are two integration modes:
+
+1. **Ambient OTEL app setup** - if your application already configures a global OTEL meter provider, Headroom records into that provider automatically.
+2. **Headroom-managed export** - if you want the proxy to configure its own OTEL metrics exporter, install:
+
+```bash
+pip install "headroom-ai[proxy,otel]"
+```
+
+Then set:
+
+```bash
+HEADROOM_OTEL_METRICS_ENABLED=1
+HEADROOM_OTEL_METRICS_EXPORTER=otlp_http
+HEADROOM_OTEL_METRICS_ENDPOINT=http://127.0.0.1:4318/v1/metrics
+HEADROOM_OTEL_SERVICE_NAME=headroom-proxy
+HEADROOM_OTEL_RESOURCE_ATTRIBUTES=deployment.environment=dev,service.namespace=headroom
+```
+
+For local validation without a collector:
+
+```bash
+HEADROOM_OTEL_METRICS_ENABLED=1
+HEADROOM_OTEL_METRICS_EXPORTER=console
+headroom proxy
+```
+
+The proxy's `/stats` response now includes an `otel` block that reports whether Headroom is managing an OTEL exporter for the current process.
+
+Headroom's managed OTEL exporters are intentionally scoped to Headroom's own instrumentation. If you already manage global OTEL providers in your app, keep using those and let Headroom record into the ambient providers instead of enabling `HEADROOM_OTEL_*`.
+
+### OTEL Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HEADROOM_OTEL_METRICS_ENABLED` | `0` | Enables Headroom-managed OTEL metric export |
+| `HEADROOM_OTEL_METRICS_EXPORTER` | `otlp_http` | Exporter type: `otlp_http` or `console` |
+| `HEADROOM_OTEL_METRICS_ENDPOINT` | unset | OTLP HTTP metrics endpoint |
+| `HEADROOM_OTEL_METRICS_HEADERS` | unset | Comma-separated `key=value` headers for OTLP export |
+| `HEADROOM_OTEL_METRICS_EXPORT_INTERVAL_MS` | `10000` | Periodic export interval in milliseconds |
+| `HEADROOM_OTEL_SERVICE_NAME` | `headroom-proxy` in proxy mode | OTEL `service.name` |
+| `HEADROOM_OTEL_RESOURCE_ATTRIBUTES` | unset | Comma-separated resource attributes |
+
+### Anonymous Telemetry vs OTEL
+
+Headroom has two separate systems:
+
+- `HEADROOM_TELEMETRY` / `--no-telemetry` controls the privacy-preserving anonymous data-flywheel beacon and TOIN-related aggregate reporting.
+- `HEADROOM_OTEL_*` controls operational OTEL metric export.
+
+They are independent by design so you can disable the anonymous beacon while keeping OTEL metrics enabled, or vice versa.
+
+### Langfuse
+
+Langfuse fits next to this implementation as a **trace backend**, not as a metrics backend.
+
+- Headroom metrics continue to go to `/metrics` and/or your OTEL metrics exporter.
+- Langfuse receives OTLP traces for Headroom's compression pipeline.
+- Headroom's `/stats` response includes a `langfuse` block when Headroom is managing Langfuse trace export for the process.
+
+Enable it with:
+
+```bash
+HEADROOM_LANGFUSE_ENABLED=1
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
+```
+
+For self-hosted Langfuse, set `LANGFUSE_BASE_URL` to your instance URL.
 
 ### Health Check
 
@@ -293,19 +378,19 @@ Example Grafana dashboard configuration for Prometheus metrics:
       "targets": [{"expr": "headroom_tokens_saved_total"}]
     },
     {
-      "title": "Compression Ratio",
+      "title": "Average Request Latency (ms)",
       "type": "gauge",
-      "targets": [{"expr": "histogram_quantile(0.5, headroom_compression_ratio_bucket)"}]
+      "targets": [{"expr": "headroom_latency_ms_sum / clamp_min(headroom_latency_ms_count, 1)"}]
     },
     {
-      "title": "Request Latency (p99)",
+      "title": "Max Request Latency (ms)",
       "type": "graph",
-      "targets": [{"expr": "histogram_quantile(0.99, headroom_latency_seconds_bucket)"}]
+      "targets": [{"expr": "headroom_latency_ms_max"}]
     },
     {
-      "title": "Cache Hit Rate",
+      "title": "Provider Cache Hit Rate",
       "type": "gauge",
-      "targets": [{"expr": "headroom_cache_hits_total / (headroom_cache_hits_total + headroom_cache_misses_total)"}]
+      "targets": [{"expr": "headroom_provider_cache_hit_requests_total / clamp_min(headroom_provider_cache_requests_total, 1)"}]
     }
   ]
 }

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -21,7 +21,29 @@ headroom proxy \
   --budget 100.0
 ```
 
-Telemetry is enabled by default. Opt out with `HEADROOM_TELEMETRY=off` or `headroom proxy --no-telemetry`. Downstream apps can set `HEADROOM_SDK=headroom-app` to override the anonymous telemetry `sdk` label; the default remains `proxy`.
+Anonymous aggregate telemetry is enabled by default. Opt out with `HEADROOM_TELEMETRY=off` or `headroom proxy --no-telemetry`. Downstream apps can set `HEADROOM_SDK=headroom-app` to override the anonymous telemetry `sdk` label; the default remains `proxy`.
+
+Operational OTEL metrics are configured separately and are **off by default**. Install `headroom-ai[proxy,otel]` and set:
+
+```bash
+HEADROOM_OTEL_METRICS_ENABLED=1
+HEADROOM_OTEL_METRICS_EXPORTER=otlp_http
+HEADROOM_OTEL_METRICS_ENDPOINT=http://127.0.0.1:4318/v1/metrics
+HEADROOM_OTEL_SERVICE_NAME=headroom-proxy
+```
+
+Use `HEADROOM_OTEL_METRICS_EXPORTER=console` for local smoke testing. `HEADROOM_TELEMETRY` controls the anonymous data-flywheel beacon only; it does not disable or enable OTEL export.
+
+Langfuse can be enabled alongside this OTEL path for **trace ingestion**. Langfuse does **not** ingest OTEL metrics, so Headroom keeps metrics and Langfuse traces as complementary signals:
+
+```bash
+HEADROOM_LANGFUSE_ENABLED=1
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
+```
+
+When configured, Headroom emits OTLP traces for the shared compression pipeline to Langfuse while continuing to expose metrics through `/metrics` and OTEL metric exporters.
 
 ## Command Line Options
 
@@ -173,6 +195,8 @@ curl "http://localhost:8787/stats-history?format=csv&series=monthly"
 ```bash
 curl http://localhost:8787/metrics
 ```
+
+`/metrics` remains the built-in Prometheus-formatted operational view. The proxy now also emits the same operational events through the OTEL facade when OTEL metrics are configured.
 
 ### LLM APIs
 

--- a/headroom/__init__.py
+++ b/headroom/__init__.py
@@ -131,6 +131,20 @@ except ImportError:
     ScopeLevel = None  # type: ignore[assignment,misc]
     with_memory = None  # type: ignore[assignment]
 
+from .observability import (
+    HeadroomOtelMetrics,
+    HeadroomTracer,
+    LangfuseTracingConfig,
+    OTelMetricsConfig,
+    configure_langfuse_tracing,
+    configure_otel_metrics,
+    get_headroom_tracer,
+    get_langfuse_tracing_status,
+    get_otel_metrics,
+    get_otel_metrics_status,
+    reset_headroom_tracing,
+    reset_otel_metrics,
+)
 from .providers import AnthropicProvider, OpenAIProvider, Provider, TokenCounter
 
 # Relevance scoring - BM25 always available, embedding requires sentence-transformers
@@ -223,6 +237,19 @@ __all__ = [
     "count_tokens_text",
     "count_tokens_messages",
     "generate_report",
+    # Observability
+    "HeadroomOtelMetrics",
+    "HeadroomTracer",
+    "LangfuseTracingConfig",
+    "OTelMetricsConfig",
+    "configure_otel_metrics",
+    "configure_langfuse_tracing",
+    "get_headroom_tracer",
+    "get_langfuse_tracing_status",
+    "get_otel_metrics",
+    "get_otel_metrics_status",
+    "reset_headroom_tracing",
+    "reset_otel_metrics",
     # Memory - hierarchical memory system
     "with_memory",  # Main user-facing API
     "Memory",

--- a/headroom/compress.py
+++ b/headroom/compress.py
@@ -57,9 +57,11 @@ Examples:
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass, field
 from typing import Any
 
+from .observability import get_otel_metrics
 from .utils import extract_user_query as _extract_user_query
 
 logger = logging.getLogger(__name__)
@@ -67,7 +69,7 @@ logger = logging.getLogger(__name__)
 
 # Lazy-initialized singleton pipeline
 _pipeline = None
-_pipeline_lock = None
+_pipeline_lock = threading.Lock()
 
 
 @dataclass
@@ -171,6 +173,11 @@ def compress(
         )
 
     except Exception as e:
+        get_otel_metrics().record_compression_failure(
+            model=model,
+            operation="compress",
+            error_type=type(e).__name__,
+        )
         logger.warning("Compression failed, returning original messages: %s", e)
         return CompressResult(
             messages=messages,
@@ -187,12 +194,6 @@ def _get_pipeline() -> Any:
 
     if _pipeline is not None:
         return _pipeline
-
-    import threading
-
-    global _pipeline_lock
-    if _pipeline_lock is None:
-        _pipeline_lock = threading.Lock()
 
     with _pipeline_lock:
         if _pipeline is not None:

--- a/headroom/observability/__init__.py
+++ b/headroom/observability/__init__.py
@@ -1,0 +1,41 @@
+"""Operational observability helpers for Headroom."""
+
+from .metrics import (
+    HeadroomOtelMetrics,
+    OTelMetricsConfig,
+    configure_otel_metrics,
+    get_otel_metrics,
+    get_otel_metrics_status,
+    reset_otel_metrics,
+    set_otel_metrics,
+    shutdown_otel_metrics,
+)
+from .tracing import (
+    HeadroomTracer,
+    LangfuseTracingConfig,
+    configure_langfuse_tracing,
+    get_headroom_tracer,
+    get_langfuse_tracing_status,
+    reset_headroom_tracing,
+    set_headroom_tracer,
+    shutdown_headroom_tracing,
+)
+
+__all__ = [
+    "HeadroomOtelMetrics",
+    "OTelMetricsConfig",
+    "configure_otel_metrics",
+    "get_otel_metrics",
+    "get_otel_metrics_status",
+    "HeadroomTracer",
+    "LangfuseTracingConfig",
+    "configure_langfuse_tracing",
+    "get_headroom_tracer",
+    "get_langfuse_tracing_status",
+    "reset_otel_metrics",
+    "reset_headroom_tracing",
+    "set_otel_metrics",
+    "set_headroom_tracer",
+    "shutdown_headroom_tracing",
+    "shutdown_otel_metrics",
+]

--- a/headroom/observability/metrics.py
+++ b/headroom/observability/metrics.py
@@ -1,0 +1,511 @@
+"""OpenTelemetry-backed operational metrics for Headroom."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+from threading import Lock
+from typing import Any, Literal
+
+from opentelemetry import metrics
+
+logger = logging.getLogger(__name__)
+
+MetricExporter = Literal["console", "otlp_http"]
+
+_SCOPE_NAME = "headroom"
+_DEFAULT_EXPORT_INTERVAL_MS = 10000
+_MILLISECONDS_TO_SECONDS = 1000.0
+
+_metrics_lock = Lock()
+_global_metrics: HeadroomOtelMetrics | None = None
+_owned_meter_provider: Any | None = None
+_owned_metrics_config: OTelMetricsConfig | None = None
+
+
+def _headroom_version() -> str:
+    try:
+        return package_version("headroom-ai")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _parse_bool(raw: str | None, default: bool = False) -> bool:
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _parse_int(raw: str | None, default: int) -> int:
+    if raw is None:
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _parse_key_value_pairs(raw: str | None) -> dict[str, str]:
+    if raw is None:
+        return {}
+
+    pairs: dict[str, str] = {}
+    for item in raw.split(","):
+        part = item.strip()
+        if not part or "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key and value:
+            pairs[key] = value
+    return pairs
+
+
+@dataclass(slots=True)
+class OTelMetricsConfig:
+    """Configuration for Headroom-managed OTEL metric export."""
+
+    enabled: bool = False
+    service_name: str = "headroom"
+    exporter: MetricExporter = "otlp_http"
+    endpoint: str | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+    export_interval_millis: int = _DEFAULT_EXPORT_INTERVAL_MS
+    resource_attributes: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_env(cls, *, default_service_name: str = "headroom") -> OTelMetricsConfig:
+        exporter_raw = (
+            os.environ.get("HEADROOM_OTEL_METRICS_EXPORTER", "otlp_http")
+            .strip()
+            .lower()
+            .replace("-", "_")
+        )
+        if exporter_raw not in {"console", "otlp_http"}:
+            logger.warning(
+                "Unknown HEADROOM_OTEL_METRICS_EXPORTER=%s; falling back to otlp_http",
+                exporter_raw,
+            )
+            exporter_raw = "otlp_http"
+
+        return cls(
+            enabled=_parse_bool(os.environ.get("HEADROOM_OTEL_METRICS_ENABLED"), default=False),
+            service_name=os.environ.get("HEADROOM_OTEL_SERVICE_NAME", default_service_name).strip()
+            or default_service_name,
+            exporter=exporter_raw,  # type: ignore[arg-type]
+            endpoint=os.environ.get("HEADROOM_OTEL_METRICS_ENDPOINT") or None,
+            headers=_parse_key_value_pairs(os.environ.get("HEADROOM_OTEL_METRICS_HEADERS")),
+            export_interval_millis=_parse_int(
+                os.environ.get("HEADROOM_OTEL_METRICS_EXPORT_INTERVAL_MS"),
+                _DEFAULT_EXPORT_INTERVAL_MS,
+            ),
+            resource_attributes=_parse_key_value_pairs(
+                os.environ.get("HEADROOM_OTEL_RESOURCE_ATTRIBUTES")
+            ),
+        )
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "configured": True,
+            "enabled": self.enabled,
+            "service_name": self.service_name,
+            "exporter": self.exporter,
+            "endpoint": self.endpoint,
+            "resource_attributes": dict(self.resource_attributes),
+        }
+
+
+class HeadroomOtelMetrics:
+    """Shared OTEL metrics facade for Headroom operations."""
+
+    def __init__(self, meter_provider: Any | None = None):
+        if meter_provider is None:
+            self._meter = metrics.get_meter(_SCOPE_NAME, _headroom_version())
+        else:
+            self._meter = meter_provider.get_meter(_SCOPE_NAME, _headroom_version())
+
+        self._proxy_requests = self._meter.create_counter(
+            "headroom.proxy.requests",
+            description="Proxy requests handled by Headroom.",
+            unit="1",
+        )
+        self._proxy_cached_requests = self._meter.create_counter(
+            "headroom.proxy.requests.cached",
+            description="Proxy requests served with provider cache participation.",
+            unit="1",
+        )
+        self._proxy_failed_requests = self._meter.create_counter(
+            "headroom.proxy.requests.failed",
+            description="Proxy requests that failed.",
+            unit="1",
+        )
+        self._proxy_rate_limited_requests = self._meter.create_counter(
+            "headroom.proxy.requests.rate_limited",
+            description="Proxy requests rejected by rate limiting.",
+            unit="1",
+        )
+        self._proxy_input_tokens = self._meter.create_counter(
+            "headroom.proxy.tokens.input",
+            description="Input tokens received by the proxy.",
+            unit="1",
+        )
+        self._proxy_output_tokens = self._meter.create_counter(
+            "headroom.proxy.tokens.output",
+            description="Output tokens returned by upstream providers.",
+            unit="1",
+        )
+        self._proxy_saved_tokens = self._meter.create_counter(
+            "headroom.proxy.tokens.saved",
+            description="Input tokens saved by Headroom compression.",
+            unit="1",
+        )
+        self._proxy_cache_read_tokens = self._meter.create_counter(
+            "headroom.proxy.cache.read_tokens",
+            description="Provider cache read tokens observed by the proxy.",
+            unit="1",
+        )
+        self._proxy_cache_write_tokens = self._meter.create_counter(
+            "headroom.proxy.cache.write_tokens",
+            description="Provider cache write tokens observed by the proxy.",
+            unit="1",
+        )
+        self._proxy_cache_write_ttl_tokens = self._meter.create_counter(
+            "headroom.proxy.cache.write_ttl_tokens",
+            description="Provider cache write tokens by observed TTL bucket.",
+            unit="1",
+        )
+        self._proxy_uncached_input_tokens = self._meter.create_counter(
+            "headroom.proxy.cache.uncached_input_tokens",
+            description="Proxy input tokens not served from provider cache.",
+            unit="1",
+        )
+        self._proxy_cache_busts = self._meter.create_counter(
+            "headroom.proxy.cache.busts",
+            description="Requests that lost provider cache efficiency.",
+            unit="1",
+        )
+        self._proxy_cache_bust_tokens_lost = self._meter.create_counter(
+            "headroom.proxy.cache.bust_tokens_lost",
+            description="Tokens that lost provider cache discount because of compression.",
+            unit="1",
+        )
+        self._proxy_latency = self._meter.create_histogram(
+            "headroom.proxy.request.duration",
+            description="End-to-end proxy request duration.",
+            unit="s",
+        )
+        self._proxy_overhead = self._meter.create_histogram(
+            "headroom.proxy.overhead.duration",
+            description="Time spent inside Headroom optimization logic.",
+            unit="s",
+        )
+        self._proxy_ttfb = self._meter.create_histogram(
+            "headroom.proxy.ttfb.duration",
+            description="Upstream time to first byte observed by Headroom.",
+            unit="s",
+        )
+        self._compression_runs = self._meter.create_counter(
+            "headroom.compression.runs",
+            description="Compression pipeline runs executed by Headroom.",
+            unit="1",
+        )
+        self._compression_failures = self._meter.create_counter(
+            "headroom.compression.failures",
+            description="Compression operations that failed before producing a result.",
+            unit="1",
+        )
+        self._compression_input_tokens = self._meter.create_counter(
+            "headroom.compression.tokens.input",
+            description="Input tokens analyzed by Headroom compression.",
+            unit="1",
+        )
+        self._compression_output_tokens = self._meter.create_counter(
+            "headroom.compression.tokens.output",
+            description="Output tokens produced by Headroom compression.",
+            unit="1",
+        )
+        self._compression_saved_tokens = self._meter.create_counter(
+            "headroom.compression.tokens.saved",
+            description="Tokens removed by Headroom compression.",
+            unit="1",
+        )
+        self._compression_duration = self._meter.create_histogram(
+            "headroom.compression.pipeline.duration",
+            description="Compression pipeline execution duration.",
+            unit="s",
+        )
+        self._compression_stage_duration = self._meter.create_histogram(
+            "headroom.compression.stage.duration",
+            description="Per-stage compression timing emitted by the pipeline.",
+            unit="s",
+        )
+        self._compression_transforms = self._meter.create_counter(
+            "headroom.compression.transforms",
+            description="Transforms applied during compression.",
+            unit="1",
+        )
+        self._waste_signal_tokens = self._meter.create_counter(
+            "headroom.compression.waste.tokens",
+            description="Waste tokens detected in compressed inputs.",
+            unit="1",
+        )
+
+    @staticmethod
+    def _attrs(**attrs: Any) -> dict[str, Any]:
+        filtered: dict[str, Any] = {}
+        for key, value in attrs.items():
+            if value is None or value == "":
+                continue
+            filtered[key] = value
+        return filtered
+
+    def record_proxy_request(
+        self,
+        *,
+        provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        tokens_saved: int,
+        latency_ms: float,
+        cached: bool = False,
+        overhead_ms: float = 0.0,
+        ttfb_ms: float = 0.0,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        cache_write_5m_tokens: int = 0,
+        cache_write_1h_tokens: int = 0,
+        uncached_input_tokens: int = 0,
+    ) -> None:
+        attrs = self._attrs(provider=provider, model=model, cached=cached)
+
+        self._proxy_requests.add(1, attrs)
+        if cached:
+            self._proxy_cached_requests.add(1, attrs)
+
+        self._proxy_input_tokens.add(max(input_tokens, 0), attrs)
+        self._proxy_output_tokens.add(max(output_tokens, 0), attrs)
+        self._proxy_saved_tokens.add(max(tokens_saved, 0), attrs)
+        self._proxy_latency.record(max(latency_ms, 0.0) / _MILLISECONDS_TO_SECONDS, attrs)
+
+        if overhead_ms > 0:
+            self._proxy_overhead.record(overhead_ms / _MILLISECONDS_TO_SECONDS, attrs)
+        if ttfb_ms > 0:
+            self._proxy_ttfb.record(ttfb_ms / _MILLISECONDS_TO_SECONDS, attrs)
+        if cache_read_tokens > 0:
+            self._proxy_cache_read_tokens.add(cache_read_tokens, attrs)
+        if cache_write_tokens > 0:
+            self._proxy_cache_write_tokens.add(cache_write_tokens, attrs)
+        if uncached_input_tokens > 0:
+            self._proxy_uncached_input_tokens.add(uncached_input_tokens, attrs)
+        if cache_write_5m_tokens > 0:
+            self._proxy_cache_write_ttl_tokens.add(
+                cache_write_5m_tokens,
+                self._attrs(provider=provider, model=model, ttl="5m"),
+            )
+        if cache_write_1h_tokens > 0:
+            self._proxy_cache_write_ttl_tokens.add(
+                cache_write_1h_tokens,
+                self._attrs(provider=provider, model=model, ttl="1h"),
+            )
+
+    def record_proxy_failed(self, *, provider: str | None = None, model: str | None = None) -> None:
+        self._proxy_failed_requests.add(1, self._attrs(provider=provider, model=model))
+
+    def record_proxy_rate_limited(
+        self,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        self._proxy_rate_limited_requests.add(1, self._attrs(provider=provider, model=model))
+
+    def record_proxy_cache_bust(self, *, tokens_lost: int) -> None:
+        self._proxy_cache_busts.add(1)
+        self._proxy_cache_bust_tokens_lost.add(max(tokens_lost, 0))
+
+    def record_pipeline_run(
+        self,
+        *,
+        model: str,
+        provider: str | None,
+        tokens_before: int,
+        tokens_after: int,
+        duration_ms: float,
+        timing: dict[str, float] | None = None,
+        transforms_applied: list[str] | None = None,
+        waste_signals: dict[str, int] | None = None,
+    ) -> None:
+        attrs = self._attrs(model=model, provider=provider)
+        tokens_saved = max(tokens_before - tokens_after, 0)
+
+        self._compression_runs.add(1, attrs)
+        self._compression_input_tokens.add(max(tokens_before, 0), attrs)
+        self._compression_output_tokens.add(max(tokens_after, 0), attrs)
+        self._compression_saved_tokens.add(tokens_saved, attrs)
+        self._compression_duration.record(max(duration_ms, 0.0) / _MILLISECONDS_TO_SECONDS, attrs)
+
+        if transforms_applied:
+            for transform in transforms_applied:
+                self._compression_transforms.add(
+                    1, self._attrs(model=model, provider=provider, transform=transform)
+                )
+
+        if timing:
+            for stage, stage_ms in timing.items():
+                if stage == "pipeline_total" or stage.startswith("_"):
+                    continue
+                self._compression_stage_duration.record(
+                    max(stage_ms, 0.0) / _MILLISECONDS_TO_SECONDS,
+                    self._attrs(model=model, provider=provider, stage=stage),
+                )
+
+        if waste_signals:
+            for signal_name, token_count in waste_signals.items():
+                if token_count > 0:
+                    self._waste_signal_tokens.add(
+                        token_count,
+                        self._attrs(model=model, provider=provider, signal=signal_name),
+                    )
+
+    def record_compression_failure(
+        self,
+        *,
+        model: str,
+        operation: str,
+        error_type: str,
+    ) -> None:
+        self._compression_failures.add(
+            1,
+            self._attrs(model=model, operation=operation, error_type=error_type),
+        )
+
+
+def get_otel_metrics() -> HeadroomOtelMetrics:
+    global _global_metrics
+
+    if _global_metrics is None:
+        with _metrics_lock:
+            if _global_metrics is None:
+                _global_metrics = HeadroomOtelMetrics()
+
+    return _global_metrics
+
+
+def set_otel_metrics(otel_metrics: HeadroomOtelMetrics) -> HeadroomOtelMetrics:
+    global _global_metrics
+    with _metrics_lock:
+        _global_metrics = otel_metrics
+    return otel_metrics
+
+
+def configure_otel_metrics(config: OTelMetricsConfig | None = None) -> HeadroomOtelMetrics:
+    global _global_metrics
+    global _owned_meter_provider
+    global _owned_metrics_config
+
+    resolved = config or OTelMetricsConfig()
+    if not resolved.enabled:
+        return get_otel_metrics()
+
+    try:
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import (
+            ConsoleMetricExporter,
+            PeriodicExportingMetricReader,
+        )
+        from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
+    except ImportError:
+        logger.warning(
+            "OpenTelemetry SDK/exporter packages are not installed. "
+            "Install headroom-ai[otel] to enable managed OTEL metric export."
+        )
+        return get_otel_metrics()
+
+    exporter: Any
+    if resolved.exporter == "console":
+        exporter = ConsoleMetricExporter()
+    else:
+        exporter_kwargs: dict[str, Any] = {}
+        if resolved.endpoint is not None:
+            exporter_kwargs["endpoint"] = resolved.endpoint
+        if resolved.headers:
+            exporter_kwargs["headers"] = resolved.headers
+        exporter = OTLPMetricExporter(**exporter_kwargs)
+
+    reader = PeriodicExportingMetricReader(
+        exporter,
+        export_interval_millis=resolved.export_interval_millis,
+    )
+    resource = Resource.create(
+        {
+            SERVICE_NAME: resolved.service_name,
+            SERVICE_VERSION: _headroom_version(),
+            **resolved.resource_attributes,
+        }
+    )
+    meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
+    otel_metrics = HeadroomOtelMetrics(meter_provider=meter_provider)
+
+    previous_provider = None
+    with _metrics_lock:
+        previous_provider = _owned_meter_provider
+        _owned_meter_provider = meter_provider
+        _owned_metrics_config = resolved
+        _global_metrics = otel_metrics
+
+    if previous_provider is not None:
+        try:
+            previous_provider.shutdown()
+        except Exception:
+            logger.debug("Failed to shut down previous OTEL metrics provider", exc_info=True)
+
+    return otel_metrics
+
+
+def get_otel_metrics_status() -> dict[str, Any]:
+    with _metrics_lock:
+        if _owned_metrics_config is None:
+            return {
+                "configured": False,
+                "enabled": False,
+                "service_name": None,
+                "exporter": None,
+                "endpoint": None,
+                "resource_attributes": {},
+            }
+        return _owned_metrics_config.status()
+
+
+def shutdown_otel_metrics() -> None:
+    global _global_metrics
+    global _owned_meter_provider
+    global _owned_metrics_config
+
+    provider = None
+    with _metrics_lock:
+        provider = _owned_meter_provider
+        _owned_meter_provider = None
+        _owned_metrics_config = None
+        _global_metrics = None
+
+    if provider is not None:
+        try:
+            provider.shutdown()
+        except Exception:
+            logger.debug("Failed to shut down OTEL metrics provider", exc_info=True)
+
+
+def reset_otel_metrics() -> None:
+    shutdown_otel_metrics()

--- a/headroom/observability/tracing.py
+++ b/headroom/observability/tracing.py
@@ -1,0 +1,228 @@
+"""OTEL tracing helpers for Headroom and Langfuse."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any
+
+from opentelemetry import trace
+
+from .metrics import _headroom_version, _parse_bool, _parse_key_value_pairs
+
+logger = logging.getLogger(__name__)
+
+_SCOPE_NAME = "headroom"
+
+_tracing_lock = Lock()
+_global_tracer: HeadroomTracer | None = None
+_owned_tracer_provider: Any | None = None
+_owned_langfuse_config: LangfuseTracingConfig | None = None
+
+
+@dataclass(slots=True)
+class LangfuseTracingConfig:
+    """Configuration for Headroom-managed Langfuse OTLP trace export."""
+
+    enabled: bool = False
+    public_key: str = field(default="", repr=False)
+    secret_key: str = field(default="", repr=False)
+    base_url: str = "https://cloud.langfuse.com"
+    service_name: str = "headroom"
+    resource_attributes: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def endpoint(self) -> str:
+        return f"{self.base_url.rstrip('/')}/api/public/otel/v1/traces"
+
+    @property
+    def auth_header(self) -> str:
+        encoded = base64.b64encode(f"{self.public_key}:{self.secret_key}".encode()).decode()
+        return f"Basic {encoded}"
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {
+            "Authorization": self.auth_header,
+            "x-langfuse-ingestion-version": "4",
+        }
+
+    @classmethod
+    def from_env(cls, *, default_service_name: str = "headroom") -> LangfuseTracingConfig:
+        public_key = os.environ.get("LANGFUSE_PUBLIC_KEY", "").strip()
+        secret_key = os.environ.get("LANGFUSE_SECRET_KEY", "").strip()
+
+        return cls(
+            enabled=_parse_bool(
+                os.environ.get("HEADROOM_LANGFUSE_ENABLED"),
+                default=False,
+            ),
+            public_key=public_key,
+            secret_key=secret_key,
+            base_url=(
+                os.environ.get("LANGFUSE_BASE_URL")
+                or os.environ.get("LANGFUSE_OTEL_HOST")
+                or "https://cloud.langfuse.com"
+            ).strip(),
+            service_name=os.environ.get(
+                "HEADROOM_LANGFUSE_SERVICE_NAME", default_service_name
+            ).strip()
+            or default_service_name,
+            resource_attributes=_parse_key_value_pairs(
+                os.environ.get("HEADROOM_LANGFUSE_RESOURCE_ATTRIBUTES")
+            ),
+        )
+
+    def is_complete(self) -> bool:
+        return bool(self.public_key and self.secret_key)
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "configured": True,
+            "enabled": self.enabled,
+            "service_name": self.service_name,
+            "base_url": self.base_url,
+            "endpoint": self.endpoint,
+        }
+
+
+class HeadroomTracer:
+    """Tracer facade used by shared Headroom compression paths."""
+
+    def __init__(self, tracer_provider: Any | None = None):
+        if tracer_provider is None:
+            self._tracer = trace.get_tracer(_SCOPE_NAME, _headroom_version())
+        else:
+            self._tracer = tracer_provider.get_tracer(_SCOPE_NAME, _headroom_version())
+
+    def start_as_current_span(
+        self,
+        name: str,
+        *,
+        attributes: dict[str, Any] | None = None,
+    ) -> Any:
+        return self._tracer.start_as_current_span(
+            name,
+            attributes=attributes,
+            record_exception=True,
+            set_status_on_exception=True,
+        )
+
+
+def get_headroom_tracer() -> HeadroomTracer:
+    global _global_tracer
+
+    if _global_tracer is None:
+        with _tracing_lock:
+            if _global_tracer is None:
+                _global_tracer = HeadroomTracer()
+
+    return _global_tracer
+
+
+def set_headroom_tracer(headroom_tracer: HeadroomTracer) -> HeadroomTracer:
+    global _global_tracer
+    with _tracing_lock:
+        _global_tracer = headroom_tracer
+    return headroom_tracer
+
+
+def configure_langfuse_tracing(
+    config: LangfuseTracingConfig | None = None,
+) -> HeadroomTracer:
+    global _global_tracer
+    global _owned_tracer_provider
+    global _owned_langfuse_config
+
+    resolved = config or LangfuseTracingConfig()
+    if not resolved.enabled:
+        return get_headroom_tracer()
+    if not resolved.is_complete():
+        logger.warning(
+            "Langfuse tracing is enabled but LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY are missing."
+        )
+        return get_headroom_tracer()
+
+    try:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        logger.warning(
+            "OpenTelemetry SDK/exporter packages are not installed. "
+            "Install headroom-ai[otel] to enable Langfuse OTLP tracing."
+        )
+        return get_headroom_tracer()
+
+    resource = Resource.create(
+        {
+            SERVICE_NAME: resolved.service_name,
+            SERVICE_VERSION: _headroom_version(),
+            **resolved.resource_attributes,
+        }
+    )
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(
+                endpoint=resolved.endpoint,
+                headers=resolved.headers,
+            )
+        )
+    )
+    headroom_tracer = HeadroomTracer(tracer_provider=tracer_provider)
+
+    previous_provider = None
+    with _tracing_lock:
+        previous_provider = _owned_tracer_provider
+        _owned_tracer_provider = tracer_provider
+        _owned_langfuse_config = resolved
+        _global_tracer = headroom_tracer
+
+    if previous_provider is not None:
+        try:
+            previous_provider.shutdown()
+        except Exception:
+            logger.debug("Failed to shut down previous Langfuse tracer provider", exc_info=True)
+
+    return headroom_tracer
+
+
+def get_langfuse_tracing_status() -> dict[str, Any]:
+    with _tracing_lock:
+        if _owned_langfuse_config is None:
+            return {
+                "configured": False,
+                "enabled": False,
+                "service_name": None,
+                "base_url": None,
+                "endpoint": None,
+            }
+        return _owned_langfuse_config.status()
+
+
+def shutdown_headroom_tracing() -> None:
+    global _global_tracer
+    global _owned_tracer_provider
+    global _owned_langfuse_config
+
+    provider = None
+    with _tracing_lock:
+        provider = _owned_tracer_provider
+        _owned_tracer_provider = None
+        _owned_langfuse_config = None
+        _global_tracer = None
+
+    if provider is not None:
+        try:
+            provider.shutdown()
+        except Exception:
+            logger.debug("Failed to shut down Langfuse tracer provider", exc_info=True)
+
+
+def reset_headroom_tracing() -> None:
+    shutdown_headroom_tracing()

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -389,7 +389,7 @@ class AnthropicHandlerMixin:
             rate_key = f"{api_key[:16]}:{client_ip}" if api_key else client_ip
             allowed, wait_seconds = await self.rate_limiter.check_request(rate_key)
             if not allowed:
-                await self.metrics.record_rate_limited()
+                await self.metrics.record_rate_limited(provider="anthropic")
                 raise HTTPException(
                     status_code=429,
                     detail=f"Rate limited. Retry after {wait_seconds:.1f}s",
@@ -1443,7 +1443,7 @@ class AnthropicHandlerMixin:
                 )
 
         except Exception as e:
-            await self.metrics.record_failed()
+            await self.metrics.record_failed(provider="anthropic")
             # Log full error details internally for debugging
             logger.error(f"[{request_id}] Request failed: {type(e).__name__}: {e}")
 
@@ -1721,7 +1721,7 @@ class AnthropicHandlerMixin:
             )
 
         except Exception as e:
-            await self.metrics.record_failed()
+            await self.metrics.record_failed(provider="anthropic")
             logger.error(f"[{request_id}] Batch request failed: {type(e).__name__}: {e}")
             return JSONResponse(
                 status_code=502,

--- a/headroom/proxy/handlers/batch.py
+++ b/headroom/proxy/handlers/batch.py
@@ -810,7 +810,7 @@ class BatchHandlerMixin:
 
         except Exception as e:
             logger.error(f"[{request_id}] Batch creation failed: {type(e).__name__}: {e}")
-            await self.metrics.record_failed()
+            await self.metrics.record_failed(provider="batch")
             return JSONResponse(
                 status_code=500,
                 content={

--- a/headroom/proxy/handlers/gemini.py
+++ b/headroom/proxy/handlers/gemini.py
@@ -175,7 +175,7 @@ class GeminiHandlerMixin:
             rate_key = headers.get("x-goog-api-key", "default")[:20]
             allowed, wait_seconds = await self.rate_limiter.check_request(rate_key)
             if not allowed:
-                await self.metrics.record_rate_limited()
+                await self.metrics.record_rate_limited(provider="gemini")
                 raise HTTPException(
                     status_code=429,
                     detail=f"Rate limited. Retry after {wait_seconds:.1f}s",
@@ -406,7 +406,7 @@ class GeminiHandlerMixin:
                     headers=response_headers,
                 )
         except Exception as e:
-            await self.metrics.record_failed()
+            await self.metrics.record_failed(provider="gemini")
             logger.error(f"[{request_id}] Gemini request failed: {type(e).__name__}: {e}")
             return JSONResponse(
                 status_code=502,
@@ -650,7 +650,7 @@ class GeminiHandlerMixin:
                 headers=response_headers,
             )
         except Exception as e:
-            await self.metrics.record_failed()
+            await self.metrics.record_failed(provider="gemini")
             logger.error(f"[{request_id}] Gemini countTokens failed: {type(e).__name__}: {e}")
             return JSONResponse(
                 status_code=502,

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -213,7 +213,7 @@ class OpenAIHandlerMixin:
             rate_key = headers.get("authorization", "default")[:20]
             allowed, wait_seconds = await self.rate_limiter.check_request(rate_key)
             if not allowed:
-                await self.metrics.record_rate_limited()
+                await self.metrics.record_rate_limited(provider="openai")
                 raise HTTPException(
                     status_code=429,
                     detail=f"Rate limited. Retry after {wait_seconds:.1f}s",
@@ -689,7 +689,7 @@ class OpenAIHandlerMixin:
                     headers=response_headers,
                 )
         except Exception as e:
-            await self.metrics.record_failed()
+            await self.metrics.record_failed(provider="openai")
             # Log full error details internally for debugging
             logger.error(f"[{request_id}] OpenAI request failed: {type(e).__name__}: {e}")
             # Return sanitized error message to client (don't expose internal details)
@@ -800,7 +800,7 @@ class OpenAIHandlerMixin:
             rate_key = headers.get("authorization", "default")[:20]
             allowed, wait_seconds = await self.rate_limiter.check_request(rate_key)
             if not allowed:
-                await self.metrics.record_rate_limited()
+                await self.metrics.record_rate_limited(provider="openai")
                 raise HTTPException(
                     status_code=429,
                     detail=f"Rate limited. Retry after {wait_seconds:.1f}s",
@@ -950,7 +950,7 @@ class OpenAIHandlerMixin:
                     headers=response_headers,
                 )
         except Exception as e:
-            await self.metrics.record_failed()
+            await self.metrics.record_failed(provider="openai")
             logger.error(f"[{request_id}] OpenAI responses request failed: {type(e).__name__}: {e}")
             return JSONResponse(
                 status_code=502,

--- a/headroom/proxy/prometheus_metrics.py
+++ b/headroom/proxy/prometheus_metrics.py
@@ -16,11 +16,46 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from headroom.observability import HeadroomOtelMetrics
     from headroom.proxy.cost import CostTracker
 
+from headroom.observability import get_otel_metrics
 from headroom.proxy.savings_tracker import SavingsTracker
 
 logger = logging.getLogger("headroom.proxy")
+
+
+def _escape_label_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _format_labels(labels: dict[str, str] | None = None) -> str:
+    if not labels:
+        return ""
+
+    rendered = ",".join(
+        f'{key}="{_escape_label_value(str(value))}"' for key, value in sorted(labels.items())
+    )
+    return f"{{{rendered}}}"
+
+
+def _append_metric(
+    lines: list[str],
+    *,
+    name: str,
+    metric_type: str,
+    help_text: str,
+    value: int | float,
+    labels: dict[str, str] | None = None,
+) -> None:
+    lines.extend(
+        [
+            f"# HELP {name} {help_text}",
+            f"# TYPE {name} {metric_type}",
+            f"{name}{_format_labels(labels)} {value}",
+            "",
+        ]
+    )
 
 
 class PrometheusMetrics:
@@ -30,6 +65,7 @@ class PrometheusMetrics:
         self,
         savings_tracker: SavingsTracker | None = None,
         cost_tracker: CostTracker | None = None,
+        otel_metrics: HeadroomOtelMetrics | None = None,
     ):
         self.requests_total = 0
         self.requests_by_provider: dict[str, int] = defaultdict(int)
@@ -115,6 +151,10 @@ class PrometheusMetrics:
         )
 
         self._lock = asyncio.Lock()
+        self._otel_metrics = otel_metrics
+
+    def _get_otel_metrics(self) -> HeadroomOtelMetrics:
+        return self._otel_metrics or get_otel_metrics()
 
     def _current_savings_tracker_totals(self) -> tuple[int, float]:
         total_input_tokens = self._savings_tracker_input_tokens_offset + self.tokens_input_total
@@ -260,77 +300,365 @@ class PrometheusMetrics:
                 total_input_cost_usd=total_input_cost_usd,
             )
 
+        self._get_otel_metrics().record_proxy_request(
+            provider=provider,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            tokens_saved=tokens_saved,
+            latency_ms=latency_ms,
+            cached=cached,
+            overhead_ms=overhead_ms,
+            ttfb_ms=ttfb_ms,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            cache_write_5m_tokens=cache_write_5m_tokens,
+            cache_write_1h_tokens=cache_write_1h_tokens,
+            uncached_input_tokens=uncached_input_tokens,
+        )
+
     async def record_cache_bust(self, tokens_lost: int) -> None:
         """Record tokens that lost their cache discount due to compression."""
         async with self._lock:
             self.cache_bust_tokens_lost += tokens_lost
             self.cache_bust_count += 1
+        self._get_otel_metrics().record_proxy_cache_bust(tokens_lost=tokens_lost)
 
-    async def record_rate_limited(self):
+    async def record_rate_limited(self, *, provider: str | None = None, model: str | None = None):
         async with self._lock:
             self.requests_rate_limited += 1
+        self._get_otel_metrics().record_proxy_rate_limited(provider=provider, model=model)
 
-    async def record_failed(self):
+    async def record_failed(self, *, provider: str | None = None, model: str | None = None):
         async with self._lock:
             self.requests_failed += 1
+        self._get_otel_metrics().record_proxy_failed(provider=provider, model=model)
 
     async def export(self) -> str:
         """Export metrics in Prometheus format."""
         async with self._lock:
-            lines = [
-                "# HELP headroom_requests_total Total number of requests",
-                "# TYPE headroom_requests_total counter",
-                f"headroom_requests_total {self.requests_total}",
-                "",
-                "# HELP headroom_requests_cached_total Cached request count",
-                "# TYPE headroom_requests_cached_total counter",
-                f"headroom_requests_cached_total {self.requests_cached}",
-                "",
-                "# HELP headroom_requests_rate_limited_total Rate limited requests",
-                "# TYPE headroom_requests_rate_limited_total counter",
-                f"headroom_requests_rate_limited_total {self.requests_rate_limited}",
-                "",
-                "# HELP headroom_requests_failed_total Failed requests",
-                "# TYPE headroom_requests_failed_total counter",
-                f"headroom_requests_failed_total {self.requests_failed}",
-                "",
-                "# HELP headroom_tokens_input_total Total input tokens",
-                "# TYPE headroom_tokens_input_total counter",
-                f"headroom_tokens_input_total {self.tokens_input_total}",
-                "",
-                "# HELP headroom_tokens_output_total Total output tokens",
-                "# TYPE headroom_tokens_output_total counter",
-                f"headroom_tokens_output_total {self.tokens_output_total}",
-                "",
-                "# HELP headroom_tokens_saved_total Tokens saved by optimization",
-                "# TYPE headroom_tokens_saved_total counter",
-                f"headroom_tokens_saved_total {self.tokens_saved_total}",
-                "",
-                "# HELP headroom_latency_ms_sum Sum of request latencies",
-                "# TYPE headroom_latency_ms_sum counter",
-                f"headroom_latency_ms_sum {self.latency_sum_ms:.2f}",
-            ]
+            lines: list[str] = []
+            _append_metric(
+                lines,
+                name="headroom_requests_total",
+                metric_type="counter",
+                help_text="Total number of requests",
+                value=self.requests_total,
+            )
+            _append_metric(
+                lines,
+                name="headroom_requests_cached_total",
+                metric_type="counter",
+                help_text="Cached request count",
+                value=self.requests_cached,
+            )
+            _append_metric(
+                lines,
+                name="headroom_requests_rate_limited_total",
+                metric_type="counter",
+                help_text="Rate limited requests",
+                value=self.requests_rate_limited,
+            )
+            _append_metric(
+                lines,
+                name="headroom_requests_failed_total",
+                metric_type="counter",
+                help_text="Failed requests",
+                value=self.requests_failed,
+            )
+            _append_metric(
+                lines,
+                name="headroom_tokens_input_total",
+                metric_type="counter",
+                help_text="Total input tokens",
+                value=self.tokens_input_total,
+            )
+            _append_metric(
+                lines,
+                name="headroom_tokens_output_total",
+                metric_type="counter",
+                help_text="Total output tokens",
+                value=self.tokens_output_total,
+            )
+            _append_metric(
+                lines,
+                name="headroom_tokens_saved_total",
+                metric_type="counter",
+                help_text="Tokens saved by optimization",
+                value=self.tokens_saved_total,
+            )
+            _append_metric(
+                lines,
+                name="headroom_latency_ms_sum",
+                metric_type="counter",
+                help_text="Sum of request latencies in milliseconds",
+                value=round(self.latency_sum_ms, 2),
+            )
+            _append_metric(
+                lines,
+                name="headroom_latency_ms_count",
+                metric_type="counter",
+                help_text="Count of observed request latencies",
+                value=self.latency_count,
+            )
+            _append_metric(
+                lines,
+                name="headroom_latency_ms_min",
+                metric_type="gauge",
+                help_text="Minimum observed request latency in milliseconds",
+                value=0 if self.latency_count == 0 else round(self.latency_min_ms, 2),
+            )
+            _append_metric(
+                lines,
+                name="headroom_latency_ms_max",
+                metric_type="gauge",
+                help_text="Maximum observed request latency in milliseconds",
+                value=round(self.latency_max_ms, 2),
+            )
+            _append_metric(
+                lines,
+                name="headroom_overhead_ms_sum",
+                metric_type="counter",
+                help_text="Sum of Headroom processing overhead in milliseconds",
+                value=round(self.overhead_sum_ms, 2),
+            )
+            _append_metric(
+                lines,
+                name="headroom_overhead_ms_count",
+                metric_type="counter",
+                help_text="Count of observed Headroom overhead samples",
+                value=self.overhead_count,
+            )
+            _append_metric(
+                lines,
+                name="headroom_overhead_ms_min",
+                metric_type="gauge",
+                help_text="Minimum observed Headroom overhead in milliseconds",
+                value=0 if self.overhead_count == 0 else round(self.overhead_min_ms, 2),
+            )
+            _append_metric(
+                lines,
+                name="headroom_overhead_ms_max",
+                metric_type="gauge",
+                help_text="Maximum observed Headroom overhead in milliseconds",
+                value=round(self.overhead_max_ms, 2),
+            )
+            _append_metric(
+                lines,
+                name="headroom_ttfb_ms_sum",
+                metric_type="counter",
+                help_text="Sum of time to first byte in milliseconds",
+                value=round(self.ttfb_sum_ms, 2),
+            )
+            _append_metric(
+                lines,
+                name="headroom_ttfb_ms_count",
+                metric_type="counter",
+                help_text="Count of observed time-to-first-byte samples",
+                value=self.ttfb_count,
+            )
+            _append_metric(
+                lines,
+                name="headroom_ttfb_ms_min",
+                metric_type="gauge",
+                help_text="Minimum observed time to first byte in milliseconds",
+                value=0 if self.ttfb_count == 0 else round(self.ttfb_min_ms, 2),
+            )
+            _append_metric(
+                lines,
+                name="headroom_ttfb_ms_max",
+                metric_type="gauge",
+                help_text="Maximum observed time to first byte in milliseconds",
+                value=round(self.ttfb_max_ms, 2),
+            )
+            _append_metric(
+                lines,
+                name="headroom_cache_bust_total",
+                metric_type="counter",
+                help_text="Requests that lost provider cache efficiency because of compression",
+                value=self.cache_bust_count,
+            )
+            _append_metric(
+                lines,
+                name="headroom_cache_bust_tokens_lost_total",
+                metric_type="counter",
+                help_text="Tokens that lost provider cache discount because of compression",
+                value=self.cache_bust_tokens_lost,
+            )
 
-            # Per-provider metrics
             lines.extend(
                 [
-                    "",
                     "# HELP headroom_requests_by_provider Requests by provider",
                     "# TYPE headroom_requests_by_provider counter",
                 ]
             )
             for provider, count in self.requests_by_provider.items():
                 lines.append(f'headroom_requests_by_provider{{provider="{provider}"}} {count}')
+            lines.append("")
 
-            # Per-model metrics
             lines.extend(
                 [
-                    "",
                     "# HELP headroom_requests_by_model Requests by model",
                     "# TYPE headroom_requests_by_model counter",
                 ]
             )
             for model, count in self.requests_by_model.items():
                 lines.append(f'headroom_requests_by_model{{model="{model}"}} {count}')
+            lines.append("")
+
+            if self.transform_timing_sum:
+                lines.extend(
+                    [
+                        "# HELP headroom_transform_timing_ms_sum Sum of transform timing in milliseconds",
+                        "# TYPE headroom_transform_timing_ms_sum counter",
+                    ]
+                )
+                for name, total in self.transform_timing_sum.items():
+                    lines.append(
+                        f'headroom_transform_timing_ms_sum{{transform="{_escape_label_value(name)}"}} {round(total, 2)}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_transform_timing_ms_count Count of transform timing samples",
+                        "# TYPE headroom_transform_timing_ms_count counter",
+                    ]
+                )
+                for name, count in self.transform_timing_count.items():
+                    lines.append(
+                        f'headroom_transform_timing_ms_count{{transform="{_escape_label_value(name)}"}} {count}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_transform_timing_ms_max Maximum transform timing in milliseconds",
+                        "# TYPE headroom_transform_timing_ms_max gauge",
+                    ]
+                )
+                for name, max_value in self.transform_timing_max.items():
+                    lines.append(
+                        f'headroom_transform_timing_ms_max{{transform="{_escape_label_value(name)}"}} {round(max_value, 2)}'
+                    )
+                lines.append("")
+
+            if self.waste_signals_total:
+                lines.extend(
+                    [
+                        "# HELP headroom_waste_signal_tokens_total Tokens attributed to detected waste signals",
+                        "# TYPE headroom_waste_signal_tokens_total counter",
+                    ]
+                )
+                for signal_name, token_count in self.waste_signals_total.items():
+                    lines.append(
+                        f'headroom_waste_signal_tokens_total{{signal="{_escape_label_value(signal_name)}"}} {token_count}'
+                    )
+                lines.append("")
+
+            if self.cache_by_provider:
+                lines.extend(
+                    [
+                        "# HELP headroom_cache_read_tokens_total Provider cache read tokens",
+                        "# TYPE headroom_cache_read_tokens_total counter",
+                    ]
+                )
+                for provider, stats in self.cache_by_provider.items():
+                    lines.append(
+                        f'headroom_cache_read_tokens_total{{provider="{provider}"}} {stats["cache_read_tokens"]}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_cache_write_tokens_total Provider cache write tokens",
+                        "# TYPE headroom_cache_write_tokens_total counter",
+                    ]
+                )
+                for provider, stats in self.cache_by_provider.items():
+                    lines.append(
+                        f'headroom_cache_write_tokens_total{{provider="{provider}"}} {stats["cache_write_tokens"]}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_cache_write_ttl_tokens_total Provider cache write tokens by observed TTL bucket",
+                        "# TYPE headroom_cache_write_ttl_tokens_total counter",
+                    ]
+                )
+                for provider, stats in self.cache_by_provider.items():
+                    lines.append(
+                        f'headroom_cache_write_ttl_tokens_total{{provider="{provider}",ttl="5m"}} {stats["cache_write_5m_tokens"]}'
+                    )
+                    lines.append(
+                        f'headroom_cache_write_ttl_tokens_total{{provider="{provider}",ttl="1h"}} {stats["cache_write_1h_tokens"]}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_cache_write_ttl_requests_total Provider cache write requests by observed TTL bucket",
+                        "# TYPE headroom_cache_write_ttl_requests_total counter",
+                    ]
+                )
+                for provider, stats in self.cache_by_provider.items():
+                    lines.append(
+                        f'headroom_cache_write_ttl_requests_total{{provider="{provider}",ttl="5m"}} {stats["cache_write_5m_requests"]}'
+                    )
+                    lines.append(
+                        f'headroom_cache_write_ttl_requests_total{{provider="{provider}",ttl="1h"}} {stats["cache_write_1h_requests"]}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_uncached_input_tokens_total Input tokens not served from provider cache",
+                        "# TYPE headroom_uncached_input_tokens_total counter",
+                    ]
+                )
+                for provider, stats in self.cache_by_provider.items():
+                    lines.append(
+                        f'headroom_uncached_input_tokens_total{{provider="{provider}"}} {stats["uncached_input_tokens"]}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_provider_cache_requests_total Requests with provider cache observations",
+                        "# TYPE headroom_provider_cache_requests_total counter",
+                    ]
+                )
+                for provider, stats in self.cache_by_provider.items():
+                    lines.append(
+                        f'headroom_provider_cache_requests_total{{provider="{provider}"}} {stats["requests"]}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_provider_cache_hit_requests_total Requests with provider cache reads",
+                        "# TYPE headroom_provider_cache_hit_requests_total counter",
+                    ]
+                )
+                for provider, stats in self.cache_by_provider.items():
+                    lines.append(
+                        f'headroom_provider_cache_hit_requests_total{{provider="{provider}"}} {stats["hit_requests"]}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_provider_cache_bust_total Provider-specific cache bust count",
+                        "# TYPE headroom_provider_cache_bust_total counter",
+                    ]
+                )
+                for provider, stats in self.cache_by_provider.items():
+                    lines.append(
+                        f'headroom_provider_cache_bust_total{{provider="{provider}"}} {stats["bust_count"]}'
+                    )
+                lines.extend(
+                    [
+                        "",
+                        "# HELP headroom_provider_cache_bust_write_tokens_total Provider cache write tokens attributed to busts",
+                        "# TYPE headroom_provider_cache_bust_write_tokens_total counter",
+                    ]
+                )
+                for provider, stats in self.cache_by_provider.items():
+                    lines.append(
+                        f'headroom_provider_cache_bust_write_tokens_total{{provider="{provider}"}} {stats["bust_write_tokens"]}'
+                    )
+                lines.append("")
 
             return "\n".join(lines)

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -78,6 +78,16 @@ from headroom.config import (
     SmartCrusherConfig,
 )
 from headroom.dashboard import get_dashboard_html
+from headroom.observability import (
+    LangfuseTracingConfig,
+    OTelMetricsConfig,
+    configure_langfuse_tracing,
+    configure_otel_metrics,
+    get_langfuse_tracing_status,
+    get_otel_metrics_status,
+    shutdown_headroom_tracing,
+    shutdown_otel_metrics,
+)
 from headroom.providers import AnthropicProvider, OpenAIProvider
 
 # =============================================================================
@@ -824,7 +834,6 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
     from contextlib import asynccontextmanager
 
     config = config or ProxyConfig()
-
     proxy = HeadroomProxy(config)
 
     # Telemetry beacon (anonymous aggregate stats).
@@ -890,32 +899,40 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):  # type: ignore[no-untyped-def]
-        # Startup
-        await proxy.startup()
-        asyncio.create_task(_log_toin_stats_periodically())
-        if proxy.usage_reporter:
-            await proxy.usage_reporter.start(proxy)
-        if proxy.traffic_learner:
-            await proxy.traffic_learner.start()
+        configure_otel_metrics(OTelMetricsConfig.from_env(default_service_name="headroom-proxy"))
+        configure_langfuse_tracing(
+            LangfuseTracingConfig.from_env(default_service_name="headroom-proxy")
+        )
 
-        # Only start beacon if we acquire the lock (first worker wins)
-        _beacon_is_owner[0] = _try_acquire_beacon_lock()
-        if _beacon_is_owner[0]:
-            await _beacon.start()
-        else:
-            logger.debug("Beacon: skipping (another worker owns the lock)")
+        try:
+            # Startup
+            await proxy.startup()
+            asyncio.create_task(_log_toin_stats_periodically())
+            if proxy.usage_reporter:
+                await proxy.usage_reporter.start(proxy)
+            if proxy.traffic_learner:
+                await proxy.traffic_learner.start()
 
-        yield
+            # Only start beacon if we acquire the lock (first worker wins)
+            _beacon_is_owner[0] = _try_acquire_beacon_lock()
+            if _beacon_is_owner[0]:
+                await _beacon.start()
+            else:
+                logger.debug("Beacon: skipping (another worker owns the lock)")
 
-        # Shutdown
-        if _beacon_is_owner[0]:
-            await _beacon.stop()
-            _release_beacon_lock()
-        if proxy.usage_reporter:
-            await proxy.usage_reporter.stop()
-        if proxy.traffic_learner:
-            await proxy.traffic_learner.stop()
-        await proxy.shutdown()
+            yield
+        finally:
+            # Shutdown
+            if _beacon_is_owner[0]:
+                await _beacon.stop()
+                _release_beacon_lock()
+            if proxy.usage_reporter:
+                await proxy.usage_reporter.stop()
+            if proxy.traffic_learner:
+                await proxy.traffic_learner.stop()
+            await proxy.shutdown()
+            shutdown_headroom_tracing()
+            shutdown_otel_metrics()
 
     app = FastAPI(
         title="Headroom Proxy",
@@ -1159,6 +1176,8 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                 "avg_compression_ratio": round(telemetry_stats.get("avg_compression_ratio", 0), 4),
                 "avg_token_reduction": round(telemetry_stats.get("avg_token_reduction", 0), 4),
             },
+            "otel": get_otel_metrics_status(),
+            "langfuse": get_langfuse_tracing_status(),
             "feedback_loop": {
                 "tools_tracked": feedback_stats.get("tools_tracked", 0),
                 "total_compressions": feedback_stats.get("total_compressions", 0),

--- a/headroom/transforms/pipeline.py
+++ b/headroom/transforms/pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 from ..config import (
@@ -17,6 +18,7 @@ from ..config import (
     TransformResult,
     WasteSignals,
 )
+from ..observability import get_headroom_tracer, get_otel_metrics
 from ..tokenizer import Tokenizer
 from ..utils import deep_copy_messages
 from .base import Transform
@@ -145,6 +147,16 @@ class TransformPipeline:
 
         return Tokenizer(get_tokenizer(model), model)  # type: ignore[arg-type]
 
+    def _provider_name(self) -> str | None:
+        if self._provider is None:
+            return None
+
+        name = getattr(self._provider, "provider_name", None)
+        if isinstance(name, str) and name:
+            return name
+
+        return self._provider.__class__.__name__.removesuffix("Provider").lower()
+
     def apply(
         self,
         messages: list[dict[str, Any]],
@@ -166,7 +178,9 @@ class TransformPipeline:
         Returns:
             Combined TransformResult.
         """
+        record_metrics = kwargs.pop("record_metrics", True)
         tokenizer = self._get_tokenizer(model)
+        provider_name = self._provider_name()
 
         # Get model limit from kwargs (should be set by client)
         model_limit = kwargs.get("model_limit")
@@ -188,135 +202,204 @@ class TransformPipeline:
             model,
         )
 
-        # Track all transforms applied
-        all_transforms: list[str] = []
-        all_markers: list[str] = []
-        all_warnings: list[str] = []
-        all_timing: dict[str, float] = {}  # transform_name → ms
-
-        # Track transform diffs if enabled
-        transform_diffs: list[TransformDiff] = []
-        generate_diff = self.config.generate_diff_artifact
-
-        t_copy = time.perf_counter()
-        current_messages = deep_copy_messages(messages)
-        copy_ms = (time.perf_counter() - t_copy) * 1000
-
-        all_timing["_deep_copy"] = copy_ms
-        all_timing["_initial_token_count"] = count_ms
-
-        pipeline_start = time.perf_counter()
-
-        frozen_count = kwargs.get("frozen_message_count", 0)
-        if frozen_count > 0:
-            logger.info(
-                "Pipeline: freezing first %d/%d messages (prefix cached by provider)",
-                frozen_count,
-                len(messages),
+        tracer = get_headroom_tracer()
+        span_attributes = {
+            "headroom.model": model,
+            "headroom.provider": provider_name or "unknown",
+            "headroom.message_count": len(messages),
+            "headroom.tokens.before": tokens_before,
+        }
+        pipeline_span_context = (
+            tracer.start_as_current_span(
+                "headroom.compression.pipeline",
+                attributes=span_attributes,
             )
+            if record_metrics
+            else nullcontext()
+        )
 
-        for transform in self.transforms:
-            # Check if transform should run
-            if not transform.should_apply(current_messages, tokenizer, **kwargs):
-                continue
+        with pipeline_span_context as pipeline_span:
+            # Track all transforms applied
+            all_transforms: list[str] = []
+            all_markers: list[str] = []
+            all_warnings: list[str] = []
+            all_timing: dict[str, float] = {}  # transform_name → ms
 
-            # Time the transform
-            t0 = time.perf_counter()
-            result = transform.apply(current_messages, tokenizer, **kwargs)
-            duration_ms = (time.perf_counter() - t0) * 1000
+            # Track transform diffs if enabled
+            transform_diffs: list[TransformDiff] = []
+            generate_diff = self.config.generate_diff_artifact
 
-            # Update messages for next transform
-            current_messages = result.messages
+            t_copy = time.perf_counter()
+            current_messages = deep_copy_messages(messages)
+            copy_ms = (time.perf_counter() - t_copy) * 1000
 
-            # Use token counts reported by the transform itself — avoids
-            # redundant O(N) recount of the full message list after each step.
-            tokens_before_transform = result.tokens_before
-            tokens_after_transform = result.tokens_after
+            all_timing["_deep_copy"] = copy_ms
+            all_timing["_initial_token_count"] = count_ms
 
-            # Accumulate results
-            all_transforms.extend(result.transforms_applied)
-            all_markers.extend(result.markers_inserted)
-            all_warnings.extend(result.warnings)
-            all_timing[transform.name] = duration_ms
+            pipeline_start = time.perf_counter()
 
-            # Merge sub-transform timing (e.g. ContentRouter's per-compressor breakdown)
-            if result.timing:
-                all_timing.update(result.timing)
-
-            # Log transform results
-            if result.transforms_applied:
+            frozen_count = kwargs.get("frozen_message_count", 0)
+            if frozen_count > 0:
                 logger.info(
-                    "Transform %s: %d -> %d tokens (saved %d) [%.1fms]",
-                    transform.name,
-                    tokens_before_transform,
-                    tokens_after_transform,
-                    tokens_before_transform - tokens_after_transform,
-                    duration_ms,
+                    "Pipeline: freezing first %d/%d messages (prefix cached by provider)",
+                    frozen_count,
+                    len(messages),
+                )
+
+            for transform in self.transforms:
+                # Check if transform should run
+                if not transform.should_apply(current_messages, tokenizer, **kwargs):
+                    continue
+
+                transform_span_context = (
+                    tracer.start_as_current_span(
+                        "headroom.compression.transform",
+                        attributes={
+                            "headroom.model": model,
+                            "headroom.provider": provider_name or "unknown",
+                            "headroom.transform": transform.name,
+                        },
+                    )
+                    if record_metrics
+                    else nullcontext()
+                )
+
+                with transform_span_context as transform_span:
+                    # Time the transform
+                    t0 = time.perf_counter()
+                    result = transform.apply(current_messages, tokenizer, **kwargs)
+                    duration_ms = (time.perf_counter() - t0) * 1000
+
+                    # Update messages for next transform
+                    current_messages = result.messages
+
+                    # Use token counts reported by the transform itself — avoids
+                    # redundant O(N) recount of the full message list after each step.
+                    tokens_before_transform = result.tokens_before
+                    tokens_after_transform = result.tokens_after
+
+                    if transform_span is not None and transform_span.is_recording():
+                        transform_span.set_attribute(
+                            "headroom.tokens.before", tokens_before_transform
+                        )
+                        transform_span.set_attribute(
+                            "headroom.tokens.after", tokens_after_transform
+                        )
+                        transform_span.set_attribute(
+                            "headroom.tokens.saved",
+                            tokens_before_transform - tokens_after_transform,
+                        )
+                        transform_span.set_attribute("headroom.duration_ms", duration_ms)
+                        transform_span.set_attribute(
+                            "headroom.transforms_applied",
+                            len(result.transforms_applied),
+                        )
+
+                    # Accumulate results
+                    all_transforms.extend(result.transforms_applied)
+                    all_markers.extend(result.markers_inserted)
+                    all_warnings.extend(result.warnings)
+                    all_timing[transform.name] = duration_ms
+
+                    # Merge sub-transform timing (e.g. ContentRouter's per-compressor breakdown)
+                    if result.timing:
+                        all_timing.update(result.timing)
+
+                    # Log transform results
+                    if result.transforms_applied:
+                        logger.info(
+                            "Transform %s: %d -> %d tokens (saved %d) [%.1fms]",
+                            transform.name,
+                            tokens_before_transform,
+                            tokens_after_transform,
+                            tokens_before_transform - tokens_after_transform,
+                            duration_ms,
+                        )
+                    else:
+                        logger.debug(
+                            "Transform %s: no changes [%.1fms]", transform.name, duration_ms
+                        )
+
+                    # Record diff if enabled
+                    if generate_diff:
+                        transform_diffs.append(
+                            TransformDiff(
+                                transform_name=transform.name,
+                                tokens_before=tokens_before_transform,
+                                tokens_after=tokens_after_transform,
+                                tokens_saved=tokens_before_transform - tokens_after_transform,
+                                details=", ".join(result.transforms_applied)
+                                if result.transforms_applied
+                                else "",
+                                duration_ms=duration_ms,
+                            )
+                        )
+
+            # Single final token count — the only full recount in the pipeline.
+            # Earlier per-transform counts come from each transform's own result.
+            t_final_count = time.perf_counter()
+            tokens_after = tokenizer.count_messages(current_messages)
+            all_timing["_final_token_count"] = (time.perf_counter() - t_final_count) * 1000
+
+            pipeline_ms = (time.perf_counter() - pipeline_start) * 1000
+            all_timing["pipeline_total"] = pipeline_ms
+
+            # Log pipeline summary
+            total_saved = tokens_before - tokens_after
+            timing_parts = " ".join(f"{k}={v:.0f}ms" for k, v in all_timing.items())
+            if total_saved > 0:
+                logger.info(
+                    "Pipeline complete: %d -> %d tokens (saved %d, %.1f%% reduction) [%s]",
+                    tokens_before,
+                    tokens_after,
+                    total_saved,
+                    (total_saved / tokens_before * 100) if tokens_before > 0 else 0,
+                    timing_parts,
                 )
             else:
-                logger.debug("Transform %s: no changes [%.1fms]", transform.name, duration_ms)
+                logger.debug("Pipeline complete: no token savings [%s]", timing_parts)
 
-            # Record diff if enabled
+            # Build diff artifact if enabled
+            diff_artifact = None
             if generate_diff:
-                transform_diffs.append(
-                    TransformDiff(
-                        transform_name=transform.name,
-                        tokens_before=tokens_before_transform,
-                        tokens_after=tokens_after_transform,
-                        tokens_saved=tokens_before_transform - tokens_after_transform,
-                        details=", ".join(result.transforms_applied)
-                        if result.transforms_applied
-                        else "",
-                        duration_ms=duration_ms,
-                    )
+                diff_artifact = DiffArtifact(
+                    request_id=kwargs.get("request_id", ""),
+                    original_tokens=tokens_before,
+                    optimized_tokens=tokens_after,
+                    total_tokens_saved=tokens_before - tokens_after,
+                    transforms=transform_diffs,
                 )
 
-        # Single final token count — the only full recount in the pipeline.
-        # Earlier per-transform counts come from each transform's own result.
-        t_final_count = time.perf_counter()
-        tokens_after = tokenizer.count_messages(current_messages)
-        all_timing["_final_token_count"] = (time.perf_counter() - t_final_count) * 1000
+            # Detect waste signals in original messages (only when significant compression)
+            waste_signals: WasteSignals | None = None
+            if tokens_before > tokens_after and (tokens_before - tokens_after) > 100:
+                try:
+                    from ..parser import parse_messages
 
-        pipeline_ms = (time.perf_counter() - pipeline_start) * 1000
-        all_timing["pipeline_total"] = pipeline_ms
+                    _, _, waste_signals = parse_messages(messages, tokenizer)
+                    if waste_signals.total() == 0:
+                        waste_signals = None
+                except Exception:
+                    pass
 
-        # Log pipeline summary
-        total_saved = tokens_before - tokens_after
-        timing_parts = " ".join(f"{k}={v:.0f}ms" for k, v in all_timing.items())
-        if total_saved > 0:
-            logger.info(
-                "Pipeline complete: %d -> %d tokens (saved %d, %.1f%% reduction) [%s]",
-                tokens_before,
-                tokens_after,
-                total_saved,
-                (total_saved / tokens_before * 100) if tokens_before > 0 else 0,
-                timing_parts,
-            )
-        else:
-            logger.debug("Pipeline complete: no token savings [%s]", timing_parts)
+            if pipeline_span is not None and pipeline_span.is_recording():
+                pipeline_span.set_attribute("headroom.tokens.after", tokens_after)
+                pipeline_span.set_attribute("headroom.tokens.saved", total_saved)
+                pipeline_span.set_attribute("headroom.duration_ms", pipeline_ms)
+                pipeline_span.set_attribute("headroom.transforms_applied", len(all_transforms))
+                pipeline_span.set_attribute("headroom.warnings", len(all_warnings))
 
-        # Build diff artifact if enabled
-        diff_artifact = None
-        if generate_diff:
-            diff_artifact = DiffArtifact(
-                request_id=kwargs.get("request_id", ""),
-                original_tokens=tokens_before,
-                optimized_tokens=tokens_after,
-                total_tokens_saved=tokens_before - tokens_after,
-                transforms=transform_diffs,
-            )
-
-        # Detect waste signals in original messages (only when significant compression)
-        waste_signals: WasteSignals | None = None
-        if tokens_before > tokens_after and (tokens_before - tokens_after) > 100:
-            try:
-                from ..parser import parse_messages
-
-                _, _, waste_signals = parse_messages(messages, tokenizer)
-                if waste_signals.total() == 0:
-                    waste_signals = None
-            except Exception:
-                pass
+            if record_metrics:
+                get_otel_metrics().record_pipeline_run(
+                    model=model,
+                    provider=provider_name,
+                    tokens_before=tokens_before,
+                    tokens_after=tokens_after,
+                    duration_ms=pipeline_ms,
+                    timing=all_timing,
+                    transforms_applied=all_transforms,
+                    waste_signals=waste_signals.to_dict() if waste_signals is not None else None,
+                )
 
         return TransformResult(
             messages=current_messages,
@@ -350,7 +433,7 @@ class TransformPipeline:
             TransformResult with simulated changes.
         """
         # apply() already works on a copy, so this is safe
-        return self.apply(messages, model, **kwargs)
+        return self.apply(messages, model, record_metrics=False, **kwargs)
 
 
 def create_pipeline(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "litellm==1.82.3",            # Model registry, pricing, and provider support
     "click>=8.1.0",               # CLI framework
     "rich>=13.0.0",               # Rich terminal output
+    "opentelemetry-api>=1.24.0",  # Safe no-op OTEL API for instrumentation
 ]
 
 [project.optional-dependencies]
@@ -101,6 +102,11 @@ image = [
 # Report generation
 reports = [
     "jinja2>=3.0.0",
+]
+# OpenTelemetry metrics export
+otel = [
+    "opentelemetry-sdk>=1.24.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.24.0",
 ]
 # any-llm multi-provider backend (requires Python 3.11+)
 anyllm = [
@@ -173,6 +179,8 @@ dev = [
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",
     "httpx[http2]>=0.24.0",
+    "opentelemetry-sdk>=1.24.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.24.0",
     "ollama>=0.4.0",
     "langchain-ollama>=0.2.0",
     "hnswlib>=0.8.0",
@@ -182,7 +190,7 @@ dev = [
 ]
 # All optional dependencies (everything you need)
 all = [
-    "headroom-ai[proxy,code,ml,memory,relevance,image,reports,evals,voice,html,benchmark,mcp]",
+    "headroom-ai[proxy,code,ml,memory,relevance,image,reports,otel,evals,voice,html,benchmark,mcp]",
 ]
 
 [project.scripts]

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -1,0 +1,200 @@
+"""Tests for OTEL-backed operational observability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from headroom.observability import HeadroomOtelMetrics, reset_otel_metrics, set_otel_metrics
+from headroom.proxy.prometheus_metrics import PrometheusMetrics
+from headroom.transforms.pipeline import TransformPipeline
+
+
+def _collect_metrics(reader: InMemoryMetricReader) -> dict[str, Any]:
+    data = reader.get_metrics_data()
+    collected: dict[str, Any] = {}
+
+    for resource_metric in data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                collected[metric.name] = metric
+
+    return collected
+
+
+def _find_point(metric: Any, **expected_attributes: Any) -> Any:
+    for point in metric.data.data_points:
+        if all(point.attributes.get(key) == value for key, value in expected_attributes.items()):
+            return point
+    raise AssertionError(f"No datapoint matched attributes: {expected_attributes}")
+
+
+def test_headroom_otel_metrics_records_proxy_and_pipeline_metrics() -> None:
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    otel_metrics = HeadroomOtelMetrics(meter_provider=provider)
+
+    otel_metrics.record_proxy_request(
+        provider="anthropic",
+        model="claude-opus-4-6",
+        input_tokens=120,
+        output_tokens=30,
+        tokens_saved=45,
+        latency_ms=18.5,
+        cached=True,
+        overhead_ms=4.0,
+        ttfb_ms=12.0,
+        cache_read_tokens=25,
+        cache_write_tokens=35,
+        cache_write_5m_tokens=10,
+        cache_write_1h_tokens=25,
+        uncached_input_tokens=60,
+    )
+    otel_metrics.record_proxy_cache_bust(tokens_lost=7)
+    otel_metrics.record_pipeline_run(
+        model="claude-opus-4-6",
+        provider="anthropic",
+        tokens_before=120,
+        tokens_after=75,
+        duration_ms=6.5,
+        timing={"_deep_copy": 0.2, "router": 3.5, "pipeline_total": 6.5},
+        transforms_applied=["router:smart_crusher:0.35"],
+        waste_signals={"json_bloat": 12},
+    )
+
+    metrics = _collect_metrics(reader)
+
+    requests = metrics["headroom.proxy.requests"]
+    request_point = _find_point(
+        requests,
+        provider="anthropic",
+        model="claude-opus-4-6",
+        cached=True,
+    )
+    assert request_point.value == 1
+
+    latency = metrics["headroom.proxy.request.duration"]
+    latency_point = _find_point(
+        latency,
+        provider="anthropic",
+        model="claude-opus-4-6",
+        cached=True,
+    )
+    assert latency_point.count == 1
+    assert latency_point.sum == pytest.approx(0.0185)
+
+    ttl_tokens = metrics["headroom.proxy.cache.write_ttl_tokens"]
+    five_minute_ttl = _find_point(
+        ttl_tokens,
+        provider="anthropic",
+        model="claude-opus-4-6",
+        ttl="5m",
+    )
+    assert five_minute_ttl.value == 10
+
+    compression_runs = metrics["headroom.compression.runs"]
+    compression_point = _find_point(
+        compression_runs,
+        provider="anthropic",
+        model="claude-opus-4-6",
+    )
+    assert compression_point.value == 1
+
+    stage_duration = metrics["headroom.compression.stage.duration"]
+    router_stage = _find_point(
+        stage_duration,
+        provider="anthropic",
+        model="claude-opus-4-6",
+        stage="router",
+    )
+    assert router_stage.count == 1
+    assert router_stage.sum == pytest.approx(0.0035)
+
+    assert len(stage_duration.data.data_points) == 1
+
+    waste_tokens = metrics["headroom.compression.waste.tokens"]
+    waste_point = _find_point(
+        waste_tokens,
+        provider="anthropic",
+        model="claude-opus-4-6",
+        signal="json_bloat",
+    )
+    assert waste_point.value == 12
+
+
+@dataclass
+class _SpyMetrics:
+    pipeline_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def record_pipeline_run(self, **kwargs: Any) -> None:
+        self.pipeline_calls.append(kwargs)
+
+
+@dataclass
+class _SpyProxyMetrics:
+    failed_calls: list[dict[str, Any]] = field(default_factory=list)
+    rate_limited_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def record_proxy_failed(self, **kwargs: Any) -> None:
+        self.failed_calls.append(kwargs)
+
+    def record_proxy_rate_limited(self, **kwargs: Any) -> None:
+        self.rate_limited_calls.append(kwargs)
+
+
+def test_transform_pipeline_simulate_skips_metric_recording() -> None:
+    spy = _SpyMetrics()
+    set_otel_metrics(spy)  # type: ignore[arg-type]
+
+    try:
+        pipeline = TransformPipeline(transforms=[])
+        messages = [{"role": "user", "content": "hello world"}]
+
+        pipeline.apply(messages, model="gpt-4o", model_limit=1024)
+        assert len(spy.pipeline_calls) == 1
+
+        pipeline.simulate(messages, model="gpt-4o", model_limit=1024)
+        assert len(spy.pipeline_calls) == 1
+    finally:
+        reset_otel_metrics()
+
+
+def test_proxy_failure_and_rate_limit_metrics_include_provider_labels() -> None:
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    otel_metrics = HeadroomOtelMetrics(meter_provider=provider)
+
+    otel_metrics.record_proxy_failed(provider="openai")
+    otel_metrics.record_proxy_rate_limited(provider="anthropic", model="claude-sonnet")
+
+    metrics = _collect_metrics(reader)
+
+    failed_point = _find_point(metrics["headroom.proxy.requests.failed"], provider="openai")
+    assert failed_point.value == 1
+
+    rate_limited_point = _find_point(
+        metrics["headroom.proxy.requests.rate_limited"],
+        provider="anthropic",
+        model="claude-sonnet",
+    )
+    assert rate_limited_point.value == 1
+
+
+@pytest.mark.asyncio
+async def test_prometheus_metrics_reads_late_configured_otel_metrics() -> None:
+    spy = _SpyProxyMetrics()
+    metrics = PrometheusMetrics()
+    set_otel_metrics(spy)  # type: ignore[arg-type]
+
+    try:
+        await metrics.record_failed(provider="openai")
+        await metrics.record_rate_limited(provider="anthropic", model="claude-sonnet")
+
+        assert spy.failed_calls == [{"provider": "openai", "model": None}]
+        assert spy.rate_limited_calls == [{"provider": "anthropic", "model": "claude-sonnet"}]
+    finally:
+        reset_otel_metrics()

--- a/tests/test_observability_tracing.py
+++ b/tests/test_observability_tracing.py
@@ -1,0 +1,71 @@
+"""Tests for Langfuse/OTEL tracing helpers."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from headroom.observability import (
+    HeadroomTracer,
+    LangfuseTracingConfig,
+    get_langfuse_tracing_status,
+    reset_headroom_tracing,
+    set_headroom_tracer,
+)
+from headroom.transforms.pipeline import TransformPipeline
+
+
+def test_langfuse_tracing_config_builds_trace_endpoint() -> None:
+    config = LangfuseTracingConfig(
+        enabled=True,
+        public_key="pk-lf-test",
+        secret_key="sk-lf-test",
+        base_url="https://cloud.langfuse.com",
+        service_name="headroom-proxy",
+    )
+
+    assert config.endpoint == "https://cloud.langfuse.com/api/public/otel/v1/traces"
+    assert config.headers["x-langfuse-ingestion-version"] == "4"
+    assert config.headers["Authorization"].startswith("Basic ")
+    assert "sk-lf-test" not in repr(config)
+
+
+def test_transform_pipeline_emits_trace_spans() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "headroom-test"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_headroom_tracer(HeadroomTracer(tracer_provider=provider))
+
+    try:
+        pipeline = TransformPipeline(transforms=[])
+        messages = [{"role": "user", "content": "hello world"}]
+        pipeline.apply(messages, model="gpt-4o", model_limit=1024)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "headroom.compression.pipeline"
+        assert span.attributes["headroom.model"] == "gpt-4o"
+        assert span.attributes["headroom.tokens.before"] >= 1
+        assert span.attributes["headroom.tokens.after"] >= 1
+    finally:
+        reset_headroom_tracing()
+
+
+def test_langfuse_tracing_status_defaults_to_unconfigured() -> None:
+    reset_headroom_tracing()
+    status = get_langfuse_tracing_status()
+    assert status["configured"] is False
+    assert status["enabled"] is False
+
+
+def test_langfuse_tracing_requires_explicit_enable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+
+    config = LangfuseTracingConfig.from_env(default_service_name="headroom-proxy")
+
+    assert config.enabled is False

--- a/tests/test_openai_codex_routing.py
+++ b/tests/test_openai_codex_routing.py
@@ -114,6 +114,10 @@ class _DummyTokenizer:
 
 
 class _ResponseStub:
+    status_code = 200
+    headers = {"content-type": "application/json", "content-length": "42"}
+    content = b'{"id":"resp_123","output":[{"type":"message"}]}'
+
     def json(self):
         return {"usage": {"input_tokens": 2, "output_tokens": 1}}
 
@@ -182,7 +186,7 @@ def test_handle_openai_responses_routes_chatgpt_auth_to_backend_api(monkeypatch)
 
     monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
 
-    anyio.run(handler.handle_openai_responses, request)
+    response = anyio.run(handler.handle_openai_responses, request)
 
     assert handler.captured_request is not None
     method, url, headers, body = handler.captured_request
@@ -190,6 +194,7 @@ def test_handle_openai_responses_routes_chatgpt_auth_to_backend_api(monkeypatch)
     assert url == "https://chatgpt.com/backend-api/codex/responses"
     assert headers["ChatGPT-Account-ID"] == "acct-from-jwt"
     assert body["input"] == "hello"
+    assert response.status_code == 200
 
 
 class _DummyWebSocket:

--- a/tests/test_proxy_cache_ttl_metrics.py
+++ b/tests/test_proxy_cache_ttl_metrics.py
@@ -6,6 +6,7 @@ import asyncio
 
 import pytest
 
+from headroom.observability import reset_headroom_tracing, reset_otel_metrics
 from headroom.proxy.cost import CostTracker, build_prefix_cache_stats
 from headroom.proxy.prometheus_metrics import PrometheusMetrics
 
@@ -78,6 +79,40 @@ def test_prefix_cache_stats_include_observed_ttl_mix() -> None:
     assert stats["totals"]["observed_ttl_buckets"]["1h"]["tokens"] == 45
 
 
+def test_prometheus_metrics_export_includes_extended_fields() -> None:
+    metrics = PrometheusMetrics()
+
+    asyncio.run(
+        metrics.record_request(
+            provider="anthropic",
+            model="claude-opus-4-6",
+            input_tokens=100,
+            output_tokens=20,
+            tokens_saved=5,
+            latency_ms=12.5,
+            overhead_ms=3.0,
+            ttfb_ms=9.0,
+            pipeline_timing={"router": 4.5},
+            waste_signals={"json_bloat": 7},
+            cache_read_tokens=40,
+            cache_write_tokens=60,
+            cache_write_5m_tokens=10,
+            cache_write_1h_tokens=50,
+            uncached_input_tokens=20,
+        )
+    )
+    asyncio.run(metrics.record_cache_bust(11))
+
+    exported = asyncio.run(metrics.export())
+
+    assert "headroom_latency_ms_count 1" in exported
+    assert 'headroom_transform_timing_ms_sum{transform="router"} 4.5' in exported
+    assert 'headroom_waste_signal_tokens_total{signal="json_bloat"} 7' in exported
+    assert 'headroom_cache_write_ttl_tokens_total{provider="anthropic",ttl="5m"} 10' in exported
+    assert 'headroom_provider_cache_hit_requests_total{provider="anthropic"} 1' in exported
+    assert "headroom_cache_bust_tokens_lost_total 11" in exported
+
+
 def test_streaming_parser_extracts_anthropic_ttl_bucket_usage() -> None:
     from headroom.proxy.server import HeadroomProxy, ProxyConfig
 
@@ -145,3 +180,73 @@ def test_stats_endpoint_reports_observed_ttl_buckets() -> None:
     assert anthropic["observed_ttl_buckets"]["5m"]["tokens"] == 20
     assert anthropic["observed_ttl_buckets"]["1h"]["tokens"] == 50
     assert prefix_cache["totals"]["observed_ttl_mix"]["active_buckets"] == ["5m", "1h"]
+
+
+def test_stats_endpoint_reports_otel_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from headroom.proxy.server import ProxyConfig, create_app
+
+    reset_otel_metrics()
+    monkeypatch.setenv("HEADROOM_OTEL_METRICS_ENABLED", "1")
+    monkeypatch.setenv("HEADROOM_OTEL_METRICS_EXPORTER", "console")
+
+    app = create_app(
+        ProxyConfig(
+            optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+            ccr_inject_tool=False,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/stats")
+
+    assert response.status_code == 200
+    otel = response.json()["otel"]
+    assert otel["configured"] is True
+    assert otel["enabled"] is True
+    assert otel["service_name"] == "headroom-proxy"
+    assert otel["exporter"] == "console"
+
+
+def test_stats_endpoint_reports_langfuse_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from headroom.proxy.server import ProxyConfig, create_app
+
+    reset_headroom_tracing()
+    monkeypatch.setenv("HEADROOM_LANGFUSE_ENABLED", "1")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "https://cloud.langfuse.com")
+
+    app = create_app(
+        ProxyConfig(
+            optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+            ccr_inject_tool=False,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/stats")
+
+    assert response.status_code == 200
+    langfuse = response.json()["langfuse"]
+    assert langfuse["configured"] is True
+    assert langfuse["enabled"] is True
+    assert langfuse["service_name"] == "headroom-proxy"
+    assert langfuse["endpoint"] == "https://cloud.langfuse.com/api/public/otel/v1/traces"


### PR DESCRIPTION
## Summary
- add a shared observability layer for OTEL metrics and Langfuse OTLP tracing
- instrument the shared compression pipeline and thread proxy metrics through the new facade
- expand /metrics, expose OTEL/Langfuse status in /stats, and document the operational telemetry split

## Validation
- ruff check .
- ruff format --check .
- mypy headroom\\observability\\metrics.py headroom\\observability\\tracing.py headroom\\transforms\\pipeline.py headroom\\proxy\\prometheus_metrics.py headroom\\compress.py --ignore-missing-imports
- pytest tests/test_observability_metrics.py tests/test_observability_tracing.py tests/test_proxy_cache_ttl_metrics.py -v --tb=short
- python -m build
- python -m twine check dist/*

## Notes
- Full-repo pytest -v --tb=short still shows pre-existing Windows/integration failures outside this branch (storage path handling, memory temp-db cleanup, Ollama integration, and a few existing learn/image tests).

## Linked issue
- Fixes #124
