### PR TITLE
fix: complete fork-friendly release publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 permissions:
   contents: read
@@ -55,6 +54,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Normalize image name
+        id: image-name
+        run: |
+          image_name="$(printf '%s' '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          printf 'image_name=%s\n' "$image_name" >> "$GITHUB_OUTPUT"
 
       - name: Determine image version
         id: version
@@ -96,7 +101,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
           tags: |
             type=ref,event=branch,enable=${{ inputs.enable_ref_tags }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=ref,event=pr,enable=${{ inputs.enable_ref_tags }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
@@ -133,7 +138,7 @@ jobs:
           echo "$BAKE_META" | jq -r '
             to_entries[].value."containerimage.digest" // empty
           ' | while read -r digest; do
-            image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${digest}"
+            image="${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}@${digest}"
             echo "Signing ${image}"
             cosign sign --yes "${image}"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,10 +243,19 @@ jobs:
     needs: [detect-version, build]
     if: github.event.inputs.dry_run != 'true' && vars.GH_PACKAGES_SKIP != 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Compute GitHub Packages scope
+        id: gh-scope
+        run: |
+          scope="$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          printf 'scope=%s\n' "$scope" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js for GitHub Package Registry
         uses: actions/setup-node@v4
@@ -260,22 +269,79 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Publish ${{ env.NPM_OPENCLAW_PACKAGE }} to GitHub Package Registry
-        id: gpr-publish
+      - name: Publish ${{ env.NPM_SDK_PACKAGE }} to GitHub Package Registry
+        id: gpr-sdk-publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PACKAGES_SCOPE: ${{ steps.gh-scope.outputs.scope }}
         run: |
-          cd plugins/openclaw
+          workdir="$(mktemp -d)"
+          assets_dir="$workdir/release-assets"
+          mkdir -p "$assets_dir"
+
+          cp -R sdk/typescript "$workdir/sdk"
+          cd "$workdir/sdk"
           npm install
           npm run build
           npm version ${{ needs.detect-version.outputs.npm_version }} --no-git-tag-version --allow-same-version
+          node <<'EOF'
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          pkg.name = `@${process.env.GITHUB_PACKAGES_SCOPE}/${pkg.name}`;
+          pkg.publishConfig = {
+            ...(pkg.publishConfig || {}),
+            registry: process.env.GITHUB_PACKAGES_REGISTRY_URL,
+          };
+          fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+          EOF
+          sdk_tarball="$(npm pack --pack-destination "$assets_dir" | tail -n 1)"
+          npm publish --access public --registry ${{ env.GITHUB_PACKAGES_REGISTRY_URL }}
+
+          printf 'sdk_tarball=%s\n' "$assets_dir/$sdk_tarball" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Publish ${{ env.NPM_OPENCLAW_PACKAGE }} to GitHub Package Registry
+        id: gpr-openclaw-publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PACKAGES_SCOPE: ${{ steps.gh-scope.outputs.scope }}
+          SDK_TARBALL: ${{ steps.gpr-sdk-publish.outputs.sdk_tarball }}
+        run: |
+          workdir="$(mktemp -d)"
+          cp -R plugins/openclaw "$workdir/openclaw"
+          cd "$workdir/openclaw"
+          node <<'EOF'
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          pkg.dependencies = pkg.dependencies || {};
+          delete pkg.dependencies["headroom-ai"];
+          fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+          EOF
+          npm install
+          npm install --no-save "$SDK_TARBALL"
+          npm run build
+          npm version ${{ needs.detect-version.outputs.npm_version }} --no-git-tag-version --allow-same-version
+          node <<'EOF'
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const scopedSdk = `@${process.env.GITHUB_PACKAGES_SCOPE}/headroom-ai`;
+          pkg.name = `@${process.env.GITHUB_PACKAGES_SCOPE}/${pkg.name}`;
+          pkg.dependencies = pkg.dependencies || {};
+          delete pkg.dependencies["headroom-ai"];
+          pkg.dependencies[scopedSdk] = `^${pkg.version}`;
+          pkg.publishConfig = {
+            ...(pkg.publishConfig || {}),
+            registry: process.env.GITHUB_PACKAGES_REGISTRY_URL,
+          };
+          fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+          EOF
           npm publish --access public --registry ${{ env.GITHUB_PACKAGES_REGISTRY_URL }}
         continue-on-error: true
 
       - name: GPR publish notice
-        if: steps.gpr-publish.outcome == 'failure'
+        if: steps.gpr-sdk-publish.outcome == 'failure' || steps.gpr-openclaw-publish.outcome == 'failure'
         run: |
-          echo "::notice::GitHub Package Registry publish failed. Check GITHUB_TOKEN permissions and registry configuration. Set GH_PACKAGES_SKIP=true to skip."
+          echo "::notice::One or more GitHub Package Registry publishes failed. Check GITHUB_TOKEN permissions and package scope/repository settings. Set GH_PACKAGES_SKIP=true to skip."
 
   publish-docker:
     needs: [detect-version]
@@ -290,8 +356,14 @@ jobs:
       enable_ref_tags: false
 
   create-release:
-    needs: [detect-version, build, publish-docker]
-    if: github.event.inputs.dry_run != 'true'
+    needs: [detect-version, build, publish-pypi, publish-npm, publish-github-packages, publish-docker]
+    if: >-
+      ${{
+        always() &&
+        github.event.inputs.dry_run != 'true' &&
+        needs.detect-version.result == 'success' &&
+        needs.build.result == 'success'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/content/docs/releases.mdx
+++ b/docs/content/docs/releases.mdx
@@ -16,8 +16,11 @@ The release workflow also calls `.github/workflows/docker.yml` as a reusable wor
 | `headroom-ai` | Python | PyPI | `PYPI_PACKAGE` |
 | `headroom-ai` | TypeScript SDK | npmjs.org | `NPM_SDK_PACKAGE` |
 | `headroom-openclaw` | TypeScript plugin | npmjs.org | `NPM_OPENCLAW_PACKAGE` |
-| `headroom-openclaw` | TypeScript plugin | GitHub Package Registry | — |
-| `ghcr.io/chopratejas/headroom` | Docker image | GitHub Container Registry | — |
+| `@{owner}/headroom-ai` | TypeScript SDK | GitHub Package Registry | — |
+| `@{owner}/headroom-openclaw` | TypeScript plugin | GitHub Package Registry | — |
+| `headroom-ai-{version}.tar.gz` / `headroom_ai-{version}-py3-none-any.whl` | Python release assets | GitHub Release (`{owner}/headroom`) | — |
+| `headroom-ai-{version}.tgz` / `headroom-openclaw-{version}.tgz` | Node release assets | GitHub Release (`{owner}/headroom`) | — |
+| `ghcr.io/{owner}/headroom` | Docker image | GitHub Container Registry | — |
 
 ## Version Strategy
 
@@ -94,13 +97,18 @@ Publishes both TypeScript packages to npmjs.org:
 - `plugins/openclaw/` as `headroom-openclaw`
 
 ### publish-github-packages
-Publishes `plugins/openclaw/` to GitHub Package Registry (`npm.pkg.github.com`).
+Publishes both Node packages to GitHub Package Registry (`npm.pkg.github.com`) using the current repository owner as the npm scope:
+- `sdk/typescript/` as `@{owner}/headroom-ai`
+- `plugins/openclaw/` as `@{owner}/headroom-openclaw`
+
+### GitHub release assets
+Uploads the built Python distributions and both npm tarballs to the GitHub Release created in the current repository. This is what makes fork-owned main-branch builds downloadable for local validation even when consumers are not pulling from PyPI or npmjs.org.
 
 ### publish-docker
 Calls the reusable Docker workflow to publish GHCR images with the same semantic version and synced package metadata as the rest of the release.
 
 ### create-release
-Creates or updates the GitHub Release, uploads the built Python distributions and npm tarballs as release assets, and publishes the generated changelog as release notes.
+Creates or updates the GitHub Release in the current repo, uploads the built Python distributions and npm tarballs as release assets, and publishes the generated changelog as release notes. The job still runs after the build succeeds even if one of the external registry publishes fails, so GitHub-hosted artifacts remain available on `main`.
 
 ## Configuration
 

--- a/tests/test_proxy_codex_route_aliases.py
+++ b/tests/test_proxy_codex_route_aliases.py
@@ -118,9 +118,7 @@ def test_codex_responses_subpath_aliases_delegate_to_passthrough():
         ),
     ],
 )
-def test_codex_responses_subpath_passthrough_derives_chatgpt_routing_from_jwt(
-    path, expected_url
-):
+def test_codex_responses_subpath_passthrough_derives_chatgpt_routing_from_jwt(path, expected_url):
     class FakeAsyncClient:
         def __init__(self) -> None:
             self.calls: list[tuple[str, str, dict[str, str]]] = []

--- a/tests/test_proxy_google_cloudcode_route_aliases.py
+++ b/tests/test_proxy_google_cloudcode_route_aliases.py
@@ -98,9 +98,7 @@ def test_cloudcode_route_uses_cloudcode_api_override(monkeypatch):
     monkeypatch.setattr(HeadroomProxy, "_stream_response", fake_stream)
 
     with TestClient(
-        create_app(
-            ProxyConfig(optimize=False, cloudcode_api_url="https://cloudcode-proxy.test/v1")
-        )
+        create_app(ProxyConfig(optimize=False, cloudcode_api_url="https://cloudcode-proxy.test/v1"))
     ) as client:
         response = client.post(
             "/v1/v1internal:streamGenerateContent",
@@ -150,9 +148,7 @@ def test_antigravity_route_does_not_cross_route_to_cloudcode_override(monkeypatc
     monkeypatch.setattr(HeadroomProxy, "_stream_response", fake_stream)
 
     with TestClient(
-        create_app(
-            ProxyConfig(optimize=False, cloudcode_api_url="https://cloudcode-proxy.test")
-        )
+        create_app(ProxyConfig(optimize=False, cloudcode_api_url="https://cloudcode-proxy.test"))
     ) as client:
         response = client.post(
             "/v1internal:streamGenerateContent",
@@ -175,9 +171,7 @@ def test_cloudcode_override_does_not_leak_between_app_instances(monkeypatch):
     monkeypatch.setattr(HeadroomProxy, "_stream_response", fake_stream)
 
     with TestClient(
-        create_app(
-            ProxyConfig(optimize=False, cloudcode_api_url="https://cloudcode-proxy.test")
-        )
+        create_app(ProxyConfig(optimize=False, cloudcode_api_url="https://cloudcode-proxy.test"))
     ) as client:
         first = client.post(
             "/v1internal:streamGenerateContent",
@@ -193,6 +187,12 @@ def test_cloudcode_override_does_not_leak_between_app_instances(monkeypatch):
         )
 
     assert first.status_code == 200
-    assert first.json()["url"] == "https://cloudcode-proxy.test/v1internal:streamGenerateContent?alt=sse"
+    assert (
+        first.json()["url"]
+        == "https://cloudcode-proxy.test/v1internal:streamGenerateContent?alt=sse"
+    )
     assert second.status_code == 200
-    assert second.json()["url"] == "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse"
+    assert (
+        second.json()["url"]
+        == "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse"
+    )

--- a/tests/test_proxy_streaming_ratelimit_headers.py
+++ b/tests/test_proxy_streaming_ratelimit_headers.py
@@ -220,9 +220,7 @@ class TestStreamingRatelimitHeaderForwarding:
                 "content-length": "42",
             }
         )
-        mock_response.aread = AsyncMock(
-            return_value=b'{"error":{"message":"capacity exhausted"}}'
-        )
+        mock_response.aread = AsyncMock(return_value=b'{"error":{"message":"capacity exhausted"}}')
         mock_response.aclose = AsyncMock()
 
         mock_request = MagicMock()

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1,0 +1,34 @@
+"""Workflow regression tests for release publishing behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_docker_workflow_normalizes_repository_name_for_signing() -> None:
+    content = (ROOT / ".github" / "workflows" / "docker.yml").read_text(encoding="utf-8")
+
+    assert "id: image-name" in content
+    assert "tr '[:upper:]' '[:lower:]'" in content
+    assert "steps.image-name.outputs.image_name" in content
+
+
+def test_release_workflow_publishes_both_node_packages_to_github_packages() -> None:
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert "Publish ${{ env.NPM_SDK_PACKAGE }} to GitHub Package Registry" in content
+    assert "Publish ${{ env.NPM_OPENCLAW_PACKAGE }} to GitHub Package Registry" in content
+    assert "pkg.name = `@${process.env.GITHUB_PACKAGES_SCOPE}/${pkg.name}`;" in content
+
+
+def test_create_release_runs_after_successful_build_even_if_other_publishes_fail() -> None:
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert (
+        "needs: [detect-version, build, publish-pypi, publish-npm, publish-github-packages, publish-docker]"
+        in content
+    )
+    assert "always()" in content
+    assert "needs.build.result == 'success'" in content


### PR DESCRIPTION
## Summary
- fix Docker release signing for fork-owned repositories by normalizing the GHCR image name before metadata/signing
- publish both Node packages to GitHub Packages under the current repository owner scope and keep GitHub Release assets available even when external publishes fail
- document the fork-friendly main-branch release behavior and add workflow regression coverage

## Validation
- uv run --extra dev pytest tests/test_release_version.py scripts/tests/test_version_sync.py tests/test_release_workflows.py tests/test_pr208_changes.py -q
- actionlint over .github/workflows/*.yml in the isolated worktree