### PR TITLE
fix: unblock CI on main (cli submodule binding + test sys.modules hygiene)

### DIFF
--- a/headroom/cli/__init__.py
+++ b/headroom/cli/__init__.py
@@ -1,5 +1,33 @@
-"""Headroom CLI - Command-line interface for memory and proxy management."""
+"""Headroom CLI - Command-line interface for memory and proxy management.
 
+The subcommand submodules are imported eagerly below so they are bound as
+attributes of `headroom.cli`. Click registration happens via side effects in
+`main.py::_register_commands`, but that only binds them to the *main.py*
+module. Tests that do `patch("headroom.cli.<sub>.<attr>")` resolve the target
+by walking attributes on the package object, and that lookup fails when a
+prior test has popped `headroom.cli` from `sys.modules` and re-imported it
+through a path other than `main.py` (e.g. a test that replaces
+`sys.modules["headroom.cli.main"]` with a fake to isolate one subcommand).
+Doing `from . import ...` here means the submodule attribute binding
+survives that kind of sys.modules mutation.
+"""
+
+from . import (  # noqa: F401
+    evals,
+    init,
+    install,
+    learn,
+    mcp,
+    perf,
+    proxy,
+    tools,
+    wrap,
+)
 from .main import main
+
+try:
+    from . import memory  # noqa: F401
+except ImportError:
+    pass
 
 __all__ = ["main"]

--- a/tests/test_cli/test_wrap_copilot.py
+++ b/tests/test_cli/test_wrap_copilot.py
@@ -2,26 +2,15 @@
 
 from __future__ import annotations
 
-import importlib
-import sys
-import types
 from pathlib import Path
 from unittest.mock import patch
 
-import click
 import pytest
 from click.testing import CliRunner
 
+from headroom.cli import wrap as wrap_cli
+from headroom.cli.main import main
 from headroom.copilot_auth import DEFAULT_API_URL
-
-fake_main_module = types.ModuleType("headroom.cli.main")
-fake_main_module.main = click.Group()
-sys.modules["headroom.cli.main"] = fake_main_module
-sys.modules.pop("headroom.cli", None)
-sys.modules.pop("headroom.cli.wrap", None)
-
-wrap_cli = importlib.import_module("headroom.cli.wrap")
-main = fake_main_module.main
 
 
 @pytest.fixture

--- a/tests/test_proxy_copilot_auth_hooks.py
+++ b/tests/test_proxy_copilot_auth_hooks.py
@@ -11,20 +11,20 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def _load_handler_module(module_name: str, relative_path: str):
+def _load_handler_module(monkeypatch: pytest.MonkeyPatch, module_name: str, relative_path: str):
     proxy_pkg = types.ModuleType("headroom.proxy")
     proxy_pkg.__path__ = [str(ROOT / "headroom" / "proxy")]
-    sys.modules["headroom.proxy"] = proxy_pkg
+    monkeypatch.setitem(sys.modules, "headroom.proxy", proxy_pkg)
 
     handlers_pkg = types.ModuleType("headroom.proxy.handlers")
     handlers_pkg.__path__ = [str(ROOT / "headroom" / "proxy" / "handlers")]
-    sys.modules["headroom.proxy.handlers"] = handlers_pkg
+    monkeypatch.setitem(sys.modules, "headroom.proxy.handlers", handlers_pkg)
 
     httpx_mod = types.ModuleType("httpx")
     httpx_mod.ConnectError = type("ConnectError", (Exception,), {})
     httpx_mod.ConnectTimeout = type("ConnectTimeout", (Exception,), {})
     httpx_mod.PoolTimeout = type("PoolTimeout", (Exception,), {})
-    sys.modules["httpx"] = httpx_mod
+    monkeypatch.setitem(sys.modules, "httpx", httpx_mod)
 
     responses_mod = types.ModuleType("fastapi.responses")
 
@@ -40,12 +40,12 @@ def _load_handler_module(module_name: str, relative_path: str):
 
     responses_mod.Response = Response
     responses_mod.StreamingResponse = StreamingResponse
