### PR TITLE
ci(docker): clean up image tags, signatures, and Latest indicator

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,6 +97,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute short SHA
+        id: short-sha
+        run: printf 'sha=%s\n' "${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata (variant)
         id: meta
         uses: docker/metadata-action@v6
@@ -106,6 +110,8 @@ jobs:
             type=ref,event=branch,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=ref,event=pr,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
+            type=raw,value=${{ steps.version.outputs.version }}-${{ steps.short-sha.outputs.sha }},enable=${{ steps.version.outputs.version != '' && matrix.variant == '' }}
+            type=raw,value=${{ steps.version.outputs.version }}-${{ matrix.variant }}-${{ steps.short-sha.outputs.sha }},enable=${{ steps.version.outputs.version != '' && matrix.variant != '' }}
             type=semver,pattern={{version}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=semver,pattern={{major}}.{{minor}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=semver,pattern={{major}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,8 +103,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
           tags: |
-            type=ref,event=branch,enable=${{ inputs.enable_ref_tags }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
-            type=ref,event=pr,enable=${{ inputs.enable_ref_tags }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
+            type=ref,event=branch,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
+            type=ref,event=pr,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=semver,pattern={{version}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=semver,pattern={{major}}.{{minor}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -109,9 +109,8 @@ jobs:
             type=semver,pattern={{version}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=semver,pattern={{major}}.{{minor}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
             type=semver,pattern={{major}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
-            type=sha,prefix=${{ matrix.variant != '' && format('{0}-', matrix.variant) || 'sha-' }}
+            type=sha,format=short,prefix=${{ matrix.variant != '' && format('{0}-', matrix.variant) || 'sha-' }}
             type=raw,value=${{ matrix.variant }},enable=${{ matrix.variant != '' }}
-            type=raw,value=latest,enable=${{ matrix.variant == '' }}
 
       - name: Build and push variant (bake)
         id: bake
@@ -133,12 +132,71 @@ jobs:
       - name: Sign images with cosign (keyless via Sigstore OIDC)
         env:
           BAKE_META: ${{ steps.bake.outputs.metadata }}
+          # Route signatures to a sibling GHCR package so the main image's
+          # package version list stays clean. GHCR does not implement the OCI 1.1
+          # referrers API yet (community discussion #163029, June 2025), so
+          # cosign's OCI 1.1 mode falls back to writing referrer tags into the
+          # *image's* repo. Using legacy signature mode here lets COSIGN_REPOSITORY
+          # actually relocate the artifacts. Verifiers must export the same
+          # COSIGN_REPOSITORY value when running 'cosign verify'.
+          COSIGN_REPOSITORY: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}-signatures
         run: |
-          # Extract all pushed image digests from bake metadata and sign each
           echo "$BAKE_META" | jq -r '
             to_entries[].value."containerimage.digest" // empty
           ' | while read -r digest; do
             image="${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}@${digest}"
-            echo "Signing ${image}"
+            echo "Signing ${image} (signatures -> ${COSIGN_REPOSITORY})"
             cosign sign --yes "${image}"
           done
+
+  promote-latest:
+    # Re-push the :latest tag pointing at the root variant *after* every
+    # variant matrix job has finished, so GHCR's package version listing
+    # (sorted by created_at) shows the root image with :latest at the top
+    # instead of whichever variant happened to finish last.
+    needs: docker-variant-tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Normalize image name
+        id: image-name
+        run: |
+          image_name="$(printf '%s' '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          printf 'image_name=%s\n' "$image_name" >> "$GITHUB_OUTPUT"
+
+      - name: Determine image version
+        id: version
+        env:
+          MANUAL_VERSION: ${{ inputs.version || github.event.inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${MANUAL_VERSION#v}"
+          if [ -z "$version" ] && [ -n "$RELEASE_TAG" ]; then
+            version="${RELEASE_TAG#v}"
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-tag root image as :latest
+        if: steps.version.outputs.version != ''
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Add a unique annotation so the resulting image index manifest gets
+          # a new digest, which makes GHCR record a fresh package version with
+          # current timestamp (otherwise the existing root manifest is reused
+          # and stays where it was in the version listing).
+          promoted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          docker buildx imagetools create \
+            --annotation "index:io.headroom.promoted-at=${promoted_at}" \
+            --tag "${IMAGE}:latest" \
+            "${IMAGE}:${VERSION}"


### PR DESCRIPTION
## Description

- Replace full-sha image tags with type=sha,format=short (7-char) so the primary package versions list stops accumulating long sha-only entries.
- Route cosign signatures into a sibling GHCR package via COSIGN_REPOSITORY=<image>-signatures, so the main image's package version list stays clean. GHCR does not yet implement the OCI 1.1 Distribution Referrers API (community discussion #163029, June 2025), so legacy signature mode is used here -- OCI 1.1 mode would force the signature manifest's subject into the same repo as the image and override COSIGN_REPOSITORY. Verifiers must export the same COSIGN_REPOSITORY value when running 'cosign verify'.
- Add a promote-latest job that runs after the variant matrix and re-pushes the :latest tag pointing at the root image with a unique index annotation. This forces a fresh manifest digest, generating a new GHCR package version with current timestamp so :latest sits at the top of the version listing instead of whichever variant happened to finish last.

### before 

<img width="773" height="688" alt="image" src="https://github.com/user-attachments/assets/47cc4dab-780b-40e0-9795-4ab8cc3137cc" />


### after 

<img width="1672" height="910" alt="image" src="https://github.com/user-attachments/assets/1195325b-708f-4953-990b-9c0663345a22" />

> it won't under my username duhhh