### PR TITLE
ci: group dependabot minor/patch updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: weekly
     commit-message:
       prefix: "docker"
+    groups:
+      docker-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions version updates
   - package-ecosystem: github-actions
@@ -15,6 +20,11 @@ updates:
       interval: weekly
     commit-message:
       prefix: "ci"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Python dependency updates (pip)
   - package-ecosystem: pip
@@ -25,3 +35,8 @@ updates:
       prefix: "deps"
     # Only open PRs for security updates to avoid noise
     open-pull-requests-limit: 5
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Adds a `groups:` block to each of the three dependabot ecosystems (docker, github-actions, pip) so minor/patch bumps land as one weekly PR per ecosystem instead of N individual PRs.
- Majors remain ungrouped — a grouped PR with a breaking major buried inside is too easy to merge without noticing.
- No schedule/interval changes; existing `commit-message.prefix` and `open-pull-requests-limit` preserved.

Closes #174

## Test plan
- [ ] YAML parses (syntax-check only — Dependabot itself runs on GitHub's side).
- [ ] Next Dependabot run produces at most one grouped PR per ecosystem for routine bumps; majors still arrive individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)