### PR TITLE
fix: switch GitHub Pages from broken MkDocs to Fumadocs static export

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,28 +6,49 @@ on:
       - main
     paths:
       - 'docs/**'
-      - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          python-version: '3.11'
+          node-version: '20'
 
       - name: Install dependencies
-        run: pip install mkdocs-material
+        working-directory: docs
+        run: npm ci
 
-      - name: Build and deploy
-        run: mkdocs gh-deploy --force
+      - name: Build docs
+        working-directory: docs
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!docs/lib/
 lib64/
 parts/
 sdist/

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,7 +1,6 @@
 import { source } from '@/lib/source';
 import { createFromSource } from 'fumadocs-core/search/server';
 
-export const { GET } = createFromSource(source, {
-  // https://docs.orama.com/docs/orama-js/supported-languages
-  language: 'english',
-});
+export const revalidate = false;
+
+export const { staticGET: GET } = createFromSource(source);

--- a/docs/lib/cn.ts
+++ b/docs/lib/cn.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/** Merge Tailwind classes with deduplication. */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/docs/lib/layout.shared.ts
+++ b/docs/lib/layout.shared.ts
@@ -1,0 +1,19 @@
+import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+import { gitConfig } from './shared';
+
+/** Shared layout options used by both home and docs layouts. */
+export function baseOptions(): BaseLayoutProps {
+  return {
+    nav: {
+      title: 'Headroom',
+    },
+    githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
+    links: [
+      {
+        text: 'Docs',
+        url: '/docs',
+        active: 'nested-url',
+      },
+    ],
+  };
+}

--- a/docs/lib/shared.ts
+++ b/docs/lib/shared.ts
@@ -1,0 +1,8 @@
+export const gitConfig = {
+  user: 'chopratejas',
+  repo: 'headroom',
+  branch: 'main',
+};
+
+export const docsRoute = '/docs';
+export const docsContentRoute = '/llms.mdx/docs';

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -1,0 +1,32 @@
+import { docs } from 'collections/server';
+import { loader } from 'fumadocs-core/source';
+import type { InferPageType } from 'fumadocs-core/source';
+
+export const source = loader({
+  baseUrl: '/docs',
+  source: docs.toFumadocsSource(),
+});
+
+type Page = InferPageType<typeof source>;
+
+/** Build the OG image URL for a given page. */
+export function getPageImage(page: Page) {
+  return {
+    url: `/og/docs/${page.slugs.join('/')}/og.png`,
+    segments: [...page.slugs, 'og.png'],
+  };
+}
+
+/** Build the raw-markdown URL for a given page. */
+export function getPageMarkdownUrl(page: Page) {
+  return {
+    url: `/llms.mdx/docs/${page.slugs.join('/')}/content.md`,
+    segments: [...page.slugs, 'content.md'],
+  };
+}
+
+/** Return the full LLM-friendly text representation of a page. */
+export async function getLLMText(page: Page): Promise<string> {
+  const md = await page.data.getText('processed');
+  return `# ${page.data.title}\n\n${page.data.description ?? ''}\n\n${md}`;
+}

--- a/docs/lib/telemetry.ts
+++ b/docs/lib/telemetry.ts
@@ -1,0 +1,41 @@
+interface CommunityStats {
+  total_tokens_saved: number;
+  total_cost_saved: number;
+  total_requests: number;
+  unique_instances: number;
+}
+
+const FALLBACK: CommunityStats = {
+  total_tokens_saved: 60_000_000_000,
+  total_cost_saved: 1_200_000,
+  total_requests: 50_000_000,
+  unique_instances: 12_000,
+};
+
+/** Fetch community stats from Supabase, falling back to static data. */
+export async function fetchCommunityStats(): Promise<CommunityStats> {
+  const url = process.env.SUPABASE_STATS_URL;
+  if (!url) return FALLBACK;
+  try {
+    const res = await fetch(url, { next: { revalidate: 3600 } });
+    if (!res.ok) return FALLBACK;
+    return (await res.json()) as CommunityStats;
+  } catch {
+    return FALLBACK;
+  }
+}
+
+/** Format a number with K/M/B suffixes. */
+export function fmtNum(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toString();
+}
+
+/** Format a number as USD with K/M suffixes. */
+export function fmtUsd(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
+  return `$${n.toFixed(0)}`;
+}

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -4,6 +4,9 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
+  output: 'export',
+  basePath: '/headroom',
+  images: { unoptimized: true },
   reactStrictMode: true,
   serverExternalPackages: ['typescript', 'twoslash'],
 };


### PR DESCRIPTION
## Summary

- GitHub Pages docs site has been serving empty/404 pages since commit 911eb85 (Apr 12) which moved all MkDocs `.md` files to `wiki/` and replaced them with Fumadocs `.mdx` files, but never updated the CI workflow or created the missing `docs/lib/` source files.
- Switch `docs.yml` workflow from MkDocs (`mkdocs gh-deploy`) to Next.js static export (`next build` → `actions/deploy-pages`)
- Add `output: 'export'`, `basePath: '/headroom'`, `images: { unoptimized: true }` to `next.config.mjs`
- Use `staticGET` for search route (static export compatible)
- Create missing `docs/lib/` modules: `source.ts`, `layout.shared.ts`, `shared.ts`, `cn.ts`, `telemetry.ts`
- Add `!docs/lib/` exception to root `.gitignore` (`lib/` was ignored for Python build artifacts)

## Note

After merging, GitHub Pages source must be set to **"GitHub Actions"** in repo Settings → Pages (not "Deploy from branch") for the new workflow to deploy correctly.

Build verified locally — 108 static pages generated successfully.