### PR TITLE
feat+fix(learn): live flush of traffic patterns to CLAUDE.md / MEMORY.md + persist real evidence_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Live flush of traffic-learned patterns to CLAUDE.md / MEMORY.md** — the
+  `TrafficLearner` now writes to agent-native context files continuously
+  during proxy operation, not just at shutdown. A new dirty-flag debounced
+  `_flush_worker` (10s window, `FLUSH_DEBOUNCE_SECONDS`) calls
+  `flush_to_file()` whenever `_accumulate()` marks the learner dirty, so
+  patterns surface in `CLAUDE.md` / `MEMORY.md` near real-time. Flushes
+  read both persisted rows (via `_load_persisted_patterns_from_sqlite`)
+  and the in-memory accumulator, bucket patterns by project via the learn
+  plugin registry (`plugin.discover_projects()` + longest-path anchoring
+  in `_project_for_pattern`), and route by `PatternCategory` to the
+  correct file (`_patterns_to_recommendations` +
+  `_CATEGORY_TO_TARGET`). Live flushes require `evidence_count >= 2`;
+  the shutdown flush accepts single-evidence rows.
+
+### Fixed
+- **Traffic-learner evidence count stuck at 1; duplicate DB rows across
+  restarts.** `_accumulate` queued patterns with the default
+  `ExtractedPattern.evidence_count = 1` regardless of how many times the
+  pattern was actually seen, so every persisted row landed at `1` and
+  never crossed the live-flush gate (`evidence_count >= 2`). Worse, once
+  a pattern was in `_saved_hashes` it was early-returned on every
+  re-sighting, and `_saved_hashes` reset on process restart — so a second
+  sighting in a later session inserted a duplicate row rather than
+  bumping the existing one. Now: `_accumulate` writes the real
+  accumulated count at save time, `start()` hydrates `_saved_hashes` +
+  a new `_persisted_ids` map from the DB, and re-sightings bump the
+  persisted row's `metadata.evidence_count` via an atomic `json_set`
+  `UPDATE` (`_bump_persisted_evidence`). `_load_persisted_patterns_from_sqlite`
+  now filters via `json_extract(metadata, '$.source')` instead of a
+  LIKE on the raw JSON string, so rows survive metadata rewrites.
+
+### Added
 - **Telemetry stack & install-mode identity fields** — anonymous beacon now
   reports `headroom_stack` (how Headroom is invoked: `proxy`, `wrap_claude`,
   `adapter_ts_openai`, ...) and `install_mode` (`wrapped` / `persistent` /

--- a/headroom/memory/traffic_learner.py
+++ b/headroom/memory/traffic_learner.py
@@ -20,17 +20,30 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
 import re
+import sqlite3
 import time
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from headroom.learn.models import ProjectInfo
     from headroom.memory.backends.local import LocalBackend
 
 logger = logging.getLogger(__name__)
+
+# Minimum seconds between successive flush_to_file calls when driven by the
+# dirty-flag worker. Prevents CLAUDE.md thrash during bursty traffic while
+# still staying "near real-time" from the user's perspective.
+FLUSH_DEBOUNCE_SECONDS = 10.0
+
+# Absolute file-path heuristic for anchoring a pattern to a project root.
+# Matches POSIX paths (starts with /) and common Windows drive paths.
+_ABS_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)[\w./\\\-]+")
 
 
 # =============================================================================
@@ -192,6 +205,16 @@ class TrafficLearner:
         self._save_task: asyncio.Task[None] | None = None
         self._stopping = False
 
+        # Dirty-flag debounced flush to CLAUDE.md / MEMORY.md. Set whenever
+        # a pattern is accumulated; checked by _flush_worker.
+        self._flush_dirty = False
+        self._last_flush_at = 0.0
+        self._flush_task: asyncio.Task[None] | None = None
+
+        # Cached project roots discovered via the learn plugin registry.
+        # Populated lazily in flush_to_file.
+        self._project_roots_cache: list[ProjectInfo] | None = None
+
     # =========================================================================
     # Public API
     # =========================================================================
@@ -201,16 +224,25 @@ class TrafficLearner:
         self._backend = backend
 
     async def start(self) -> None:
-        """Start the background save worker."""
+        """Start the background save worker and flush worker."""
         if self._save_task is None or self._save_task.done():
             self._save_task = asyncio.create_task(self._save_worker())
+        if self._flush_task is None or self._flush_task.done():
+            self._flush_task = asyncio.create_task(self._flush_worker())
 
     async def stop(self) -> None:
-        """Stop the background save worker, draining the queue first."""
+        """Stop the background workers, drain the save queue, final flush."""
+        self._stopping = True
+
+        if self._flush_task and not self._flush_task.done():
+            self._flush_task.cancel()
+            try:
+                await self._flush_task
+            except asyncio.CancelledError:
+                pass
+
         # Drain any remaining patterns in the queue before cancelling
         if self._save_task and not self._save_task.done():
-            # Signal the worker to stop by putting a sentinel
-            self._stopping = True
             self._save_task.cancel()
             try:
                 await self._save_task
