### PR TITLE
fix: support GitHub Copilot OAuth sessions

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -36,6 +36,9 @@ if sys.platform == "win32" and hasattr(sys.stdout, "buffer"):
 
 import click
 
+from headroom.copilot_auth import DEFAULT_API_URL as COPILOT_API_URL
+from headroom.copilot_auth import has_oauth_auth, resolve_client_bearer_token
+
 from .main import main
 
 
@@ -85,6 +88,7 @@ def _start_proxy(
     backend: str | None = None,
     anyllm_provider: str | None = None,
     region: str | None = None,
+    openai_api_url: str | None = None,
 ) -> subprocess.Popen:
     """Start Headroom proxy as a background subprocess.
 
@@ -123,6 +127,9 @@ def _start_proxy(
     _region = region or os.environ.get("HEADROOM_REGION")
     if _region:
         cmd.extend(["--region", _region])
+
+    if openai_api_url:
+        cmd.extend(["--openai-api-url", openai_api_url])
 
     log_path = _get_log_path()
     log_file = open(log_path, "a")  # noqa: SIM115
@@ -694,6 +701,26 @@ def _copilot_model_configured(copilot_args: tuple[str, ...], env: dict[str, str]
     return False
 
 
+def _should_use_copilot_oauth(
+    *,
+    backend: str | None,
+    provider_type: str,
+    env: dict[str, str],
+) -> bool:
+    """Prefer existing Copilot auth when the requested routing supports it."""
+
+    if env.get("COPILOT_PROVIDER_API_KEY") or env.get("COPILOT_PROVIDER_BEARER_TOKEN"):
+        return False
+    if provider_type == "anthropic":
+        return False
+
+    effective_backend = backend or os.environ.get("HEADROOM_BACKEND")
+    if effective_backend not in (None, "", "anthropic"):
+        return False
+
+    return has_oauth_auth()
+
+
 def _ensure_proxy(
     port: int,
     no_proxy: bool,
@@ -705,6 +732,7 @@ def _ensure_proxy(
     backend: str | None = None,
     anyllm_provider: str | None = None,
     region: str | None = None,
+    openai_api_url: str | None = None,
 ) -> subprocess.Popen | None:
     """Start or verify proxy. Returns process handle if we started it."""
     if not no_proxy:
@@ -780,6 +808,7 @@ def _ensure_proxy(
                 backend=backend,
                 anyllm_provider=anyllm_provider,
                 region=region,
+                openai_api_url=openai_api_url,
             )
             click.echo(f"  Proxy ready on http://127.0.0.1:{port}")
             return proc
@@ -847,6 +876,7 @@ def _launch_tool(
     backend: str | None = None,
     anyllm_provider: str | None = None,
     region: str | None = None,
+    openai_api_url: str | None = None,
 ) -> None:
     """Common logic: start proxy, launch tool, clean up."""
     proxy_holder: list[subprocess.Popen | None] = [None]
@@ -872,6 +902,7 @@ def _launch_tool(
             backend=backend,
             anyllm_provider=anyllm_provider,
             region=region,
+            openai_api_url=openai_api_url,
         )
 
         if code_graph:
@@ -1412,58 +1443,81 @@ def copilot(
             _inject_rtk_instructions(copilot_instructions, verbose=verbose)
 
     env = os.environ.copy()
-    env["COPILOT_PROVIDER_TYPE"] = effective_provider_type
     env.pop("COPILOT_PROVIDER_WIRE_API", None)
+    openai_api_url: str | None = None
 
-    # Copilot BYOK requires COPILOT_PROVIDER_API_KEY — propagate from the
-    # user's existing provider key so they don't have to set it twice.
-    # Note: `headroom wrap copilot` uses Copilot's BYOK mode, which bypasses
-    # GitHub's Copilot API and talks directly to the model provider through
-    # the Headroom proxy. This requires the provider's own API key — a GitHub
-    # Copilot subscription alone is not sufficient for BYOK mode.
-    if not env.get("COPILOT_PROVIDER_API_KEY"):
-        if effective_provider_type == "anthropic":
-            _key = env.get("ANTHROPIC_API_KEY", "")
-        else:
-            _key = env.get("OPENAI_API_KEY", "")
-        if _key:
-            env["COPILOT_PROVIDER_API_KEY"] = _key
+    if _should_use_copilot_oauth(
+        backend=effective_backend,
+        provider_type=provider_type,
+        env=env,
+    ):
+        client_bearer = resolve_client_bearer_token()
+        if not client_bearer:
+            raise click.ClickException(
+                "GitHub Copilot auth was detected but no reusable bearer token could be resolved."
+            )
 
-    env_vars_display: list[str]
-    if effective_provider_type == "anthropic":
-        env["COPILOT_PROVIDER_BASE_URL"] = f"http://127.0.0.1:{port}"
-        env_vars_display = [
-            "COPILOT_PROVIDER_TYPE=anthropic",
-            f"COPILOT_PROVIDER_BASE_URL=http://127.0.0.1:{port}",
-        ]
-    else:
-        effective_wire_api = wire_api or "completions"
+        env["COPILOT_PROVIDER_TYPE"] = "openai"
         env["COPILOT_PROVIDER_BASE_URL"] = f"http://127.0.0.1:{port}/v1"
-        env["COPILOT_PROVIDER_WIRE_API"] = effective_wire_api
+        env["COPILOT_PROVIDER_WIRE_API"] = wire_api or "completions"
+        env["COPILOT_PROVIDER_BEARER_TOKEN"] = client_bearer
+        env.pop("COPILOT_PROVIDER_API_KEY", None)
         env_vars_display = [
             "COPILOT_PROVIDER_TYPE=openai",
             f"COPILOT_PROVIDER_BASE_URL=http://127.0.0.1:{port}/v1",
-            f"COPILOT_PROVIDER_WIRE_API={effective_wire_api}",
+            f"COPILOT_PROVIDER_WIRE_API={env['COPILOT_PROVIDER_WIRE_API']}",
+            "COPILOT_AUTH_MODE=github-oauth",
         ]
+        openai_api_url = COPILOT_API_URL
+    else:
+        env["COPILOT_PROVIDER_TYPE"] = effective_provider_type
 
-    if not env.get("COPILOT_PROVIDER_API_KEY"):
-        src = "ANTHROPIC_API_KEY" if effective_provider_type == "anthropic" else "OPENAI_API_KEY"
-        click.echo(
-            f"\n  Error: Copilot BYOK mode requires a provider API key.\n"
-            f"  `headroom wrap copilot` uses Copilot's BYOK mode, which bypasses GitHub's\n"
-            f"  Copilot API and routes requests directly to the model provider through the\n"
-            f"  Headroom proxy. A GitHub Copilot subscription alone is not sufficient.\n\n"
-            f"  Set one of:\n"
-            f"    export {src}=sk-...          # recommended\n"
-            f"    export COPILOT_PROVIDER_API_KEY=sk-...  # also works\n"
-        )
-        raise SystemExit(1)
+        # Copilot BYOK requires COPILOT_PROVIDER_API_KEY — propagate from the
+        # user's existing provider key so they don't have to set it twice.
+        if not env.get("COPILOT_PROVIDER_API_KEY"):
+            if effective_provider_type == "anthropic":
+                _key = env.get("ANTHROPIC_API_KEY", "")
+            else:
+                _key = env.get("OPENAI_API_KEY", "")
+            if _key:
+                env["COPILOT_PROVIDER_API_KEY"] = _key
 
-    if not _copilot_model_configured(copilot_args, env):
-        click.echo(
-            "  Note: Copilot BYOK requires a model. Pass `--model <name>` "
-            "or set `COPILOT_MODEL` / `COPILOT_PROVIDER_MODEL_ID`."
-        )
+        if effective_provider_type == "anthropic":
+            env["COPILOT_PROVIDER_BASE_URL"] = f"http://127.0.0.1:{port}"
+            env_vars_display = [
+                "COPILOT_PROVIDER_TYPE=anthropic",
+                f"COPILOT_PROVIDER_BASE_URL=http://127.0.0.1:{port}",
+            ]
+        else:
+            effective_wire_api = wire_api or "completions"
+            env["COPILOT_PROVIDER_BASE_URL"] = f"http://127.0.0.1:{port}/v1"
+            env["COPILOT_PROVIDER_WIRE_API"] = effective_wire_api
+            env_vars_display = [
+                "COPILOT_PROVIDER_TYPE=openai",
+                f"COPILOT_PROVIDER_BASE_URL=http://127.0.0.1:{port}/v1",
+                f"COPILOT_PROVIDER_WIRE_API={effective_wire_api}",
+            ]
+
+        if not env.get("COPILOT_PROVIDER_API_KEY"):
+            src = (
+                "ANTHROPIC_API_KEY" if effective_provider_type == "anthropic" else "OPENAI_API_KEY"
+            )
+            click.echo(
+                f"\n  Error: Copilot BYOK mode requires a provider API key.\n"
+                f"  No reusable GitHub Copilot OAuth session was found, so Headroom fell back to\n"
+                f"  Copilot's BYOK provider mode. That mode bypasses GitHub's Copilot API and\n"
+                f"  routes requests directly to the model provider through the Headroom proxy.\n\n"
+                f"  Set one of:\n"
+                f"    export {src}=sk-...          # recommended\n"
+                f"    export COPILOT_PROVIDER_API_KEY=sk-...  # also works\n"
+            )
+            raise SystemExit(1)
+
+        if not _copilot_model_configured(copilot_args, env):
+            click.echo(
+                "  Note: Copilot BYOK requires a model. Pass `--model <name>` "
+                "or set `COPILOT_MODEL` / `COPILOT_PROVIDER_MODEL_ID`."
+            )
 
     _launch_tool(
         binary=copilot_bin,
@@ -1479,6 +1533,7 @@ def copilot(
         backend=backend,
         anyllm_provider=anyllm_provider,
         region=region,
+        openai_api_url=openai_api_url,
     )
 
 

--- a/headroom/copilot_auth.py
+++ b/headroom/copilot_auth.py
@@ -1,0 +1,306 @@
+"""GitHub Copilot OAuth discovery and API-token exchange helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_URL = "https://api.githubcopilot.com"
+DEFAULT_TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
+DEFAULT_GITHUB_HOST = "github.com"
+_TOKEN_EXPIRY_BUFFER_S = 60
+_DEFAULT_EDITOR_VERSION = "vscode/1.104.1"
+_DEFAULT_USER_AGENT = "GitHubCopilotChat/0.1"
+
+_API_TOKEN_ENV_VARS = (
+    "GITHUB_COPILOT_API_TOKEN",
+    "COPILOT_PROVIDER_BEARER_TOKEN",
+)
+_OAUTH_TOKEN_ENV_VARS = (
+    "GITHUB_COPILOT_GITHUB_TOKEN",
+    "GITHUB_COPILOT_TOKEN",
+    "GITHUB_TOKEN",
+    "COPILOT_GITHUB_TOKEN",
+)
+_OAUTH_TOKEN_KEYS = (
+    "oauth_token",
+    "oauthToken",
+    "token",
+    "access_token",
+    "accessToken",
+)
+_EXPIRY_KEYS = ("expires_at", "expiresAt", "expiry", "expires")
+
+
+@dataclass(frozen=True)
+class CopilotAPIToken:
+    """Short-lived API token exchanged from a GitHub OAuth token."""
+
+    token: str
+    expires_at: float
+    api_url: str = DEFAULT_API_URL
+    refresh_in: int | None = None
+    sku: str | None = None
+
+    @property
+    def is_valid(self) -> bool:
+        return time.time() < (self.expires_at - _TOKEN_EXPIRY_BUFFER_S)
+
+
+def _github_host() -> str:
+    return (os.environ.get("GITHUB_COPILOT_HOST") or DEFAULT_GITHUB_HOST).strip().lower()
+
+
+def _token_exchange_url() -> str:
+    return os.environ.get("GITHUB_COPILOT_TOKEN_EXCHANGE_URL", DEFAULT_TOKEN_EXCHANGE_URL).strip()
+
+
+def _resolve_token_file_paths() -> list[Path]:
+    override = os.environ.get("GITHUB_COPILOT_TOKEN_FILE", "").strip()
+    if override:
+        return [Path(override).expanduser()]
+
+    paths: list[Path] = []
+    local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+    if local_appdata:
+        base = Path(local_appdata) / "github-copilot"
+        paths.extend([base / "apps.json", base / "hosts.json"])
+
+    config_base = Path.home() / ".config" / "github-copilot"
+    paths.extend([config_base / "apps.json", config_base / "hosts.json"])
+    return paths
+
+
+def _parse_expiry(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+
+    if isinstance(value, int | float):
+        number = float(value)
+        if number > 10_000_000_000:
+            return number / 1000.0
+        return number
+
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.isdigit():
+            return _parse_expiry(int(raw))
+        try:
+            normalized = raw.replace("Z", "+00:00")
+            return datetime.fromisoformat(normalized).timestamp()
+        except ValueError:
+            return None
+
+    return None
+
+
+def _entry_expired(entry: dict[str, Any]) -> bool:
+    for key in _EXPIRY_KEYS:
+        expiry = _parse_expiry(entry.get(key))
+        if expiry is None:
+            continue
+        return time.time() >= (expiry - _TOKEN_EXPIRY_BUFFER_S)
+    return False
+
+
+def _extract_oauth_token(entry: dict[str, Any]) -> str | None:
+    if _entry_expired(entry):
+        return None
+
+    for key in _OAUTH_TOKEN_KEYS:
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    for value in entry.values():
+        if isinstance(value, dict):
+            nested = _extract_oauth_token(value)
+            if nested:
+                return nested
+
+    return None
+
+
+def _iter_file_entries(payload: Any) -> list[tuple[str, dict[str, Any]]]:
+    entries: list[tuple[str, dict[str, Any]]] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if isinstance(value, dict):
+                entries.append((str(key), value))
+    elif isinstance(payload, list):
+        for idx, value in enumerate(payload):
+            if isinstance(value, dict):
+                key = str(value.get("host") or value.get("githubHost") or idx)
+                entries.append((key, value))
+    return entries
+
+
+def read_cached_oauth_token() -> str | None:
+    """Return a GitHub OAuth token for Copilot, if one is available."""
+
+    for env_var in _OAUTH_TOKEN_ENV_VARS:
+        token = os.environ.get(env_var, "").strip()
+        if token:
+            return token
+
+    host = _github_host()
+    for path in _resolve_token_file_paths():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            continue
+        except Exception as exc:
+            logger.debug("Unable to read Copilot credentials file %s: %s", path, exc)
+            continue
+
+        for key, entry in _iter_file_entries(payload):
+            if host not in key.lower():
+                continue
+            cached_token = _extract_oauth_token(entry)
+            if cached_token:
+                return cached_token
+
+    return None
+
+
+def resolve_client_bearer_token() -> str | None:
+    """Return a bearer token suitable for satisfying Copilot provider auth checks."""
+
+    for env_var in _API_TOKEN_ENV_VARS:
+        token = os.environ.get(env_var, "").strip()
+        if token:
+            return token
+    return read_cached_oauth_token()
+
+
+def has_oauth_auth() -> bool:
+    """Return True when existing Copilot auth can be reused."""
+
+    return resolve_client_bearer_token() is not None
+
+
+def is_copilot_api_url(url: str | None) -> bool:
+    """Return True when the upstream URL points at GitHub Copilot."""
+
+    if not url:
+        return False
+    parsed = urlparse(url)
+    host = parsed.netloc.lower() or parsed.path.lower()
+    return "githubcopilot.com" in host
+
+
+class CopilotTokenProvider:
+    """Resolve and cache short-lived Copilot API tokens."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._cached: CopilotAPIToken | None = None
+
+    async def get_api_token(self) -> CopilotAPIToken:
+        explicit_api_token = os.environ.get("GITHUB_COPILOT_API_TOKEN", "").strip()
+        if explicit_api_token:
+            return CopilotAPIToken(
+                token=explicit_api_token,
+                expires_at=time.time() + 3600,
+                api_url=os.environ.get("GITHUB_COPILOT_API_URL", DEFAULT_API_URL).strip()
+                or DEFAULT_API_URL,
+            )
+
+        cached = self._cached
+        if cached is not None and cached.is_valid:
+            return cached
+
+        async with self._lock:
+            cached = self._cached
+            if cached is not None and cached.is_valid:
+                return cached
+
+            oauth_token = read_cached_oauth_token()
+            if not oauth_token:
+                raise RuntimeError("No GitHub Copilot OAuth token is available.")
+
+            exchanged = await self._exchange_token(oauth_token)
+            self._cached = exchanged
+            return exchanged
+
+    async def _exchange_token(self, oauth_token: str) -> CopilotAPIToken:
+        headers = {
+            "Authorization": f"token {oauth_token}",
+            "Accept": "application/json",
+            "Editor-Version": os.environ.get(
+                "GITHUB_COPILOT_EDITOR_VERSION", _DEFAULT_EDITOR_VERSION
+            ),
+            "User-Agent": _DEFAULT_USER_AGENT,
+        }
+        payload = await asyncio.to_thread(self._exchange_token_sync, headers)
+        token = str(payload.get("token") or "").strip()
+        if not token:
+            raise RuntimeError("Copilot token exchange returned an empty token.")
+
+        expires_at = _parse_expiry(payload.get("expires_at")) or (time.time() + 1800)
+        raw_endpoints = payload.get("endpoints")
+        endpoints: dict[str, Any] = raw_endpoints if isinstance(raw_endpoints, dict) else {}
+        api_url = str(endpoints.get("api") or DEFAULT_API_URL).strip() or DEFAULT_API_URL
+        refresh_in = payload.get("refresh_in")
+        sku = payload.get("sku")
+        return CopilotAPIToken(
+            token=token,
+            expires_at=expires_at,
+            api_url=api_url,
+            refresh_in=int(refresh_in) if isinstance(refresh_in, int | float) else None,
+            sku=str(sku) if isinstance(sku, str) and sku.strip() else None,
+        )
+
+    @staticmethod
+    def _exchange_token_sync(headers: dict[str, str]) -> dict[str, Any]:
+        request = urllib_request.Request(_token_exchange_url(), headers=headers, method="GET")
+        try:
+            with urllib_request.urlopen(request, timeout=10.0) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                return payload if isinstance(payload, dict) else {}
+        except urllib_error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Copilot token exchange failed with HTTP {exc.code}: {body}"
+            ) from exc
+
+
+_provider: CopilotTokenProvider | None = None
+
+
+def get_copilot_token_provider() -> CopilotTokenProvider:
+    """Return the shared Copilot token provider."""
+
+    global _provider
+    if _provider is None:
+        _provider = CopilotTokenProvider()
+    return _provider
+
+
+async def apply_copilot_api_auth(headers: dict[str, str], *, url: str) -> dict[str, str]:
+    """Replace Authorization with a fresh Copilot API token when targeting Copilot."""
+
+    resolved = dict(headers)
+    if not is_copilot_api_url(url):
+        return resolved
+
+    token = await get_copilot_token_provider().get_api_token()
+    for key in list(resolved):
+        if key.lower() == "authorization":
+            resolved.pop(key)
+    resolved["Authorization"] = f"Bearer {token.token}"
+    return resolved

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 
 import httpx
 
+from headroom.copilot_auth import apply_copilot_api_auth
+
 logger = logging.getLogger("headroom.proxy")
 
 
@@ -584,6 +586,7 @@ class OpenAIHandlerMixin:
                     prefix_tracker=openai_prefix_tracker,
                 )
             else:
+                headers = await apply_copilot_api_auth(headers, url=url)
                 response = await self._retry_request("POST", url, headers, body)
 
                 # Full diagnostic dump on upstream errors (OpenAI handler)
@@ -1093,6 +1096,7 @@ class OpenAIHandlerMixin:
                     memory_user_id=memory_user_id,
                 )
             else:
+                headers = await apply_copilot_api_auth(headers, url=url)
                 response = await self._retry_request("POST", url, headers, body)
                 total_latency = (time.time() - start_time) * 1000
 
@@ -1368,6 +1372,8 @@ class OpenAIHandlerMixin:
                     f"[{request_id}] WS: no Authorization header from client and "
                     f"OPENAI_API_KEY not set — upstream will likely reject"
                 )
+
+        upstream_headers = await apply_copilot_api_auth(upstream_headers, url=upstream_url)
 
         # Ensure the required beta header is present — OpenAI returns 500 without it.
         # Codex sends `responses_websockets=2026-02-06`; only inject if missing entirely.
@@ -2463,6 +2469,7 @@ class OpenAIHandlerMixin:
 
         body = await request.body()
 
+        headers = await apply_copilot_api_auth(headers, url=url)
         response = await self.http_client.request(  # type: ignore[union-attr]
             method=request.method,
             url=url,

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 import httpx
 
+from headroom.copilot_auth import apply_copilot_api_auth
+
 logger = logging.getLogger("headroom.proxy")
 
 
@@ -579,6 +581,7 @@ class StreamingMixin:
 
         from headroom.proxy.helpers import MAX_SSE_BUFFER_SIZE
 
+        headers = await apply_copilot_api_auth(headers, url=url)
         start_time = time.time()
 
         # Mutable state for the generator to update

--- a/tests/test_cli/test_wrap_copilot.py
+++ b/tests/test_cli/test_wrap_copilot.py
@@ -2,19 +2,36 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
+import types
 from pathlib import Path
 from unittest.mock import patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
-from headroom.cli import wrap as wrap_cli
-from headroom.cli.main import main
+from headroom.copilot_auth import DEFAULT_API_URL
+
+fake_main_module = types.ModuleType("headroom.cli.main")
+fake_main_module.main = click.Group()
+sys.modules["headroom.cli.main"] = fake_main_module
+sys.modules.pop("headroom.cli", None)
+sys.modules.pop("headroom.cli.wrap", None)
+
+wrap_cli = importlib.import_module("headroom.cli.wrap")
+main = fake_main_module.main
 
 
 @pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def no_running_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wrap_cli, "_check_proxy", lambda _port: False)
 
 
 def test_wrap_copilot_auto_anthropic_injects_instructions(
@@ -118,6 +135,57 @@ def test_wrap_copilot_auto_detects_running_proxy_backend(
     assert env["COPILOT_PROVIDER_TYPE"] == "openai"
     assert env["COPILOT_PROVIDER_BASE_URL"] == "http://127.0.0.1:8787/v1"
     assert env["COPILOT_PROVIDER_WIRE_API"] == "completions"
+
+
+def test_wrap_copilot_prefers_existing_oauth_session(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-dummy")
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value="copilot"):
+        with patch("headroom.cli.wrap.resolve_client_bearer_token", return_value="gho-existing"):
+            with patch("headroom.cli.wrap.has_oauth_auth", return_value=True):
+                with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
+                    result = runner.invoke(
+                        main,
+                        ["wrap", "copilot", "--no-rtk", "--", "--model", "claude-sonnet-4.6"],
+                    )
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["COPILOT_PROVIDER_TYPE"] == "openai"
+    assert env["COPILOT_PROVIDER_BASE_URL"] == "http://127.0.0.1:8787/v1"
+    assert env["COPILOT_PROVIDER_WIRE_API"] == "completions"
+    assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "gho-existing"
+    assert "COPILOT_PROVIDER_API_KEY" not in env
+    assert captured["openai_api_url"] == DEFAULT_API_URL
+
+
+def test_wrap_copilot_translated_backend_still_requires_byok(
+    runner: CliRunner,
+) -> None:
+    with patch("headroom.cli.wrap.shutil.which", return_value="copilot"):
+        with patch("headroom.cli.wrap.has_oauth_auth", return_value=True):
+            result = runner.invoke(
+                main,
+                [
+                    "wrap",
+                    "copilot",
+                    "--backend",
+                    "anyllm",
+                    "--",
+                    "--model",
+                    "gpt-4o",
+                ],
+            )
+
+    assert result.exit_code == 1
+    assert "Copilot BYOK mode requires a provider API key" in result.output
 
 
 def test_wrap_copilot_rejects_wire_api_for_anthropic_provider(runner: CliRunner) -> None:

--- a/tests/test_copilot_auth.py
+++ b/tests/test_copilot_auth.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from headroom import copilot_auth
+
+
+def test_read_cached_oauth_token_prefers_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN", "gho-env")
+    assert copilot_auth.read_cached_oauth_token() == "gho-env"
+
+
+def test_read_cached_oauth_token_reads_hosts_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    hosts = tmp_path / "hosts.json"
+    hosts.write_text(
+        json.dumps(
+            {
+                "github.com": {
+                    "oauth_token": "gho-file",
+                    "expires_at": "2999-01-01T00:00:00Z",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN_FILE", str(hosts))
+
+    assert copilot_auth.read_cached_oauth_token() == "gho-file"
+
+
+def test_read_cached_oauth_token_skips_expired_entries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    hosts = tmp_path / "hosts.json"
+    hosts.write_text(
+        json.dumps({"github.com": {"oauthToken": "gho-old", "expiresAt": 1}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN_FILE", str(hosts))
+
+    assert copilot_auth.read_cached_oauth_token() is None
+
+
+def test_resolve_client_bearer_token_prefers_api_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-api")
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN", "gho-oauth")
+
+    assert copilot_auth.resolve_client_bearer_token() == "copilot-api"
+
+
+def test_is_copilot_api_url_matches_expected_hosts() -> None:
+    assert copilot_auth.is_copilot_api_url("https://api.githubcopilot.com/v1/chat/completions")
+    assert copilot_auth.is_copilot_api_url("wss://api.githubcopilot.com/v1/responses")
+    assert not copilot_auth.is_copilot_api_url("https://api.openai.com/v1/chat/completions")
+
+
+@pytest.mark.asyncio
+async def test_apply_copilot_api_auth_replaces_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_api_token() -> copilot_auth.CopilotAPIToken:
+        return copilot_auth.CopilotAPIToken(
+            token="copilot-session",
+            expires_at=time.time() + 3600,
+            api_url=copilot_auth.DEFAULT_API_URL,
+        )
+
+    monkeypatch.setattr(
+        copilot_auth.get_copilot_token_provider(),
+        "get_api_token",
+        fake_get_api_token,
+    )
+
+    headers = await copilot_auth.apply_copilot_api_auth(
+        {"authorization": "Bearer downstream-token"},
+        url="https://api.githubcopilot.com/v1/chat/completions",
+    )
+
+    assert headers["Authorization"] == "Bearer copilot-session"
+    assert "authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_token_provider_exchanges_and_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN", "gho-oauth")
+
+    provider = copilot_auth.CopilotTokenProvider()
+    calls = {"count": 0}
+
+    def fake_exchange(headers: dict[str, str]) -> dict[str, object]:
+        calls["count"] += 1
+        return {
+            "token": "copilot-api",
+            "expires_at": int(time.time()) + 3600,
+            "refresh_in": 1200,
+            "endpoints": {"api": "https://api.githubcopilot.com"},
+            "sku": "copilot_individual",
+        }
+
+    monkeypatch.setattr(provider, "_exchange_token_sync", staticmethod(fake_exchange))
+
+    first = await provider.get_api_token()
+    second = await provider.get_api_token()
+
+    assert first.token == "copilot-api"
+    assert second.token == "copilot-api"
+    assert calls["count"] == 1

--- a/tests/test_proxy_copilot_auth_hooks.py
+++ b/tests/test_proxy_copilot_auth_hooks.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_handler_module(module_name: str, relative_path: str):
+    proxy_pkg = types.ModuleType("headroom.proxy")
+    proxy_pkg.__path__ = [str(ROOT / "headroom" / "proxy")]
+    sys.modules["headroom.proxy"] = proxy_pkg
+
+    handlers_pkg = types.ModuleType("headroom.proxy.handlers")
+    handlers_pkg.__path__ = [str(ROOT / "headroom" / "proxy" / "handlers")]
+    sys.modules["headroom.proxy.handlers"] = handlers_pkg
+
+    httpx_mod = types.ModuleType("httpx")
+    httpx_mod.ConnectError = type("ConnectError", (Exception,), {})
+    httpx_mod.ConnectTimeout = type("ConnectTimeout", (Exception,), {})
+    httpx_mod.PoolTimeout = type("PoolTimeout", (Exception,), {})
+    sys.modules["httpx"] = httpx_mod
+
+    responses_mod = types.ModuleType("fastapi.responses")
+
+    class Response:
+        def __init__(self, content=None, status_code: int = 200, headers=None, media_type=None):
+            self.content = content
+            self.status_code = status_code
+            self.headers = headers or {}
+            self.media_type = media_type
+
+    class StreamingResponse(Response):
+        pass
+
+    responses_mod.Response = Response
+    responses_mod.StreamingResponse = StreamingResponse
+    sys.modules["fastapi.responses"] = responses_mod
+
+    spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_openai_passthrough_applies_copilot_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    openai_mod = _load_handler_module(
+        "tests.headroom_proxy_handlers_openai",
+        "headroom/proxy/handlers/openai.py",
+    )
+
+    seen: dict[str, object] = {}
+
+    async def fake_apply(headers: dict[str, str], *, url: str) -> dict[str, str]:
+        seen["headers"] = dict(headers)
+        seen["url"] = url
+        return {"Authorization": "Bearer upstream-token"}
+
+    monkeypatch.setattr(openai_mod, "apply_copilot_api_auth", fake_apply)
+
+    class Dummy(openai_mod.OpenAIHandlerMixin):
+        def __init__(self) -> None:
+            self.metrics = SimpleNamespace(record_request=self._record_request)
+            self.http_client = SimpleNamespace(request=self._request)
+
+        async def _record_request(self, **kwargs) -> None:  # noqa: ANN003
+            return None
+
+        async def _request(self, **kwargs):  # noqa: ANN003
+            seen["request_kwargs"] = kwargs
+            return SimpleNamespace(headers={}, content=b"{}", status_code=200)
+
+    request = SimpleNamespace(
+        url=SimpleNamespace(path="/v1/models", query=""),
+        headers={
+            "authorization": "Bearer downstream",
+            "host": "localhost",
+            "accept-encoding": "gzip",
+        },
+        method="GET",
+        body=lambda: None,
+    )
+
+    async def body() -> bytes:
+        return b""
+
+    request.body = body
+
+    handler = Dummy()
+    response = await handler.handle_passthrough(
+        request,
+        "https://api.githubcopilot.com",
+        "models",
+        "openai",
+    )
+
+    assert seen["url"] == "https://api.githubcopilot.com/v1/models"
+    assert seen["request_kwargs"]["headers"] == {"Authorization": "Bearer upstream-token"}
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_applies_copilot_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    streaming_mod = _load_handler_module(
+        "tests.headroom_proxy_handlers_streaming",
+        "headroom/proxy/handlers/streaming.py",
+    )
+
+    seen: dict[str, object] = {}
+
+    async def fake_apply(headers: dict[str, str], *, url: str) -> dict[str, str]:
+        seen["headers"] = dict(headers)
+        seen["url"] = url
+        return {"Authorization": "Bearer upstream-token"}
+
+    monkeypatch.setattr(streaming_mod, "apply_copilot_api_auth", fake_apply)
+
+    class Dummy(streaming_mod.StreamingMixin):
+        def __init__(self) -> None:
+            self.memory_handler = None
+            self.config = SimpleNamespace(
+                retry_max_attempts=1,
+                retry_base_delay_ms=1,
+                retry_max_delay_ms=1,
+            )
+            self.http_client = SimpleNamespace(
+                build_request=self._build_request,
+                send=self._send,
+            )
+
+        def _build_request(self, method: str, url: str, json: dict, headers: dict):  # noqa: ANN003, A002
+            seen["request"] = {
+                "method": method,
+                "url": url,
+                "json": json,
+                "headers": headers,
+            }
+            return SimpleNamespace()
+
+        async def _send(self, request, stream: bool):  # noqa: ANN001, ANN003
+            return SimpleNamespace(headers={}, status_code=200)
+
+    handler = Dummy()
+    response = await handler._stream_response(
+        url="https://api.githubcopilot.com/v1/responses",
+        headers={"authorization": "Bearer downstream"},
+        body={"model": "gpt-4o"},
+        provider="openai",
+        model="gpt-4o",
+        request_id="req-test",
+        original_tokens=0,
+        optimized_tokens=0,
+        tokens_saved=0,
+        transforms_applied=[],
+        tags={},
+        optimization_latency=0.0,
+    )
+
+    assert seen["url"] == "https://api.githubcopilot.com/v1/responses"
+    assert seen["request"]["headers"] == {"Authorization": "Bearer upstream-token"}
+    assert response.status_code == 200


### PR DESCRIPTION
## Description

Add GitHub Copilot OAuth-aware routing for `headroom wrap copilot` so logged-in Copilot users can run through Headroom without supplying a separate provider API key. The wrapper now prefers existing Copilot auth when compatible, exchanges it for short-lived Copilot API tokens, and keeps explicit/transformed BYOK flows on the existing path.

Fixes #156

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added `headroom.copilot_auth` for Copilot OAuth discovery, token exchange, caching, and upstream auth normalization.
- Updated `headroom wrap copilot` to prefer existing Copilot auth in auto mode, while preserving explicit Copilot BYOK and translated backend behavior.
- Wired the OpenAI passthrough and streaming paths to replace downstream auth with fresh exchanged Copilot API tokens when targeting `api.githubcopilot.com`.
- Added focused tests for OAuth discovery/exchange, wrapper mode selection, passthrough auth rewriting, and streaming auth rewriting.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

## Test Output

```
python -m pytest tests\test_copilot_auth.py tests\test_cli\test_wrap_copilot.py tests\test_proxy_copilot_auth_hooks.py -q
18 passed in 0.30s

python -m ruff check headroom\copilot_auth.py headroom\cli\wrap.py headroom\proxy\handlers\openai.py headroom\proxy\handlers\streaming.py tests\test_copilot_auth.py tests\test_cli\test_wrap_copilot.py tests\test_proxy_copilot_auth_hooks.py
All checks passed!

mypy (via pre-commit)
Passed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

- Auto mode now prefers existing Copilot auth over ambient provider keys when the requested routing is compatible.
- Translated backends and explicit Copilot provider credentials stay on the existing BYOK path.
- The new focused tests cover each introduced auth seam directly.
