### PR TITLE
fix: Fix MCP command resolution to use stable CLI entrypoint

### DIFF
--- a/headroom/cli/mcp.py
+++ b/headroom/cli/mcp.py
@@ -8,7 +8,6 @@ needing API key access.
 import json
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -25,15 +24,9 @@ DEFAULT_PROXY_URL = "http://127.0.0.1:8787"
 def get_headroom_command() -> list[str]:
     """Get the command to run headroom MCP server.
 
-    Returns the most reliable way to invoke headroom based on installation.
+    Returns the CLI invocation used by Claude Code config.
     """
-    # Check if headroom is in PATH
-    headroom_path = shutil.which("headroom")
-    if headroom_path:
-        return ["headroom", "mcp", "serve"]
-
-    # Fall back to python -m
-    return [sys.executable, "-m", "headroom.ccr.mcp_server"]
+    return ["headroom", "mcp", "serve"]
 
 
 def load_mcp_config() -> dict[str, Any]:


### PR DESCRIPTION
## Description

Fixes the CLI test cascade by addressing two related issues in the MCP + wrap-copilot test path:

1. Prevents cross-test pollution from import-time `sys.modules` mutation in wrap-copilot tests.
2. Makes MCP install command generation deterministic so config always uses `command = "headroom"` with `args = ["mcp", "serve"]`.

Motivation: CI on main was red after #229 due to `headroom.cli.mcp` attribute lookup failures and subsequent `test_cli/*` cascade failures.

Fixes #234

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Scoped `sys.modules` mutation in wrap-copilot tests so it does not leak globally during pytest collection.
- Kept CLI subcommand module binding resilient after package re-import so `headroom.cli.<subcommand>` lookups remain available.
- Updated MCP command construction to consistently emit the CLI command form expected by tests and runtime config.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

## Test Output

```text
pytest -q tests/test_cli/test_mcp.py tests/test_cli/test_wrap_copilot.py

========================== test session starts ===========================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/omthorat/Opensource/headroom
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 39 items

tests/test_cli/test_mcp.py ...................sss........          [ 76%]
tests/test_cli/test_wrap_copilot.py .........                      [100%]

================ 36 passed, 3 skipped, 1 warning in 0.38s ================
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

- This PR is intentionally focused on unblocking CI and test stability in the CLI path.
- The pytest warning about `asyncio_mode` is pre-existing and unrelated to this fix.
