### PR TITLE
fix(proxy): log streaming Anthropic requests so /transformations/feed populates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hourly/daily/weekly/monthly rollups. Responses now include a
   `history_summary` block describing stored versus returned points.
 
+### Fixed
+- **Streaming Anthropic requests are now visible to `/stats.recent_requests`
+  and `/transformations/feed`** — `_finalize_stream_response` did not call
+  `self.logger.log(...)`, so the entire streaming Anthropic code path (the
+  one Claude Code uses) silently bypassed the request logger. Only the
+  non-streaming Anthropic path and the Bedrock streaming path were logged.
+  As a consequence, `--log-messages` had no observable effect on the live
+  transformations feed for typical traffic. The streaming finalizer now
+  emits the same `RequestLog` shape the other paths do, including
+  `request_messages` when `log_full_messages` is enabled.
+
 ## [0.5.22] - 2026-04-11
 
 ### Added

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -451,6 +451,7 @@ class StreamingMixin:
         optimization_latency: float,
         stream_state: dict[str, Any],
         start_time: float,
+        tags: dict[str, str] | None = None,
         pipeline_timing: dict[str, float] | None = None,
         prefix_tracker: Any | None = None,
         original_messages: list[dict] | None = None,
@@ -545,6 +546,38 @@ class StreamingMixin:
                 cache_write_5m_tokens=cache_write_5m_tokens,
                 cache_write_1h_tokens=cache_write_1h_tokens,
                 uncached_input_tokens=uncached_input_tokens,