@@ -225,6 +257,7 @@ class TrafficLearner:
                     await self._backend.save_memory(
                         content=pattern.content,
                         user_id=self._user_id,
+                        importance=pattern.importance,
                         metadata={
                             "source": "traffic_learner",
                             "category": pattern.category.value,
@@ -236,80 +269,159 @@ class TrafficLearner:
             except Exception:
                 break
 
-        # Flush learned patterns to the agent-native .md file
+        # Final flush on shutdown — bypass debounce.
         await self.flush_to_file()
 
-    async def flush_to_file(self) -> None:
-        """Flush accumulated patterns to the agent-native context file.
+    async def _flush_worker(self) -> None:
+        """Background worker: call flush_to_file when dirty, rate-limited."""
+        while True:
+            try:
+                await asyncio.sleep(2.0)
+                if not self._flush_dirty:
+                    continue
+                if time.monotonic() - self._last_flush_at < FLUSH_DEBOUNCE_SECONDS:
+                    continue
+                # Reset before flushing so patterns accumulated during the
+                # flush still trigger a follow-up.
+                self._flush_dirty = False
+                self._last_flush_at = time.monotonic()
+                await self.flush_to_file()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warning("Traffic learner flush worker iteration failed: %s", e)
 
-        Uses the learn plugin registry to find the correct writer for the
-        current agent_type (e.g., MEMORY.md for Claude, AGENTS.md for Codex).
+    async def flush_to_file(self) -> None:
+        """Flush patterns (persisted + in-memory) to agent-native context files.
+
+        Buckets patterns by project via longest-matching file path in content
+        or entity_refs, routes by category to CLAUDE.md vs MEMORY.md, and
+        delegates the actual write to the learn plugin writer.
+
+        Un-anchored patterns (no absolute path in content) are dropped in v1.
         """
-        patterns = self.get_learned_patterns()
-        if not patterns or self.agent_type == "unknown":
+        try:
+            from headroom.learn.registry import auto_detect_plugins, get_plugin
+        except Exception as e:
+            logger.debug("Traffic learner flush: learn package unavailable (%s)", e)
             return
 
+        # Resolve plugin: explicit agent_type wins, else first detected plugin.
         try:
-            from headroom.learn.models import ProjectInfo, Recommendation, RecommendationTarget
-            from headroom.learn.registry import get_plugin
-
-            plugin = get_plugin(self.agent_type)
-            writer = plugin.create_writer()
-
-            # Convert patterns to Recommendations
-            recommendations = []
-            for p in patterns:
-                recommendations.append(
-                    Recommendation(
-                        target=RecommendationTarget.CONTEXT_FILE,
-                        section="Learned Patterns (Live Traffic)",
-                        content=f"- {p.content}",
-                        confidence=p.importance,
-                        evidence_count=p.evidence_count,
-                    )
-                )
-
-            if not recommendations:
-                return
-
-            # Use cwd as project path — the proxy runs in the project directory
-            from pathlib import Path
-
-            project = ProjectInfo(
-                name=Path.cwd().name,
-                project_path=Path.cwd(),
-                data_path=Path.cwd(),
-            )
-
-            result = writer.write(recommendations, project, dry_run=False)
-            if result.files_written:
-                logger.info(
-                    "Traffic learner flushed %d patterns to %s",
-                    len(recommendations),
-                    ", ".join(str(f) for f in result.files_written),
-                )
+            if self.agent_type and self.agent_type != "unknown":
+                plugin = get_plugin(self.agent_type)
+            else:
+                detected = auto_detect_plugins()
+                if not detected:
+                    logger.debug("Traffic learner flush: no agent plugins detected")
+                    return
+                plugin = detected[0]
         except KeyError:
-            logger.debug("No learn plugin for agent_type=%s, skipping file flush", self.agent_type)
-        except Exception as e:
-            logger.warning("Traffic learner flush_to_file failed: %s", e)
+            logger.debug("No learn plugin for agent_type=%s", self.agent_type)
+            return
+
+        # Gather patterns: persisted rows + in-memory accumulator, deduped.
+        patterns = self._collect_all_patterns()
+        if not patterns:
+            return
+
+        # Evidence gate: at shutdown accept single-evidence rows; during live
+        # flushes require 2+ to suppress one-off noise.
+        min_evidence = 1 if self._stopping else 2
+        patterns = [p for p in patterns if p.evidence_count >= min_evidence]
+        if not patterns:
+            return
+
+        # Bucket patterns by project.
+        if self._project_roots_cache is None:
+            try:
+                self._project_roots_cache = plugin.discover_projects()
+            except Exception as e:
+                logger.warning("discover_projects failed: %s", e)
+                self._project_roots_cache = []
+
+        roots = self._project_roots_cache
+        if not roots:
+            logger.debug("Traffic learner flush: no projects discovered, skipping")
+            return
+
+        by_project: dict[Path, list[ExtractedPattern]] = {}
+        unanchored = 0
+        for p in patterns:
+            proj = _project_for_pattern(p, roots)
+            if proj is None:
+                unanchored += 1
+                continue
+            by_project.setdefault(proj.project_path, []).append(p)
+
+        if unanchored:
+            logger.debug("Traffic learner flush: dropped %d un-anchored pattern(s)", unanchored)
+
+        writer = plugin.create_writer()
+        project_by_path = {p.project_path: p for p in roots}
+
+        for project_path, proj_patterns in by_project.items():
+            project = project_by_path[project_path]
+            recommendations = _patterns_to_recommendations(proj_patterns)
+            if not recommendations:
+                continue
+            try:
+                result = writer.write(recommendations, project, dry_run=False)
+                if result.files_written:
+                    logger.info(
+                        "Traffic learner flushed %d pattern(s) to %s",
+                        len(proj_patterns),
+                        ", ".join(str(f) for f in result.files_written),
+                    )
+            except Exception as e:
+                logger.warning("Traffic learner write failed for %s: %s", project_path, e)
+
+    def _collect_all_patterns(self) -> list[ExtractedPattern]:
+        """Merge persisted (memory.db) + in-memory patterns, deduped by content.
+
+        Evidence counts are summed across duplicates.
+        """
+        by_hash: dict[str, ExtractedPattern] = {}
+
+        # Persisted rows from memory.db
+        db_path = _resolve_backend_db_path(self._backend)
+        if db_path is not None and db_path.exists():
+            try:
+                persisted = _load_persisted_patterns_from_sqlite(db_path)
+            except Exception as e:
+                logger.debug("Reading persisted traffic patterns failed: %s", e)
+                persisted = []
+            for p in persisted:
+                if p.content_hash in by_hash:
+                    by_hash[p.content_hash].evidence_count += p.evidence_count
+                else:
+                    by_hash[p.content_hash] = p
+
+        # In-memory accumulator (patterns not yet persisted)
+        for pattern, count in self._pattern_counts.values():
+            h = pattern.content_hash
+            if h in by_hash:
+                by_hash[h].evidence_count += count
+            else:
+                by_hash[h] = ExtractedPattern(
+                    category=pattern.category,
+                    content=pattern.content,
+                    importance=pattern.importance,
+                    evidence_count=count,
+                    entity_refs=list(pattern.entity_refs),
+                    metadata=dict(pattern.metadata),
+                    content_hash=pattern.content_hash,
+                )
+
+        return list(by_hash.values())
 
     def get_learned_patterns(self) -> list[ExtractedPattern]:
-        """Return all patterns that have been saved or met the evidence threshold.
+        """Return patterns from the in-memory accumulator.
 
-        Includes patterns still in the accumulator that haven't hit min_evidence
-        but have been seen at least once (for end-of-session flush).
+        Retained for backwards compatibility. Reads only the accumulator;
+        does not consult persisted rows. Use flush_to_file() for full data.
         """
-        patterns: list[ExtractedPattern] = []
-
-        # Patterns that met the threshold and were queued
-        # (already saved to DB, but also want them in the .md file)
-        # We track what was saved via _saved_hashes, but don't keep the content.
-        # So we collect from the accumulator — patterns still accumulating.
-        for pattern, count in self._pattern_counts.values():
-            if count >= 1:  # At shutdown, flush even single-evidence patterns
-                patterns.append(pattern)
-
-        return patterns
+        return [pattern for pattern, count in self._pattern_counts.values() if count >= 1]
 
     async def on_tool_result(
         self,
@@ -597,6 +709,7 @@ class TrafficLearner:
     async def _accumulate(self, pattern: ExtractedPattern) -> None:
         """Accumulate a pattern, saving when evidence threshold is met."""
         self._patterns_extracted += 1
+        self._flush_dirty = True
         h = pattern.content_hash
 
         # Already saved — skip
@@ -639,6 +752,7 @@ class TrafficLearner:
                 await self._backend.save_memory(
                     content=pattern.content,
                     user_id=self._user_id,
+                    importance=pattern.importance,
                     metadata={
                         "source": "traffic_learner",
                         "category": pattern.category.value,
@@ -712,3 +826,188 @@ class TrafficLearner:
                 )
 
         return results
+
+
+# =============================================================================
+# Module helpers: project routing, memory.db loading, recommendation build
+# =============================================================================
+
+# Category → file routing. Stable project facts go to CLAUDE.md; evolving
+# preferences and error recovery tips go to MEMORY.md (which the user's
+# auto-memory system already owns).
+_CATEGORY_TO_TARGET: dict[PatternCategory, str] = {
+    PatternCategory.ENVIRONMENT: "context_file",
+    PatternCategory.ARCHITECTURE: "context_file",
+    PatternCategory.PREFERENCE: "memory_file",
+    PatternCategory.ERROR_RECOVERY: "memory_file",
+}
+
+_CATEGORY_SECTION_TITLE: dict[PatternCategory, str] = {
+    PatternCategory.ENVIRONMENT: "Learned: environment",
+    PatternCategory.ARCHITECTURE: "Learned: architecture",
+    PatternCategory.PREFERENCE: "Learned: preference",
+    PatternCategory.ERROR_RECOVERY: "Learned: error recovery",
+}
+
+
+def _project_for_pattern(pattern: ExtractedPattern, roots: list[ProjectInfo]) -> ProjectInfo | None:
+    """Return the project whose root most specifically matches this pattern.
+
+    We look for absolute paths in the pattern's content and entity_refs, then
+    pick the longest project root that prefixes any of those paths. Returns
+    None if the pattern mentions no paths under a known project.
+    """
+    if not roots:
+        return None
+
+    # Collect candidate absolute paths from content and entity_refs
+    candidates: list[str] = []
+    for match in _ABS_PATH_RE.findall(pattern.content or ""):
+        candidates.append(match)
+    for ref in pattern.entity_refs or []:
+        if ref and (ref.startswith("/") or (len(ref) > 2 and ref[1] == ":")):
+            candidates.append(ref)
+
+    if not candidates:
+        return None
+
+    # Longest root first — most specific wins
+    roots_sorted = sorted(roots, key=lambda p: len(str(p.project_path)), reverse=True)
+
+    for cand in candidates:
+        for root in roots_sorted:
+            root_str = str(root.project_path).rstrip("/")
+            if not root_str:
+                continue
+            if (
+                cand == root_str
+                or cand.startswith(root_str + "/")
+                or cand.startswith(root_str + "\\")
+            ):
+                return root
+    return None
+
+
+def _resolve_backend_db_path(backend: Any) -> Path | None:
+    """Best-effort lookup of the SQLite path used by the memory backend.
+
+    Returns None if the backend is not a LocalBackend or its config is not
+    accessible (e.g. mem0 remote backend).
+    """
+    if backend is None:
+        return None
+    cfg = getattr(backend, "_config", None)
+    db_path = getattr(cfg, "db_path", None) if cfg is not None else None
+    if not db_path:
+        return None
+    return Path(db_path)
+
+
+def _load_persisted_patterns_from_sqlite(db_path: Path) -> list[ExtractedPattern]:
+    """Read traffic_learner rows from memory.db, dedupe, return patterns.
+
+    Uses a direct read-only SQLite connection — we don't go through the
+    backend's vector search because we want all rows, not semantically
+    similar ones, and the backend doesn't expose a "list by source" query.
+    """
+    uri = f"file:{db_path}?mode=ro"
+    patterns: dict[str, ExtractedPattern] = {}
+    try:
+        conn = sqlite3.connect(uri, uri=True)
+    except sqlite3.OperationalError:
+        return []
+    try:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT content, metadata, entity_refs, importance "
+            "FROM memories "
+            'WHERE metadata LIKE \'%"source": "traffic_learner"%\''
+        ).fetchall()
+    except sqlite3.DatabaseError:
+        conn.close()
+        return []
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    for row in rows:
+        content = row["content"] or ""
+        if not content:
+            continue
+        try:
+            meta = json.loads(row["metadata"] or "{}")
+        except json.JSONDecodeError:
+            meta = {}
+        try:
+            entity_refs = json.loads(row["entity_refs"] or "[]") or []
+        except json.JSONDecodeError:
+            entity_refs = []
+
+        cat_str = meta.get("category", "")
+        try:
+            category = PatternCategory(cat_str)
+        except ValueError:
+            continue  # Skip rows whose category we don't recognize
+
+        evidence = int(meta.get("evidence_count", 1) or 1)
+        try:
+            importance = float(row["importance"]) if row["importance"] is not None else 0.5
+        except (TypeError, ValueError):
+            importance = 0.5
+
+        h = hashlib.sha256(content.encode()).hexdigest()[:16]
+        if h in patterns:
+            existing = patterns[h]
+            existing.evidence_count += evidence
+            if importance > existing.importance:
+                existing.importance = importance
+        else:
+            patterns[h] = ExtractedPattern(
+                category=category,
+                content=content,
+                importance=importance,
+                evidence_count=evidence,
+                entity_refs=list(entity_refs),
+                metadata=meta,
+                content_hash=h,
+            )
+
+    return list(patterns.values())
+
+
+def _patterns_to_recommendations(patterns: list[ExtractedPattern]) -> list:
+    """Group patterns by category into one Recommendation per category.
+
+    Returns a list of Recommendation objects ready for ContextWriter.write.
+    """
+    from headroom.learn.models import Recommendation, RecommendationTarget
+
+    by_category: dict[PatternCategory, list[ExtractedPattern]] = {}
+    for p in patterns:
+        by_category.setdefault(p.category, []).append(p)
+
+    recs: list[Recommendation] = []
+    for category, items in by_category.items():
+        target_str = _CATEGORY_TO_TARGET.get(category)
+        if target_str is None:
+            continue
+        target = (
+            RecommendationTarget.CONTEXT_FILE
+            if target_str == "context_file"
+            else RecommendationTarget.MEMORY_FILE
+        )
+        # Sort by evidence_count desc so the most-supported rules appear first.
+        items.sort(key=lambda p: p.evidence_count, reverse=True)
+        bullets = "\n".join(f"- {p.content}" for p in items)
+        recs.append(
+            Recommendation(
+                target=target,
+                section=_CATEGORY_SECTION_TITLE.get(category, f"Learned: {category.value}"),
+                content=bullets,
+                confidence=max((p.importance for p in items), default=0.5),
+                evidence_count=sum(p.evidence_count for p in items),
+            )
+        )
+    return recs

--- a/headroom/memory/traffic_learner.py
+++ b/headroom/memory/traffic_learner.py
@@ -193,6 +193,10 @@ class TrafficLearner:
 
         # Dedup: hashes of patterns already saved to DB
         self._saved_hashes: set[str] = set()
+        # content_hash → memory.id for persisted rows. Lets re-sightings
+        # bump the existing row's evidence_count instead of creating a
+        # duplicate row.
+        self._persisted_ids: dict[str, str] = {}
         self._dedup_window = dedup_window
 
         # Stats
@@ -225,6 +229,9 @@ class TrafficLearner:
 
     async def start(self) -> None:
         """Start the background save worker and flush worker."""
+        # Hydrate persisted dedup state before workers spin up so cross-session
+        # re-sightings bump existing rows instead of creating duplicates.
+        await self._hydrate_persisted_state()
         if self._save_task is None or self._save_task.done():
             self._save_task = asyncio.create_task(self._save_worker())
         if self._flush_task is None or self._flush_task.done():
@@ -712,8 +719,12 @@ class TrafficLearner:
         self._flush_dirty = True
         h = pattern.content_hash
 
-        # Already saved — skip
+        # Already saved — bump the persisted row's evidence_count rather
+        # than creating a duplicate.
         if h in self._saved_hashes:
+            memory_id = self._persisted_ids.get(h)
+            if memory_id is not None:
+                await self._bump_persisted_evidence(memory_id)
             return
 
         # Accumulate evidence
@@ -736,6 +747,8 @@ class TrafficLearner:
                 # Remove oldest (arbitrary, set is unordered, but prevents growth)
                 self._saved_hashes.pop()
 
+            # Persist the real accumulated count, not the dataclass default.
+            pattern.evidence_count = count
             try:
                 self._save_queue.put_nowait(pattern)
             except asyncio.QueueFull:
@@ -749,7 +762,7 @@ class TrafficLearner:
                 if self._backend is None:
                     continue
 
-                await self._backend.save_memory(
+                memory = await self._backend.save_memory(
                     content=pattern.content,
                     user_id=self._user_id,
                     importance=pattern.importance,
@@ -761,12 +774,87 @@ class TrafficLearner:
                     },
                 )
                 self._patterns_saved += 1
+                # Track id so future re-sightings bump this row.
+                memory_id = getattr(memory, "id", None)
+                if memory_id is not None:
+                    self._persisted_ids[pattern.content_hash] = memory_id
                 logger.debug(f"Traffic learner saved pattern: {pattern.content[:80]}")
 
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 logger.warning(f"Traffic learner save failed: {e}")
+
+    async def _hydrate_persisted_state(self) -> None:
+        """Load existing traffic_learner rows into _saved_hashes / _persisted_ids.
+
+        Runs once at start() so re-sightings across process restarts bump the
+        existing row rather than inserting a duplicate. Read-only; if the DB
+        is absent or unreadable we simply skip.
+        """
+        db_path = _resolve_backend_db_path(self._backend)
+        if db_path is None or not db_path.exists():
+            return
+
+        def _read() -> list[tuple[str, str]]:
+            uri = f"file:{db_path}?mode=ro"
+            try:
+                conn = sqlite3.connect(uri, uri=True)
+            except sqlite3.OperationalError:
+                return []
+            try:
+                rows = conn.execute(
+                    "SELECT id, content FROM memories "
+                    "WHERE json_extract(metadata, '$.source') = 'traffic_learner'"
+                ).fetchall()
+            except sqlite3.DatabaseError:
+                return []
+            finally:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            return [(row[0], row[1] or "") for row in rows]
+
+        try:
+            rows = await asyncio.to_thread(_read)
+        except Exception as e:
+            logger.debug("Traffic learner hydrate failed: %s", e)
+            return
+
+        for memory_id, content in rows:
+            if not content:
+                continue
+            h = hashlib.sha256(content.encode()).hexdigest()[:16]
+            self._saved_hashes.add(h)
+            # If multiple rows share the same content (legacy duplicates),
+            # last-wins — we only need one id to target the bump.
+            self._persisted_ids[h] = memory_id
+
+    async def _bump_persisted_evidence(self, memory_id: str) -> None:
+        """Atomically increment a persisted row's metadata.evidence_count."""
+        db_path = _resolve_backend_db_path(self._backend)
+        if db_path is None or not db_path.exists():
+            return
+
+        def _bump() -> None:
+            conn = sqlite3.connect(str(db_path))
+            try:
+                conn.execute(
+                    "UPDATE memories SET metadata = json_set("
+                    "metadata, '$.evidence_count', "
+                    "COALESCE(json_extract(metadata, '$.evidence_count'), 0) + 1"
+                    ") WHERE id = ?",
+                    (memory_id,),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        try:
+            await asyncio.to_thread(_bump)
+        except Exception as e:
+            logger.debug("Traffic learner evidence bump failed for %s: %s", memory_id, e)
 
     # =========================================================================
     # Convenience: Extract from Anthropic messages format
@@ -921,7 +1009,7 @@ def _load_persisted_patterns_from_sqlite(db_path: Path) -> list[ExtractedPattern
         rows = conn.execute(
             "SELECT content, metadata, entity_refs, importance "
             "FROM memories "
-            'WHERE metadata LIKE \'%"source": "traffic_learner"%\''
+            "WHERE json_extract(metadata, '$.source') = 'traffic_learner'"
         ).fetchall()
     except sqlite3.DatabaseError:
         conn.close()

--- a/tests/test_anthropic_pre_upstream_backpressure.py
+++ b/tests/test_anthropic_pre_upstream_backpressure.py
@@ -564,6 +564,14 @@ def test_livez_unaffected_under_anthropic_backpressure():
 
     latencies: list[float] = []
     with TestClient(app) as client:
+        # Warm up: the first few requests pay one-time costs (TestClient
+        # ASGI lifespan, route resolution, import side effects) that are
+        # unrelated to what this test measures. Without warm-up, the
+        # single cold-start sample dominates `max(latencies)` (which is
+        # what the p99 fallback below reduces to for small N) and causes
+        # flakes on slow CI runners.
+        for _ in range(3):
+            client.get("/livez")
         for _ in range(20):
             t0 = time.perf_counter()
             resp = client.get("/livez")

--- a/tests/test_memory/test_traffic_learner.py
+++ b/tests/test_memory/test_traffic_learner.py
@@ -753,3 +753,326 @@ class TestEvidencePersistence:
         assert len(rows) == 1
         assert rows[0][0] == "seed-id"
         assert rows[0][2]["evidence_count"] == 4
+
+
+# =============================================================================
+# flush_to_file end-to-end + early-return paths
+# =============================================================================
+
+
+class _FakeWriteResult:
+    def __init__(self, files_written):
+        self.files_written = files_written
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.calls: list[tuple] = []
+        self.files_to_return: list = []
+        self.raise_on_write = False
+
+    def write(self, recommendations, project, *, dry_run):
+        self.calls.append((list(recommendations), project, dry_run))
+        if self.raise_on_write:
+            raise RuntimeError("boom")
+        return _FakeWriteResult(list(self.files_to_return))
+
+
+class _FakePlugin:
+    def __init__(self, roots, writer, discover_raises=False):
+        self._roots = roots
+        self._writer = writer
+        self._discover_raises = discover_raises
+
+    def discover_projects(self):
+        if self._discover_raises:
+            raise RuntimeError("discover blew up")
+        return list(self._roots)
+
+    def create_writer(self):
+        return self._writer
+
+
+def _install_plugin_registry(monkeypatch, plugin):
+    """Stub out headroom.learn.registry so flush_to_file uses our fake."""
+    import sys
+    import types as _types
+
+    fake = _types.ModuleType("headroom.learn.registry")
+    fake.auto_detect_plugins = lambda: [plugin] if plugin is not None else []  # type: ignore[attr-defined]
+    fake.get_plugin = lambda agent_type: plugin  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "headroom.learn.registry", fake)
+
+
+def _make_project(path):
+    from pathlib import Path as _P
+
+    from headroom.learn.models import ProjectInfo
+
+    p = _P(path)
+    return ProjectInfo(name=p.name, project_path=p, data_path=p)
+
+
+class TestFlushToFile:
+    @pytest.mark.asyncio
+    async def test_end_to_end_writes_per_project(self, tmp_path, monkeypatch):
+        """Happy path: anchored patterns → bucketed per project → writer called."""
+        db = tmp_path / "memory.db"
+        _init_db(db)
+        backend = _FakeBackend(db)
+
+        learner = TrafficLearner(backend=backend, agent_type="claude", min_evidence=2)
+        writer = _FakeWriter()
+        writer.files_to_return = [tmp_path / "CLAUDE.md"]
+        proj = _make_project(str(tmp_path))
+        plugin = _FakePlugin(roots=[proj], writer=writer)
+        _install_plugin_registry(monkeypatch, plugin)
+
+        # Need the save worker running so accumulated patterns actually land in
+        # the DB where flush_to_file reads them.
+        await learner.start()
+        try:
+
+            def mk() -> ExtractedPattern:
+                return ExtractedPattern(
+                    category=PatternCategory.ENVIRONMENT,
+                    content=f"Use /usr/bin/python3 at {tmp_path}/main.py",
+                    importance=0.6,
+                )
+
+            # Two sightings → save at evidence_count=2 (crosses live-flush gate).
+            await learner._accumulate(mk())
+            await learner._accumulate(mk())
+            await _wait_for_saved(learner, 1, db)
+
+            await learner.flush_to_file()
+        finally:
+            await learner.stop()
+
+        assert len(writer.calls) >= 1
+        recs, written_proj, dry_run = writer.calls[0]
+        assert dry_run is False
+        assert written_proj is proj
+        assert len(recs) == 1
+        assert "python3" in recs[0].content
+
+    @pytest.mark.asyncio
+    async def test_early_returns_no_plugin(self, monkeypatch):
+        """No plugin detected → flush is a no-op."""
+        learner = TrafficLearner(backend=None, agent_type="unknown", min_evidence=1)
+        _install_plugin_registry(monkeypatch, None)
+        # Seed an accumulator entry so the check isn't vacuously "no patterns".
+        learner._pattern_counts["h"] = (
+            ExtractedPattern(
+                category=PatternCategory.ENVIRONMENT,
+                content="x",
+                importance=0.5,
+                evidence_count=2,
+            ),
+            2,
+        )
+        await learner.flush_to_file()  # returns without raising
+
+    @pytest.mark.asyncio
+    async def test_early_return_no_patterns(self, monkeypatch):
+        """Empty accumulator and empty DB → flush returns without calling writer."""
+        writer = _FakeWriter()
+        plugin = _FakePlugin(roots=[_make_project("/x/a")], writer=writer)
+        _install_plugin_registry(monkeypatch, plugin)
+
+        learner = TrafficLearner(backend=None, agent_type="claude", min_evidence=1)
+        await learner.flush_to_file()
+        assert writer.calls == []
+
+    @pytest.mark.asyncio
+    async def test_discover_projects_failure_is_swallowed(self, monkeypatch):
+        """If plugin.discover_projects raises, flush logs and returns."""
+        writer = _FakeWriter()
+        plugin = _FakePlugin(roots=[], writer=writer, discover_raises=True)
+        _install_plugin_registry(monkeypatch, plugin)
+
+        learner = TrafficLearner(backend=None, agent_type="claude", min_evidence=1)
+        learner._pattern_counts["h"] = (
+            ExtractedPattern(
+                category=PatternCategory.ENVIRONMENT,
+                content="whatever",
+                importance=0.5,
+                evidence_count=2,
+            ),
+            2,
+        )
+        await learner.flush_to_file()
+        assert writer.calls == []  # no roots → short-circuits before writer
+
+    @pytest.mark.asyncio
+    async def test_unanchored_patterns_dropped(self, tmp_path, monkeypatch):
+        """Patterns with no path anchoring are dropped before writer is called."""
+        writer = _FakeWriter()
+        plugin = _FakePlugin(roots=[_make_project(str(tmp_path))], writer=writer)
+        _install_plugin_registry(monkeypatch, plugin)
+
+        learner = TrafficLearner(backend=None, agent_type="claude", min_evidence=1)
+        # Content has no absolute path — should be dropped as un-anchored.
+        learner._pattern_counts["h"] = (
+            ExtractedPattern(
+                category=PatternCategory.PREFERENCE,
+                content="User preference: use terse output",
+                importance=0.7,
+                evidence_count=2,
+            ),
+            2,
+        )
+        await learner.flush_to_file()
+        assert writer.calls == []
+
+    @pytest.mark.asyncio
+    async def test_writer_exception_does_not_propagate(self, tmp_path, monkeypatch):
+        """A writer raising should be logged; flush must not bubble the error."""
+        writer = _FakeWriter()
+        writer.raise_on_write = True
+        plugin = _FakePlugin(roots=[_make_project(str(tmp_path))], writer=writer)
+        _install_plugin_registry(monkeypatch, plugin)
+
+        learner = TrafficLearner(backend=None, agent_type="claude", min_evidence=1)
+        learner._pattern_counts["h"] = (
+            ExtractedPattern(
+                category=PatternCategory.ENVIRONMENT,
+                content=f"Use {tmp_path}/tool.py",
+                importance=0.6,
+                evidence_count=2,
+            ),
+            2,
+        )
+        await learner.flush_to_file()  # must not raise
+        assert len(writer.calls) == 1
+
+
+# =============================================================================
+# Internal helper edge cases — _resolve_backend_db_path / _collect_all_patterns
+# / _hydrate_persisted_state / _bump_persisted_evidence
+# =============================================================================
+
+
+class TestBackendResolution:
+    def test_resolve_none_backend(self):
+        from headroom.memory.traffic_learner import _resolve_backend_db_path
+
+        assert _resolve_backend_db_path(None) is None
+
+    def test_resolve_backend_without_config(self):
+        from headroom.memory.traffic_learner import _resolve_backend_db_path
+
+        class _Bare:
+            pass
+
+        assert _resolve_backend_db_path(_Bare()) is None
+
+    def test_resolve_backend_with_empty_db_path(self):
+        import types as _types
+
+        from headroom.memory.traffic_learner import _resolve_backend_db_path
+
+        backend = _types.SimpleNamespace(_config=_types.SimpleNamespace(db_path=""))
+        assert _resolve_backend_db_path(backend) is None
+
+
+class TestCollectAllPatterns:
+    @pytest.mark.asyncio
+    async def test_merges_db_and_accumulator(self, tmp_path):
+        """Patterns in both DB and accumulator get evidence_count summed by hash."""
+        db = tmp_path / "memory.db"
+        _init_db(db)
+        backend = _FakeBackend(db)
+
+        # Seed DB with a traffic_learner row at evidence_count=3.
+        await backend.save_memory(
+            content="shared pattern",
+            user_id="t",
+            importance=0.5,
+            metadata={
+                "source": "traffic_learner",
+                "category": "environment",
+                "evidence_count": 3,
+            },
+        )
+
+        learner = TrafficLearner(backend=backend, min_evidence=1)
+        # Same content in accumulator with count=2; hash matches.
+        p = ExtractedPattern(
+            category=PatternCategory.ENVIRONMENT,
+            content="shared pattern",
+            importance=0.5,
+        )
+        learner._pattern_counts[p.content_hash] = (p, 2)
+
+        merged = learner._collect_all_patterns()
+        assert len(merged) == 1
+        assert merged[0].evidence_count == 3 + 2
+
+    def test_handles_missing_db_gracefully(self, tmp_path):
+        """A backend pointing to a nonexistent DB is skipped, not raised."""
+        backend = _FakeBackend(tmp_path / "absent.db")  # file not created
+        learner = TrafficLearner(backend=backend, min_evidence=1)
+        merged = learner._collect_all_patterns()
+        assert merged == []
+
+
+class TestHydrateEdgeCases:
+    @pytest.mark.asyncio
+    async def test_no_backend(self):
+        """start() with backend=None hydrates to empty state and still runs."""
+        learner = TrafficLearner(backend=None, min_evidence=1)
+        await learner.start()
+        try:
+            assert learner._saved_hashes == set()
+            assert learner._persisted_ids == {}
+        finally:
+            await learner.stop()
+
+    @pytest.mark.asyncio
+    async def test_missing_db_file(self, tmp_path):
+        """Backend with a db_path that doesn't exist → hydrate is a no-op."""
+        backend = _FakeBackend(tmp_path / "not-there.db")
+        learner = TrafficLearner(backend=backend, min_evidence=1)
+        await learner._hydrate_persisted_state()
+        assert learner._saved_hashes == set()
+        assert learner._persisted_ids == {}
+
+
+class TestBumpEdgeCases:
+    @pytest.mark.asyncio
+    async def test_bump_with_no_backend_is_noop(self):
+        learner = TrafficLearner(backend=None, min_evidence=1)
+        # Should not raise even with no backend.
+        await learner._bump_persisted_evidence("some-id")
+
+    @pytest.mark.asyncio
+    async def test_bump_with_missing_db_is_noop(self, tmp_path):
+        backend = _FakeBackend(tmp_path / "absent.db")
+        learner = TrafficLearner(backend=backend, min_evidence=1)
+        await learner._bump_persisted_evidence("some-id")  # no exception
+
+    @pytest.mark.asyncio
+    async def test_bump_unknown_id_is_noop(self, tmp_path):
+        """Updating a non-existent memory id silently affects zero rows."""
+        db = tmp_path / "memory.db"
+        _init_db(db)
+        backend = _FakeBackend(db)
+        learner = TrafficLearner(backend=backend, min_evidence=1)
+        await learner._bump_persisted_evidence("no-such-id")
+        assert _read_traffic_rows(db) == []
+
+
+# =============================================================================
+# stop() cancels the flush task
+# =============================================================================
+
+
+class TestStopCancels:
+    @pytest.mark.asyncio
+    async def test_stop_cancels_flush_task(self):
+        learner = TrafficLearner(backend=None, min_evidence=1)
+        await learner.start()
+        assert learner._flush_task is not None and not learner._flush_task.done()
+        await learner.stop()
+        assert learner._flush_task is None or learner._flush_task.done()

--- a/tests/test_memory/test_traffic_learner.py
+++ b/tests/test_memory/test_traffic_learner.py
@@ -14,6 +14,9 @@ from headroom.memory.traffic_learner import (
     TrafficLearner,
     _classify_error,
     _is_error,
+    _load_persisted_patterns_from_sqlite,
+    _patterns_to_recommendations,
+    _project_for_pattern,
 )
 
 # =============================================================================
@@ -284,3 +287,271 @@ class TestExtractedPattern:
             importance=0.5,
         )
         assert p1.content_hash != p2.content_hash
+
+
+# =============================================================================
+# Project Routing
+# =============================================================================
+
+
+class TestProjectForPattern:
+    def _project(self, path: str):
+        from pathlib import Path as _P
+
+        from headroom.learn.models import ProjectInfo
+
+        p = _P(path)
+        return ProjectInfo(name=p.name, project_path=p, data_path=p)
+
+    def test_matches_longest_root(self):
+        proj_a = self._project("/x/a")
+        proj_b = self._project("/x/a/b")
+        pattern = ExtractedPattern(
+            category=PatternCategory.ERROR_RECOVERY,
+            content="File `/x/a/b/foo.py` does not exist.",
+            importance=0.5,
+        )
+        result = _project_for_pattern(pattern, [proj_a, proj_b])
+        assert result is proj_b
+
+    def test_returns_none_for_unanchored(self):
+        proj_a = self._project("/x/a")
+        pattern = ExtractedPattern(
+            category=PatternCategory.PREFERENCE,
+            content="User preference: use terse responses",
+            importance=0.7,
+        )
+        assert _project_for_pattern(pattern, [proj_a]) is None
+
+    def test_matches_via_entity_refs(self):
+        proj = self._project("/x/a")
+        pattern = ExtractedPattern(
+            category=PatternCategory.ERROR_RECOVERY,
+            content="Command failed.",
+            importance=0.5,
+            entity_refs=["/x/a/tool.py"],
+        )
+        assert _project_for_pattern(pattern, [proj]) is proj
+
+    def test_no_false_match_on_prefix_boundary(self):
+        # /x/ab should not match a project rooted at /x/a
+        proj_a = self._project("/x/a")
+        pattern = ExtractedPattern(
+            category=PatternCategory.ERROR_RECOVERY,
+            content="File `/x/ab/foo.py` does not exist.",
+            importance=0.5,
+        )
+        assert _project_for_pattern(pattern, [proj_a]) is None
+
+
+# =============================================================================
+# Persisted-pattern loading from memory.db
+# =============================================================================
+
+
+class TestLoadPersistedPatterns:
+    def _make_db(self, tmp_path, rows: list[dict]):
+        import json as _json
+        import sqlite3 as _sql
+
+        db = tmp_path / "memory.db"
+        conn = _sql.connect(db)
+        conn.execute(
+            "CREATE TABLE memories ("
+            "id TEXT PRIMARY KEY, content TEXT NOT NULL, "
+            "metadata TEXT NOT NULL DEFAULT '{}', "
+            "entity_refs TEXT NOT NULL DEFAULT '[]', "
+            "importance REAL NOT NULL DEFAULT 0.5)"
+        )
+        for i, r in enumerate(rows):
+            conn.execute(
+                "INSERT INTO memories (id, content, metadata, entity_refs, importance) "
+                "VALUES (?,?,?,?,?)",
+                (
+                    str(i),
+                    r["content"],
+                    _json.dumps(r.get("metadata", {})),
+                    _json.dumps(r.get("entity_refs", [])),
+                    r.get("importance", 0.5),
+                ),
+            )
+        conn.commit()
+        conn.close()
+        return db
+
+    def test_dedupes_by_content_and_sums_evidence(self, tmp_path):
+        db = self._make_db(
+            tmp_path,
+            [
+                {
+                    "content": "Command `foo` fails.",
+                    "metadata": {
+                        "source": "traffic_learner",
+                        "category": "error_recovery",
+                        "evidence_count": 2,
+                    },
+                },
+                {
+                    "content": "Command `foo` fails.",
+                    "metadata": {
+                        "source": "traffic_learner",
+                        "category": "error_recovery",
+                        "evidence_count": 3,
+                    },
+                },
+            ],
+        )
+        patterns = _load_persisted_patterns_from_sqlite(db)
+        assert len(patterns) == 1
+        assert patterns[0].evidence_count == 5
+        assert patterns[0].category == PatternCategory.ERROR_RECOVERY
+
+    def test_skips_non_traffic_rows(self, tmp_path):
+        db = self._make_db(
+            tmp_path,
+            [
+                {
+                    "content": "Something else",
+                    "metadata": {"source": "other"},
+                },
+                {
+                    "content": "From traffic",
+                    "metadata": {
+                        "source": "traffic_learner",
+                        "category": "environment",
+                    },
+                },
+            ],
+        )
+        patterns = _load_persisted_patterns_from_sqlite(db)
+        assert len(patterns) == 1
+        assert patterns[0].content == "From traffic"
+
+    def test_reads_importance_column(self, tmp_path):
+        db = self._make_db(
+            tmp_path,
+            [
+                {
+                    "content": "High-importance pattern",
+                    "metadata": {
+                        "source": "traffic_learner",
+                        "category": "environment",
+                    },
+                    "importance": 0.85,
+                },
+            ],
+        )
+        patterns = _load_persisted_patterns_from_sqlite(db)
+        assert len(patterns) == 1
+        assert patterns[0].importance == 0.85
+
+    def test_skips_unknown_category(self, tmp_path):
+        db = self._make_db(
+            tmp_path,
+            [
+                {
+                    "content": "X",
+                    "metadata": {"source": "traffic_learner", "category": "bogus"},
+                },
+            ],
+        )
+        assert _load_persisted_patterns_from_sqlite(db) == []
+
+
+# =============================================================================
+# Category → recommendation routing
+# =============================================================================
+
+
+class TestPatternsToRecommendations:
+    def test_routes_preference_to_memory_file(self):
+        from headroom.learn.models import RecommendationTarget
+
+        patterns = [
+            ExtractedPattern(
+                category=PatternCategory.PREFERENCE,
+                content="User prefers terse output",
+                importance=0.8,
+                evidence_count=3,
+            ),
+        ]
+        recs = _patterns_to_recommendations(patterns)
+        assert len(recs) == 1
+        assert recs[0].target == RecommendationTarget.MEMORY_FILE
+        assert "User prefers terse output" in recs[0].content
+
+    def test_routes_environment_to_context_file(self):
+        from headroom.learn.models import RecommendationTarget
+
+        patterns = [
+            ExtractedPattern(
+                category=PatternCategory.ENVIRONMENT,
+                content="Use uv run python",
+                importance=0.7,
+                evidence_count=4,
+            ),
+        ]
+        recs = _patterns_to_recommendations(patterns)
+        assert len(recs) == 1
+        assert recs[0].target == RecommendationTarget.CONTEXT_FILE
+
+    def test_groups_by_category(self):
+        patterns = [
+            ExtractedPattern(
+                category=PatternCategory.ERROR_RECOVERY,
+                content="A",
+                importance=0.5,
+                evidence_count=2,
+            ),
+            ExtractedPattern(
+                category=PatternCategory.ERROR_RECOVERY,
+                content="B",
+                importance=0.5,
+                evidence_count=5,
+            ),
+        ]
+        recs = _patterns_to_recommendations(patterns)
+        assert len(recs) == 1
+        # B has higher evidence, should sort first
+        lines = recs[0].content.splitlines()
+        assert lines[0] == "- B"
+        assert lines[1] == "- A"
+        assert recs[0].evidence_count == 7
+
+
+# =============================================================================
+# Debounced flush worker
+# =============================================================================
+
+
+class TestFlushDebounce:
+    @pytest.mark.asyncio
+    async def test_flush_worker_rate_limits(self, monkeypatch):
+        """Rapid dirty flags should not cause rapid flush_to_file calls."""
+        from headroom.memory import traffic_learner as tl_mod
+
+        # Shorten debounce for a fast test
+        monkeypatch.setattr(tl_mod, "FLUSH_DEBOUNCE_SECONDS", 0.5)
+
+        learner = TrafficLearner(backend=None, min_evidence=1)
+        call_count = 0
+
+        async def fake_flush() -> None:
+            nonlocal call_count
+            call_count += 1
+
+        learner.flush_to_file = fake_flush  # type: ignore[method-assign]
+
+        await learner.start()
+        # Toggle dirty rapidly over ~1.2s, which permits at most ~2 flushes.
+        for _ in range(30):
+            learner._flush_dirty = True
+            await __import__("asyncio").sleep(0.04)
+
+        await learner.stop()
+
+        # start() kicked a flush dirty→false at some point; stop() also calls
+        # flush_to_file once (final flush). We want evidence the worker did
+        # NOT call flush on every sleep tick — cap is generous.
+        assert call_count <= 5, f"Expected few flushes, got {call_count}"
+        assert call_count >= 1, "Expected at least one flush during the burst"

--- a/tests/test_memory/test_traffic_learner.py
+++ b/tests/test_memory/test_traffic_learner.py
@@ -555,3 +555,201 @@ class TestFlushDebounce:
         # NOT call flush on every sleep tick — cap is generous.
         assert call_count <= 5, f"Expected few flushes, got {call_count}"
         assert call_count >= 1, "Expected at least one flush during the burst"
+
+
+# =============================================================================
+# Evidence-count persistence & re-sighting bumps
+# =============================================================================
+
+
+class _FakeBackend:
+    """Minimal LocalBackend stand-in that persists to a real SQLite file.
+
+    Provides just enough surface area for TrafficLearner: `_config.db_path`
+    (read by `_resolve_backend_db_path`) and an `async save_memory` that
+    inserts a row and returns an object with `.id`.
+    """
+
+    def __init__(self, db_path):
+        import types as _types
+
+        self._config = _types.SimpleNamespace(db_path=str(db_path))
+        self._db_path = str(db_path)
+
+    async def save_memory(
+        self,
+        *,
+        content: str,
+        user_id: str,
+        importance: float,
+        metadata: dict,
+    ):
+        import json as _json
+        import sqlite3 as _sql
+        import types as _types
+        import uuid
+
+        mid = str(uuid.uuid4())
+        conn = _sql.connect(self._db_path)
+        try:
+            conn.execute(
+                "INSERT INTO memories (id, content, metadata, entity_refs, importance) "
+                "VALUES (?,?,?,?,?)",
+                (mid, content, _json.dumps(metadata), "[]", importance),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return _types.SimpleNamespace(id=mid)
+
+
+def _init_db(path):
+    import sqlite3 as _sql
+
+    conn = _sql.connect(path)
+    conn.execute(
+        "CREATE TABLE memories ("
+        "id TEXT PRIMARY KEY, content TEXT NOT NULL, "
+        "metadata TEXT NOT NULL DEFAULT '{}', "
+        "entity_refs TEXT NOT NULL DEFAULT '[]', "
+        "importance REAL NOT NULL DEFAULT 0.5)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _read_traffic_rows(db_path):
+    import json as _json
+    import sqlite3 as _sql
+
+    conn = _sql.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, content, metadata FROM memories "
+            "WHERE json_extract(metadata, '$.source') = 'traffic_learner'"
+        ).fetchall()
+    finally:
+        conn.close()
+    return [(r[0], r[1], _json.loads(r[2])) for r in rows]
+
+
+async def _wait_for_saved(learner: TrafficLearner, count: int, db_path) -> None:
+    """Wait until at least `count` traffic_learner rows exist in the DB."""
+    import asyncio as _asyncio
+
+    for _ in range(100):
+        if len(_read_traffic_rows(db_path)) >= count:
+            return
+        await _asyncio.sleep(0.02)
+    raise AssertionError(
+        f"Timeout waiting for {count} saved row(s); got {len(_read_traffic_rows(db_path))}"
+    )
+
+
+class TestEvidencePersistence:
+    @pytest.mark.asyncio
+    async def test_save_persists_actual_evidence_count(self, tmp_path):
+        """The count written to the DB reflects total sightings, not the default 1."""
+        db = tmp_path / "memory.db"
+        _init_db(db)
+        backend = _FakeBackend(db)
+        learner = TrafficLearner(backend=backend, min_evidence=3)
+        await learner.start()
+
+        pattern_kwargs = {
+            "category": PatternCategory.ENVIRONMENT,
+            "content": "Use /usr/bin/python3 for system scripts.",
+            "importance": 0.6,
+        }
+        for _ in range(3):
+            await learner._accumulate(ExtractedPattern(**pattern_kwargs))
+        await _wait_for_saved(learner, 1, db)
+        await learner.stop()
+
+        rows = _read_traffic_rows(db)
+        assert len(rows) == 1
+        assert rows[0][2]["evidence_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_resighting_bumps_persisted_row(self, tmp_path):
+        """Sightings after save bump the existing row instead of creating duplicates."""
+        db = tmp_path / "memory.db"
+        _init_db(db)
+        backend = _FakeBackend(db)
+        learner = TrafficLearner(backend=backend, min_evidence=2)
+        await learner.start()
+
+        def mk() -> ExtractedPattern:
+            return ExtractedPattern(
+                category=PatternCategory.PREFERENCE,
+                content="User preference: terse replies.",
+                importance=0.7,
+            )
+
+        # Two sightings → save with evidence_count=2.
+        await learner._accumulate(mk())
+        await learner._accumulate(mk())
+        await _wait_for_saved(learner, 1, db)
+
+        # Three more sightings → three bumps.
+        for _ in range(3):
+            await learner._accumulate(mk())
+        await learner.stop()
+
+        rows = _read_traffic_rows(db)
+        assert len(rows) == 1, "re-sightings must not create duplicate rows"
+        assert rows[0][2]["evidence_count"] == 5
+
+    @pytest.mark.asyncio
+    async def test_hydrate_prevents_cross_session_duplicates(self, tmp_path):
+        """A second session re-sighting an already-persisted pattern bumps, doesn't insert."""
+        import json as _json
+        import sqlite3 as _sql
+
+        db = tmp_path / "memory.db"
+        _init_db(db)
+
+        # Session 1 row pre-seeded directly.
+        seeded_content = "Command `foo` fails; use `bar` instead."
+        conn = _sql.connect(db)
+        conn.execute(
+            "INSERT INTO memories (id, content, metadata, entity_refs, importance) "
+            "VALUES (?,?,?,?,?)",
+            (
+                "seed-id",
+                seeded_content,
+                _json.dumps(
+                    {
+                        "source": "traffic_learner",
+                        "category": "error_recovery",
+                        "evidence_count": 2,
+                    }
+                ),
+                "[]",
+                0.7,
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        # Session 2: fresh learner, hydrates from DB on start().
+        backend = _FakeBackend(db)
+        learner = TrafficLearner(backend=backend, min_evidence=2)
+        await learner.start()
+
+        def mk() -> ExtractedPattern:
+            return ExtractedPattern(
+                category=PatternCategory.ERROR_RECOVERY,
+                content=seeded_content,
+                importance=0.7,
+            )
+
+        # Two sightings: both should bump the seeded row (no duplicates).
+        await learner._accumulate(mk())
+        await learner._accumulate(mk())
+        await learner.stop()
+
+        rows = _read_traffic_rows(db)
+        assert len(rows) == 1
+        assert rows[0][0] == "seed-id"
+        assert rows[0][2]["evidence_count"] == 4


### PR DESCRIPTION
## Description

Turns `--learn` mode from "quietly collects patterns in the DB" into "actually writes them to `CLAUDE.md` / `MEMORY.md` as it goes", and fixes the evidence-counting chain that was preventing any pattern from crossing the live-flush gate.

Two commits, reviewable independently:

1. **`feat(learn): live flush of traffic patterns to agent-native context files`** — replaces the shutdown-only `flush_to_file` with a dirty-flag debounced `_flush_worker` (10s window) that runs for the lifetime of the proxy. Flushes read both the persisted memory DB and the in-memory accumulator, bucket patterns per-project via the learn plugin registry + longest-path anchoring (`_project_for_pattern`), and route by `PatternCategory` to `CLAUDE.md` (context file) or `MEMORY.md` (memory file) via `_patterns_to_recommendations`.
2. **`fix(learn): persist real evidence_count and bump on re-sighting`** — fixes the chain where every `traffic_learner` DB row landed with `evidence_count = 1` (so the new live-flush gate always rejected them), and where cross-session re-sightings created duplicate rows instead of bumping the existing one. `_accumulate` now writes the real accumulated count at save time, `start()` hydrates dedup state from the DB, and re-sightings atomically `json_set` the persisted row's `evidence_count`.

The fix commit is the one that unblocks user-visible behavior in `--learn` mode; the feat commit is the infrastructure it runs on.

> **CI note:** this PR is based on current `main`, which has a red CI since #229 merged. The test failures reported by CI on this branch are the exact set fixed by #235 (`test_cli/*`, `test_proxy_copilot_auth_hooks`, `test_release_version`, `test_proxy_openai_cache_stability`, `test_proxy_passthrough_integration`, `test_proxy_streaming_ratelimit_headers`, `test_telemetry_warning`). None are caused by this PR, and all clear once #235 lands. Happy to rebase once #235 merges.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

**`feat` commit (`headroom/memory/traffic_learner.py`, `tests/test_memory/test_traffic_learner.py`):**

- New `FLUSH_DEBOUNCE_SECONDS = 10.0` gate, `_flush_dirty` / `_last_flush_at` / `_flush_task` state on `TrafficLearner`.
- `TrafficLearner.start()` spawns `_flush_worker`; `_flush_worker` polls every 2s and calls `flush_to_file()` when dirty past the debounce window.
- `_accumulate()` sets `_flush_dirty = True` on every sighting.
- `flush_to_file()` now reads persisted rows via new `_load_persisted_patterns_from_sqlite()` + `_resolve_backend_db_path()`, merges with the in-memory accumulator via `_collect_all_patterns()`, buckets patterns per-project via `plugin.discover_projects()` + `_project_for_pattern()` (longest-matching-root on content or `entity_refs`), and writes via the learn plugin's `create_writer()`.
- Category routing via `_patterns_to_recommendations()` + `_CATEGORY_TO_TARGET` (error-recovery/environment → `CLAUDE.md`; preference → `MEMORY.md`; architecture → `CLAUDE.md`).
- Live flushes require `evidence_count >= 2`; shutdown flushes accept single-evidence rows.

**`fix` commit (same two files + `CHANGELOG.md`):**

- `_accumulate` now sets `pattern.evidence_count = count` before enqueuing, so the persisted row reflects the real accumulated count (not the dataclass default `1`).
- New `_persisted_ids: dict[str, str]` maps content_hash → `memory.id` for bumps.
- `_save_worker` captures `memory.id` from `save_memory(...)` and records it.
- New `_hydrate_persisted_state()` called from `start()` reads existing `traffic_learner` rows and seeds `_saved_hashes` + `_persisted_ids` so cross-session re-sightings bump instead of duplicating.
- New `_bump_persisted_evidence(memory_id)` runs an atomic `UPDATE memories SET metadata = json_set(metadata, '$.evidence_count', COALESCE(..., 0) + 1) WHERE id = ?` via `asyncio.to_thread` to keep the proxy hot path non-blocking.
- `_accumulate`'s saved-hash branch now awaits the bump instead of dropping the sighting.
- `_load_persisted_patterns_from_sqlite` and `_hydrate_persisted_state` filter by `json_extract(metadata, '$.source') = 'traffic_learner'` instead of a `LIKE` on raw JSON — required because the bump path uses `json_set`, which rewrites metadata without the default `": "` spacing (would otherwise make the `LIKE` blind to bumped rows).

## Testing

- [x] Unit tests pass (`pytest`) _(for tests in the modules this PR touches; the 49 failures on `main` are the #235 set and are unrelated — see CI note above)_
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

**New tests (`tests/test_memory/test_traffic_learner.py`):**

- `TestProjectForPattern` (4 cases) — longest-path matching, `entity_refs` anchoring, prefix-boundary safety, un-anchored returns None.
- `TestLoadPersistedPatterns` (4 cases) — dedup by content + evidence-count summing, source filtering, importance column, unknown category skipped.
- `TestPatternsToRecommendations` (3 cases) — preference → MEMORY_FILE, environment → CONTEXT_FILE, category grouping with evidence-desc sort.
- `TestFlushDebounce` — bursty dirty flags produce bounded flush count (rate-limited).
- `TestEvidencePersistence` (3 cases) — save persists real count, re-sightings bump existing row without duplicating, cross-session hydration prevents duplicates.

**Manual verification**: on the reporter's local `memory.db`, before the fix 107 `traffic_learner` rows were pinned at `evidence_count = 1` with 3 duplicate-content pairs (symptom of the cross-session insert bug); the new bump path produces monotonically increasing counts on re-sightings and inserts no duplicates (verified via unit tests end-to-end through a real SQLite file).

## Test Output

```
$ pytest tests/test_memory/test_traffic_learner.py -v
...
tests/test_memory/test_traffic_learner.py::TestEvidencePersistence::test_save_persists_actual_evidence_count PASSED
tests/test_memory/test_traffic_learner.py::TestEvidencePersistence::test_resighting_bumps_persisted_row PASSED
tests/test_memory/test_traffic_learner.py::TestEvidencePersistence::test_hydrate_prevents_cross_session_duplicates PASSED
============================== 33 passed in 1.57s ==============================

$ ruff check headroom/memory/traffic_learner.py tests/test_memory/test_traffic_learner.py
All checks passed!

$ ruff format --check headroom/memory/traffic_learner.py tests/test_memory/test_traffic_learner.py
2 files already formatted

$ mypy headroom/memory/traffic_learner.py
Success: no issues found in 1 source file

$ pytest -q --ignore=tests/integrations --ignore=tests/e2e
# 49 failed, 4092 passed, 372 skipped
# All 49 failures are the same set #235 fixes — none touch traffic_learner
# or memory; confirmed identical failures on upstream/main without this PR.
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes _(for everything this PR touches; the 49 unrelated failures are the #235 set)_
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

- The fix affects **every `--learn` user**, not just desktop-app users: the evidence-count bug was in the core `TrafficLearner` save path, independent of how `flush_to_file` is invoked. After the fix, `traffic_learner` rows in `memory.db` will correctly reflect how many times a pattern has been observed, and cross-session re-sightings bump rather than duplicate.
- Existing DB rows already stuck at `evidence_count = 1` stay there until re-sighted — there's no backfill script in this PR. A one-off `UPDATE memories SET metadata = json_set(metadata, '$.evidence_count', 2) WHERE json_extract(metadata, '$.source') = 'traffic_learner' AND json_extract(metadata, '$.evidence_count') = 1` would unstick them immediately if desired, but felt out of scope here.