### PR TITLE
Fix OpenClaw GitHub Packages build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,7 @@ jobs:
           npm install
           npm run build
           npm version ${{ needs.detect-version.outputs.npm_version }} --no-git-tag-version --allow-same-version
+          unscoped_sdk_tarball="$(npm pack --pack-destination "$assets_dir" | tail -n 1)"
           node <<'EOF'
           const fs = require("fs");
           const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
@@ -295,9 +296,9 @@ jobs:
           fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
           EOF
           sdk_tarball="$(npm pack --pack-destination "$assets_dir" | tail -n 1)"
-          npm publish --access public --registry ${{ env.GITHUB_PACKAGES_REGISTRY_URL }}
-
+          printf 'unscoped_sdk_tarball=%s\n' "$assets_dir/$unscoped_sdk_tarball" >> "$GITHUB_OUTPUT"
           printf 'sdk_tarball=%s\n' "$assets_dir/$sdk_tarball" >> "$GITHUB_OUTPUT"
+          npm publish --access public --registry ${{ env.GITHUB_PACKAGES_REGISTRY_URL }}
         continue-on-error: true
 
       - name: Publish ${{ env.NPM_OPENCLAW_PACKAGE }} to GitHub Package Registry
@@ -305,7 +306,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PACKAGES_SCOPE: ${{ steps.gh-scope.outputs.scope }}
-          SDK_TARBALL: ${{ steps.gpr-sdk-publish.outputs.sdk_tarball }}
+          SDK_TARBALL: ${{ steps.gpr-sdk-publish.outputs.unscoped_sdk_tarball }}
         run: |
           workdir="$(mktemp -d)"
           cp -R plugins/openclaw "$workdir/openclaw"

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -21,6 +21,10 @@ def test_release_workflow_publishes_both_node_packages_to_github_packages() -> N
     assert "Publish ${{ env.NPM_SDK_PACKAGE }} to GitHub Package Registry" in content
     assert "Publish ${{ env.NPM_OPENCLAW_PACKAGE }} to GitHub Package Registry" in content
     assert "pkg.name = `@${process.env.GITHUB_PACKAGES_SCOPE}/${pkg.name}`;" in content
+    assert (
+        'unscoped_sdk_tarball="$(npm pack --pack-destination "$assets_dir" | tail -n 1)"' in content
+    )
+    assert "SDK_TARBALL: ${{ steps.gpr-sdk-publish.outputs.unscoped_sdk_tarball }}" in content
 
 
 def test_create_release_runs_after_successful_build_even_if_other_publishes_fail() -> None:


### PR DESCRIPTION
## Summary
- keep an unscoped SDK tarball from the GitHub Packages SDK publish job for local OpenClaw builds
- use that unscoped tarball so the OpenClaw source import of `headroom-ai` resolves before publishing package metadata is rewritten to scoped GitHub Packages dependencies
- add a release workflow regression assertion for the unscoped tarball handoff

## Tests
- `python -m pytest tests\test_release_workflows.py`
- `npm run build` in `plugins/openclaw`