### PR TITLE
fix: skip commitlint for PR merge commits

### DIFF
--- a/.github/act/push-merge-pr.json
+++ b/.github/act/push-merge-pr.json
@@ -1,0 +1,11 @@
+{
+  "ref": "refs/heads/main",
+  "head_commit": {
+    "message": "Merge pull request #217 from JerrettDavis/fix/openclaw-local-node-publish\n\nFix OpenClaw GPR package build"
+  },
+  "commits": [
+    {
+      "message": "Merge pull request #217 from JerrettDavis/fix/openclaw-local-node-publish\n\nFix OpenClaw GPR package build"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
           path: dist/
 
   commitlint:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'Merge pull request ')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -36,3 +36,10 @@ def test_create_release_runs_after_successful_build_even_if_other_publishes_fail
     )
     assert "always()" in content
     assert "needs.build.result == 'success'" in content
+
+
+def test_ci_commitlint_skips_default_github_merge_commits() -> None:
+    content = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "github.event_name != 'push'" in content
+    assert "!startsWith(github.event.head_commit.message, 'Merge pull request ')" in content


### PR DESCRIPTION
## Summary
- skip commitlint only for default GitHub PR merge commits pushed to main
- keep commitlint active for pull requests and normal push commits
- add an act push fixture for the merge-commit case and a workflow regression assertion

## Tests
- `python -m pytest tests\test_release_workflows.py`
- `act push -W .github/workflows/ci.yml -j commitlint -e .github/act/push-feat.json --rm --bind`
- `act push -W .github/workflows/ci.yml -j commitlint -e .github/act/push-merge-pr.json --rm --bind`