-    sys.modules["fastapi.responses"] = responses_mod
+    monkeypatch.setitem(sys.modules, "fastapi.responses", responses_mod)
 
     spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
+    monkeypatch.setitem(sys.modules, module_name, module)
     spec.loader.exec_module(module)
     return module
 
@@ -53,6 +53,7 @@ def _load_handler_module(module_name: str, relative_path: str):
 @pytest.mark.asyncio
 async def test_openai_passthrough_applies_copilot_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     openai_mod = _load_handler_module(
+        monkeypatch,
         "tests.headroom_proxy_handlers_openai",
         "headroom/proxy/handlers/openai.py",
     )
@@ -110,6 +111,7 @@ async def test_openai_passthrough_applies_copilot_auth(monkeypatch: pytest.Monke
 @pytest.mark.asyncio
 async def test_streaming_response_applies_copilot_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     streaming_mod = _load_handler_module(
+        monkeypatch,
         "tests.headroom_proxy_handlers_streaming",
         "headroom/proxy/handlers/streaming.py",
     )

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -14,6 +14,7 @@ from headroom.release_version import (
     compute_release_version,
     determine_bump_level,
     find_latest_release_tag,
+    get_canonical_version,
     list_release_commits,
     normalize_release_tag,
     parse_release_tag,
@@ -177,7 +178,7 @@ def test_release_version_script_runs_directly_without_importing_headroom_package
     assert output_path.read_text(encoding="utf-8").splitlines() == [
         "version=0.6.0",
         "npm_version=0.6.0",
-        "canonical=0.5.25",
+        f"canonical={get_canonical_version(ROOT)}",
         "height=0",
         "bump=manual",
         "previous_tag=",

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -53,6 +53,8 @@ def test_macos_native_wrapper_dependency_install_retries_pypi_downloads() -> Non
     content = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
     assert "python -m pip install --retries 10 --timeout 60 pytest" in content
+
+
 def test_ci_commitlint_skips_default_github_merge_commits() -> None:
     content = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Description

`main` CI has been red since #229 merged (2026-04-22 03:14 UTC). Every Python test matrix row (`test (3.10/3.11/3.12/3.13)`) failed — 55 failed / 17 errors / 3914 passed on py3.10. This PR resolves every root cause that is fixable without reverting #229.

Four independent pre-existing regressions were feeding the cascade; each is now addressed:

1. **`headroom.cli.*` submodules not bound as package attributes** — `tests/test_cli/test_wrap_copilot.py` (from #229) replaced `sys.modules["headroom.cli.main"]` with a fake `click.Group()` at module-import time and popped `headroom.cli`. When later tests did `from headroom.cli.main import main`, they got an empty group with no version option and no subcommands. Harden `headroom/cli/__init__.py` to eagerly bind submodules so the import chain is robust against sys.modules mutation, and rewrite `test_wrap_copilot.py` to import the real `main` directly (the fake-group indirection served no purpose).

2. **`ImportError: cannot import name 'JSONResponse' from 'fastapi.responses'` / `'ASGITransport' from 'httpx'`** — `tests/test_proxy_copilot_auth_hooks.py` (from #229) installed fake `httpx` / `fastapi.responses` / `headroom.proxy.*` modules into `sys.modules` from a helper that was called inside test functions, and never cleaned up. Any later test that imported `ASGITransport` or `JSONResponse` hit the leftover fakes. Switch the helper to `monkeypatch.setitem` so the fakes are scoped to the owning test.

3. **Hardcoded `canonical=0.5.25` in `test_release_version`** — the project version in `pyproject.toml` has since bumped to `0.9.1`, so the subprocess-output assertion fails on every run. Compute the expected value dynamically via `get_canonical_version(ROOT)` so the test tracks pyproject going forward.

4. **Drive-by format fix for `tests/test_release_workflows.py`** — `main` was failing `ruff format --check .` because of two missing blank lines between top-level functions (introduced in `8bf11d2`). Format check gates every other CI job, so this had to land before the substantive fixes could go green.

Fixes #234

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/__init__.py`: eagerly `from . import evals, init, install, learn, mcp, perf, proxy, tools, wrap` (with the optional `memory` import guarded by the same `try/except ImportError` pattern used by `main.py::_register_commands`). Docstring explains why.
- `tests/test_cli/test_wrap_copilot.py`: drop the `types.ModuleType(...)` / `sys.modules.pop(...)` / `importlib.import_module(...)` dance at module-import time. Use `from headroom.cli.main import main` and `from headroom.cli import wrap as wrap_cli` instead. No assertion changes; all 9 tests still pass.
- `tests/test_proxy_copilot_auth_hooks.py`: `_load_handler_module` now takes `monkeypatch: pytest.MonkeyPatch` and uses `monkeypatch.setitem(sys.modules, ...)` for all four fakes so pytest cleans them up after each test.
- `tests/test_release_version.py`: import `get_canonical_version`; replace the hardcoded `"canonical=0.5.25"` in the subprocess-output assertion with `f"canonical={get_canonical_version(ROOT)}"`.
- `tests/test_release_workflows.py`: `ruff format` (adds two blank lines between two top-level functions).

Public `headroom.cli` API is unchanged. No behavior changes to any module under `headroom/`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality _(N/A — test-hygiene regressions; the repaired tests themselves are the signal)_
- [x] Manual testing performed

**Before/after on a clean checkout of `main` at `57383395` vs this PR (both on local py3.12 / macOS):**

| Metric | main | This PR |
|---|---|---|
| `pytest tests/test_cli/` failures | 13 | 2 (local-only env PATH issue) |
| `pytest tests` failures | 50 + 17 errors | 3 (all local-only env issues) |
| `pytest tests` passed | 4074 | 4118 |

The 3 remaining local failures are all deterministic environment differences on my machine, not regressions:

- `tests/test_cli/test_mcp.py::TestMCPInstallCommand::test_install_creates_config` and `TestEndToEndFlow::test_full_lifecycle` — expect `get_headroom_command()` to return `["headroom", ...]` but my `$PATH` has no `headroom` binary so `shutil.which("headroom")` returns `None` and the function falls back to `[sys.executable, "-m", ...]`. On CI the package is pip-installed and `headroom` is on `PATH`, so these pass.
- `tests/test_install/test_native_installers.py::test_bash_native_installer_supports_persistent_docker_lifecycle` — `scripts/install.sh` exits 1 locally (pre-existing; unrelated to this PR; passes on CI where the installer runs in a proper environment).

## Test Output

```
$ .venv/bin/ruff check .
All checks passed!

$ .venv/bin/ruff format --check .
592 files already formatted

$ .venv/bin/mypy headroom
Success: no issues found in 303 source files

$ .venv/bin/pytest tests --tb=line
...
==== 3 failed, 4118 passed, 459 skipped in 132.02s (0:02:12) ====
# (3 remaining failures are local-env only, unrelated to this PR)

$ .venv/bin/pytest tests/test_release_version.py tests/test_cli/test_wrap_copilot.py tests/test_proxy_copilot_auth_hooks.py tests/test_proxy_openai_cache_stability.py tests/test_telemetry_warning.py tests/test_proxy_streaming_ratelimit_headers.py tests/test_proxy_passthrough_integration.py -p no:randomly
==================== 70 passed, 19 skipped in 12.71s ====================
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _(module docstring in `headroom/cli/__init__.py` explains the sys.modules interaction that motivates the eager imports)_
- [ ] I have made corresponding changes to the documentation _(N/A — internal package-init and test hygiene, no user-facing behavior change)_
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works _(N/A — repaired existing tests are the regression signal; adding a dedicated test for "package attribute survives sys.modules mutation" would reify the anti-pattern we just removed)_
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable _(N/A — internal fix, no user-facing behavior change)_

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

**Why not revert #229**: #229 brings real value (Copilot OAuth) and only its test hygiene was problematic. Two targeted test rewrites preserve its coverage and unblock CI.

**Why eager imports in `__init__.py` are safe**: `main.py::_register_commands` already imports all of the same submodules at module load. The eager imports in `__init__.py` hit Python's module cache after the first load — idempotent, no double side effects. Import order chosen so submodule imports land before `from .main import main` so the click group sees all subcommands registered exactly once.