### PR TITLE
chore: bump openclaw plugin version #162

### DIFF
--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-openclaw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Headroom context compression plugin for OpenClaw — 70-90% token savings with zero LLM calls",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Description

Bumps the openclaw plugin version so openclaw properly allows updating.

Fixes #162