+            )
+
+        # Log the request to the in-memory request logger so it shows up in
+        # /stats `recent_requests` and `/transformations/feed`. Without this
+        # the streaming Anthropic path (which is what Claude Code uses) is
+        # invisible to both surfaces — only Bedrock streaming and the
+        # non-streaming Anthropic path were logged previously.
+        if getattr(self, "logger", None) is not None:
+            from headroom.proxy.models import RequestLog
+
+            self.logger.log(
+                RequestLog(
+                    request_id=request_id,
+                    timestamp=datetime.now().isoformat(),
+                    provider=provider,
+                    model=model,
+                    input_tokens_original=original_tokens,
+                    input_tokens_optimized=optimized_tokens,
+                    output_tokens=output_tokens,
+                    tokens_saved=tokens_saved,
+                    savings_percent=(tokens_saved / original_tokens * 100)
+                    if original_tokens > 0
+                    else 0,
+                    optimization_latency_ms=optimization_latency,
+                    total_latency_ms=total_latency,
+                    tags=tags or {},
+                    cache_hit=False,
+                    transforms_applied=transforms_applied,
+                    request_messages=body.get("messages")
+                    if getattr(self.config, "log_full_messages", False)
+                    else None,
+                )
             )
 
     async def _stream_response(
@@ -702,6 +735,7 @@ class StreamingMixin:
                 optimization_latency=optimization_latency,
                 stream_state=stream_state,
                 start_time=start_time,
+                tags=tags,
                 pipeline_timing=pipeline_timing,
                 prefix_tracker=prefix_tracker,
                 original_messages=original_messages,
@@ -875,6 +909,7 @@ class StreamingMixin:
                     optimization_latency=optimization_latency,
                     stream_state=stream_state,
                     start_time=start_time,
+                    tags=tags,
                     pipeline_timing=pipeline_timing,
                     prefix_tracker=prefix_tracker,
                     original_messages=original_messages,

--- a/tests/test_proxy_streaming_request_logger.py
+++ b/tests/test_proxy_streaming_request_logger.py
@@ -1,0 +1,174 @@
+"""Tests that the Anthropic streaming finalizer logs requests for the feed.
+
+Without this, the streaming Anthropic path (which is what Claude Code uses)
+silently bypassed the request logger, leaving `/stats.recent_requests` and
+`/transformations/feed` permanently empty even when `--log-messages` was set.
+The non-streaming Anthropic path and the Bedrock streaming path were the
+only ones that called `self.logger.log(...)`.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from headroom.proxy.request_logger import RequestLogger
+from headroom.proxy.server import HeadroomProxy
+
+
+def _build_proxy_with_real_logger(*, log_full_messages: bool) -> HeadroomProxy:
+    """Build a HeadroomProxy with mocks for everything except the request logger,
+    so we can assert what actually gets recorded."""
+    proxy = object.__new__(HeadroomProxy)
+    proxy.http_client = MagicMock(spec=httpx.AsyncClient)
+    proxy.metrics = MagicMock()
+    proxy.metrics.record_request = AsyncMock(return_value=None)
+    proxy.cost_tracker = MagicMock()
+    proxy.cost_tracker.record_tokens.return_value = None
+    proxy.memory_manager = None
+    proxy.memory_handler = None
+    proxy._config = MagicMock()
+    proxy._config.log_full_messages = log_full_messages
+    proxy._config.ccr_inject_tool = False
+    proxy.config = proxy._config
+    proxy.logger = RequestLogger(log_file=None, log_full_messages=log_full_messages)
+    return proxy
+
+
+def _stream_state(output_tokens: int = 42) -> dict:
+    return {
+        "output_tokens": output_tokens,
+        "total_bytes": 200,
+        "ttfb_ms": 35.0,
+        "input_tokens": 1000,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cache_creation_ephemeral_5m_input_tokens": 0,
+        "cache_creation_ephemeral_1h_input_tokens": 0,
+        "sse_buffer": "",
+    }
+
+
+@pytest.mark.asyncio
+async def test_finalize_stream_response_logs_request_for_feed():
+    proxy = _build_proxy_with_real_logger(log_full_messages=False)
+
+    await proxy._finalize_stream_response(
+        body={"messages": [{"role": "user", "content": "hi"}]},
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        request_id="req-stream-1",
+        original_tokens=1000,
+        optimized_tokens=600,
+        tokens_saved=400,
+        transforms_applied=["smart_crusher"],
+        optimization_latency=12.0,
+        stream_state=_stream_state(),
+        start_time=0.0,
+        tags={"stack": "wrap_claude"},
+    )
+
+    entries = proxy.logger.get_recent(10)
+    assert len(entries) == 1, "streaming finalizer must log exactly one entry per request"
+    entry = entries[0]
+    assert entry["request_id"] == "req-stream-1"
+    assert entry["provider"] == "anthropic"
+    assert entry["model"] == "claude-sonnet-4-6"
+    assert entry["input_tokens_original"] == 1000
+    assert entry["input_tokens_optimized"] == 600
+    assert entry["tokens_saved"] == 400
+    assert entry["savings_percent"] == pytest.approx(40.0)
+    assert entry["transforms_applied"] == ["smart_crusher"]
+    assert entry["tags"] == {"stack": "wrap_claude"}
+    assert entry["cache_hit"] is False
+
+
+@pytest.mark.asyncio
+async def test_finalize_stream_response_includes_messages_when_log_full_messages_enabled():
+    proxy = _build_proxy_with_real_logger(log_full_messages=True)
+    body = {"messages": [{"role": "user", "content": "hello"}]}
+
+    await proxy._finalize_stream_response(
+        body=body,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        request_id="req-stream-2",
+        original_tokens=10,
+        optimized_tokens=8,
+        tokens_saved=2,
+        transforms_applied=[],
+        optimization_latency=1.0,
+        stream_state=_stream_state(output_tokens=5),
+        start_time=0.0,
+    )
+
+    entries = proxy.logger.get_recent_with_messages(10)
+    assert len(entries) == 1
+    assert entries[0]["request_messages"] == body["messages"]
+
+
+@pytest.mark.asyncio
+async def test_finalize_stream_response_omits_messages_when_log_full_messages_disabled():
+    proxy = _build_proxy_with_real_logger(log_full_messages=False)
+
+    await proxy._finalize_stream_response(
+        body={"messages": [{"role": "user", "content": "hello"}]},
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        request_id="req-stream-3",
+        original_tokens=10,
+        optimized_tokens=8,
+        tokens_saved=2,
+        transforms_applied=[],
+        optimization_latency=1.0,
+        stream_state=_stream_state(output_tokens=5),
+        start_time=0.0,
+    )
+
+    entries = proxy.logger.get_recent_with_messages(10)
+    assert len(entries) == 1
+    assert entries[0]["request_messages"] is None
+
+
+@pytest.mark.asyncio
+async def test_finalize_stream_response_handles_zero_original_tokens():
+    proxy = _build_proxy_with_real_logger(log_full_messages=False)
+
+    await proxy._finalize_stream_response(
+        body={"messages": []},
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        request_id="req-stream-4",
+        original_tokens=0,
+        optimized_tokens=0,
+        tokens_saved=0,
+        transforms_applied=[],
+        optimization_latency=0.0,
+        stream_state=_stream_state(output_tokens=0),
+        start_time=0.0,
+    )
+
+    entries = proxy.logger.get_recent(10)
+    assert len(entries) == 1
+    assert entries[0]["savings_percent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_finalize_stream_response_no_op_when_logger_disabled():
+    proxy = _build_proxy_with_real_logger(log_full_messages=False)
+    proxy.logger = None  # `--no-log-requests` would put us here
+
+    # Should not raise.
+    await proxy._finalize_stream_response(
+        body={"messages": []},
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        request_id="req-stream-5",
+        original_tokens=10,
+        optimized_tokens=8,
+        tokens_saved=2,
+        transforms_applied=[],
+        optimization_latency=1.0,
+        stream_state=_stream_state(),
+        start_time=0.0,
+    )


### PR DESCRIPTION
## Description

`_finalize_stream_response` records metrics, cost, and prefix-cache stats but **never appends a `RequestLog` to `self.logger`**. Because the streaming Anthropic path is the one Claude Code (and most other Anthropic clients) use, the in-memory request log is permanently empty for typical traffic. As a downstream consequence, both `/stats.recent_requests` and `/transformations/feed` always return empty arrays — even when the proxy is started with `--log-messages`. Only the non-streaming Anthropic path (`handlers/anthropic.py:1167, 1599`) and the Bedrock streaming finalizer (`handlers/streaming.py:_stream_response_bedrock`) populate the logger.

This was discovered while wiring the live transformations feed into the Headroom desktop's Activity tab: the proxy showed 50+ streaming requests with millions of tokens compressed in `/stats.summary`, but `/transformations/feed?limit=50` returned `{"transformations":[],"log_full_messages":true}`. The `--log-messages` flag had no observable effect for streaming traffic.

This PR makes the streaming Anthropic finalizer emit the same `RequestLog` shape the other paths already do, plumbing `tags` through both `_finalize_stream_response` call sites in `_stream_response` and respecting `config.log_full_messages` for `request_messages`.

Fixes #(no issue)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `handlers/streaming.py`: `_finalize_stream_response` now constructs and emits a `RequestLog` matching the shape of the other handlers (provider, model, both token counts, savings %, transforms, latency, tags, optional `request_messages`).
- `handlers/streaming.py`: added an optional `tags: dict[str, str] | None = None` parameter to `_finalize_stream_response`, threaded through both call sites in `_stream_response` (success and pre-stream-error paths).
- `tests/test_proxy_streaming_request_logger.py`: new regression tests that drive `_finalize_stream_response` directly with a real `RequestLogger` and assert the deque populates correctly.
- `CHANGELOG.md`: entry under `[Unreleased] → Fixed` describing the user-visible impact.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed (verified live proxy populates `/transformations/feed` after the patch)

## Test Output

```
$ pytest tests/test_proxy_streaming_request_logger.py tests/test_proxy_streaming_ratelimit_headers.py tests/test_proxy/test_transformations_feed.py
============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
configfile: pyproject.toml
plugins: langsmith-0.7.33, cov-7.1.0, asyncio-1.3.0, anyio-4.13.0
collected 15 items

tests/test_proxy_streaming_request_logger.py::test_finalize_stream_response_logs_request_for_feed PASSED
tests/test_proxy_streaming_request_logger.py::test_finalize_stream_response_includes_messages_when_log_full_messages_enabled PASSED
tests/test_proxy_streaming_request_logger.py::test_finalize_stream_response_omits_messages_when_log_full_messages_disabled PASSED
tests/test_proxy_streaming_request_logger.py::test_finalize_stream_response_handles_zero_original_tokens PASSED
tests/test_proxy_streaming_request_logger.py::test_finalize_stream_response_no_op_when_logger_disabled PASSED
[+ 10 existing streaming/feed tests]

============================== 15 passed in 0.30s ==============================

$ ruff check headroom/proxy/handlers/streaming.py tests/test_proxy_streaming_request_logger.py
All checks passed!

$ mypy headroom/proxy/handlers/streaming.py
Success: no issues found in 1 source file
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A — backend-only change. Behavior is observable via `curl http://127.0.0.1:6767/transformations/feed?limit=10` after running the proxy with `--log-messages` against any streaming Anthropic client.

## Additional Notes

- The fix is additive and minimal: the streaming finalizer now does what every other code path with a `self.logger` reference already does. No behavior change for setups that did not pass `--log-requests` (default true) or that disabled the logger.
- `tags` is added as `tags: dict[str, str] | None = None` rather than required, so the change is signature-compatible with any in-flight subclasses or out-of-tree forks calling `_finalize_stream_response` directly. Both internal call sites pass the `tags` value the surrounding `_stream_response` already has in scope.
- The new test exercises `_finalize_stream_response` with a real `RequestLogger` (not a mock) so it pins the contract end-to-end: the actual deque must be populated, with the actual JSON shape consumers will see.
- The existing `tests/test_proxy/test_transformations_feed.py` tests only assert the endpoint returns a list — they don't assert it ever populates after real traffic, which is why this regression slipped past CI.