### PR TITLE
ci(docker): fix Argument list too long when signing bake outputs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.11.0"
+    "version": "0.10.18"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.11.0",
+      "version": "0.10.18",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.11.0"
+    "version": "0.10.18"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.11.0",
+      "version": "0.10.18",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -137,7 +137,6 @@ jobs:
 
       - name: Sign images with cosign (keyless via Sigstore OIDC)
         env:
-          BAKE_META: ${{ steps.bake.outputs.metadata }}
           # Route signatures to a sibling GHCR package so the main image's
           # package version list stays clean. GHCR does not implement the OCI 1.1
           # referrers API yet (community discussion #163029, June 2025), so
@@ -147,9 +146,22 @@ jobs:
           # COSIGN_REPOSITORY value when running 'cosign verify'.
           COSIGN_REPOSITORY: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}-signatures
         run: |
-          echo "$BAKE_META" | jq -r '
-            to_entries[].value."containerimage.digest" // empty
-          ' | while read -r digest; do
+          # Write bake metadata to a file rather than pass it through
+          # the `env:` block. The `code-nonroot` and `runtime-code-nonroot`
+          # bake targets emit metadata blobs large enough that combined
+          # argv+env at bash spawn exceeds Linux ARG_MAX (~128 KiB on
+          # ubuntu-latest), failing with `E2BIG: Argument list too long`
+          # before the script can run. The heredoc puts the JSON in the
+          # script body (which is read from a temp file by bash, no
+          # ARG_MAX limit) and we read it back via `jq -f`-style file
+          # input. Sentinel chosen long enough that no JSON payload is
+          # plausibly going to collide with it.
+          cat > "${RUNNER_TEMP}/bake_meta.json" <<'__HEADROOM_BAKE_META_EOF__'
+          ${{ steps.bake.outputs.metadata }}
+          __HEADROOM_BAKE_META_EOF__
+
+          jq -r 'to_entries[].value."containerimage.digest" // empty' \
+              "${RUNNER_TEMP}/bake_meta.json" | while read -r digest; do
             image="${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}@${digest}"
             echo "Signing ${image} (signatures -> ${COSIGN_REPOSITORY})"
             cosign sign --yes "${image}"

--- a/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.11.0",
+  "version": "0.10.18",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/plugins/headroom-agent-hooks/.github/plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.11.0",
+  "version": "0.10.18",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",


### PR DESCRIPTION
## Summary
- Cosign signing step in `publish-docker / docker-variant-tags` was failing for the `code-nonroot` and `runtime-code-nonroot` bake targets with `Argument list too long`.
- Root cause: `BAKE_META: \${{ steps.bake.outputs.metadata }}` was passed as an env var. For those large variants the JSON metadata pushes combined argv+env past Linux ARG_MAX (~128 KiB on ubuntu-latest), so bash dies with E2BIG before the script body can run.
- Fix: write metadata into `\${RUNNER_TEMP}/bake_meta.json` via a single-quoted heredoc and feed it to `jq` from disk. Heredoc bodies live in the script (read by bash from a temp file), so they don't count against env size.

## Failing run
- https://github.com/chopratejas/headroom/actions/runs/25015075740/job/73260660994

## Test plan
- [x] `make ci-precheck` (commitlint, ruff, mypy, pytest, cargo fmt/clippy/test) green locally before push
- [ ] On this PR, the `publish-docker / docker-variant-tags` matrix succeeds for all 8 variants — including `code-nonroot` and `runtime-code-nonroot`
- [ ] Cosign signatures land in `\${REGISTRY}/\${image}-signatures` as before; verify by checking package version listing on GHCR after merge