### PR TITLE
style: apply ruff format to server.py

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2532,7 +2532,8 @@ if __name__ == "__main__":
         "--openai-api-url", help=f"Custom OpenAI API URL (default: {HeadroomProxy.OPENAI_API_URL})"
     )
     parser.add_argument(
-        "--anthropic-api-url", help=f"Custom Anthropic API URL (default: {HeadroomProxy.ANTHROPIC_API_URL})"
+        "--anthropic-api-url",
+        help=f"Custom Anthropic API URL (default: {HeadroomProxy.ANTHROPIC_API_URL})",
     )
 
     # Backend (anthropic direct, bedrock, openrouter, anyllm, or litellm-<provider>)


### PR DESCRIPTION
## Summary
- Commit 997f364 (PR #186) landed `headroom/proxy/server.py` in a state that fails CI's `ruff format --check .` step, which is currently blocking every open PR (including #188).
- This PR just runs `ruff format` on that one file. No logic changes, no other files touched.

## Test plan
- [x] `ruff format --check .` passes locally.
- [x] `ruff check .` passes locally.
- [ ] CI lint job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)