### PR TITLE
chore(rust): port ContentRouter types/config/cache to Rust + PyO3 bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1284,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1302,6 +1322,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "criterion",
+ "dashmap",
  "fastembed",
  "flate2",
  "hf-hub 0.4.3",
@@ -1915,6 +1936,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2386,19 @@ dependencies = [
  "hmac-sha256",
  "lzma-rust2",
  "ureq 3.3.0",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -2856,6 +2899,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3127,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"

--- a/crates/headroom-core/Cargo.toml
+++ b/crates/headroom-core/Cargo.toml
@@ -49,6 +49,11 @@ flate2 = "1"
 # Same library + same model = byte-equal embeddings between Python and Rust
 # (both call into ONNX Runtime over the identical ONNX file).
 fastembed = "5"
+# `dashmap` provides a sharded concurrent map. The `ContentRouter`'s
+# `CompressionCache` is read/written from every worker thread on the
+# proxy hot path; sharding avoids the contention a single `Mutex<HashMap>`
+# would create. Using v6 (latest) with default features.
+dashmap = "6"
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/headroom-core/src/transforms/content_router/cache.rs
+++ b/crates/headroom-core/src/transforms/content_router/cache.rs
@@ -1,0 +1,374 @@
+//! Two-tier TTL cache used by the `ContentRouter` to skip work on
+//! repeat content.
+//!
+//! Mirrors `headroom.transforms.content_router.CompressionCache`:
+//!
+//! - **Tier 1 (skip set)**: hashes of content that *won't* compress.
+//!   Hits are near-zero-cost (just a key lookup) and let the router
+//!   pass-through known-incompressible payloads without re-running any
+//!   compressor.
+//! - **Tier 2 (result cache)**: cached compressed text + ratio +
+//!   strategy for content that *did* compress, so subsequent identical
+//!   requests reuse the result.
+//!
+//! Entries expire after a fixed TTL (default 30 minutes). There's no
+//! max-entries cap — TTL is the natural bound, and memory grows with
+//! `compressible_content × TTL`, which is bounded by session duration.
+//!
+//! # Concurrency
+//!
+//! The proxy serves requests on a thread pool; the router's hot path
+//! shares one cache across all workers. We use `DashMap` (sharded
+//! concurrent map) so puts/gets don't block each other under load.
+//! That's the same pattern PR9 used for the CCR store and gave us
+//! ~4× throughput on multi-worker benches.
+//!
+//! # Stats
+//!
+//! Counters (`hits`, `misses`, `skip_hits`, `evictions`,
+//! `total_lookup_ns`, `lookup_count`) are exposed via [`CompressionCache::stats`].
+//! They're informational — telemetry can scrape them periodically.
+//! Counts use `AtomicU64` so updates don't take any cache lock.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+/// Default TTL: 30 minutes. Matches Python's default.
+pub const DEFAULT_TTL_SECONDS: u64 = 1800;
+
+/// Tier-2 entry: cached compression result.
+#[derive(Debug, Clone)]
+struct ResultEntry {
+    compressed: String,
+    ratio: f64,
+    strategy: String,
+    inserted: Instant,
+}
+
+/// Tier-1 entry: marker that this hash is known non-compressible.
+#[derive(Debug, Clone, Copy)]
+struct SkipEntry {
+    inserted: Instant,
+}
+
+/// Two-tier TTL cache. Cheap to clone (it's an `Arc` internally via
+/// `DashMap`), so handing the same cache to multiple worker threads is
+/// just a refcount bump.
+#[derive(Debug)]
+pub struct CompressionCache {
+    results: DashMap<u64, ResultEntry>,
+    skip: DashMap<u64, SkipEntry>,
+    ttl: Duration,
+    // Counters
+    hits: AtomicU64,
+    misses: AtomicU64,
+    skip_hits: AtomicU64,
+    evictions: AtomicU64,
+    total_lookup_ns: AtomicU64,
+    lookup_count: AtomicU64,
+}
+
+/// Snapshot of cache counters at a point in time.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub skip_hits: u64,
+    pub evictions: u64,
+    pub size: u64,
+    pub skip_size: u64,
+    /// Average lookup latency in nanoseconds. `0` when no lookups have
+    /// happened yet (we don't divide by zero).
+    pub avg_lookup_ns: f64,
+}
+
+/// Result returned by [`CompressionCache::get`] on a hit.
+#[derive(Debug, Clone)]
+pub struct CachedResult {
+    pub compressed: String,
+    pub ratio: f64,
+    pub strategy: String,
+}
+
+impl CompressionCache {
+    /// New cache with the default 30-minute TTL.
+    pub fn new() -> Self {
+        Self::with_ttl(Duration::from_secs(DEFAULT_TTL_SECONDS))
+    }
+
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            results: DashMap::new(),
+            skip: DashMap::new(),
+            ttl,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            skip_hits: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
+            total_lookup_ns: AtomicU64::new(0),
+            lookup_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Look up a Tier-2 cached result. `None` if missing or expired.
+    /// Increments `hits` / `misses` / lookup-latency stats.
+    ///
+    /// Always check [`is_skipped`](Self::is_skipped) first — a hit there
+    /// means the content is known not to compress and the router should
+    /// short-circuit without ever running this lookup.
+    pub fn get(&self, key: u64) -> Option<CachedResult> {
+        let t0 = Instant::now();
+        let outcome = self.results.get(&key);
+        let result = match outcome {
+            Some(entry) => {
+                if entry.inserted.elapsed() < self.ttl {
+                    let r = CachedResult {
+                        compressed: entry.compressed.clone(),
+                        ratio: entry.ratio,
+                        strategy: entry.strategy.clone(),
+                    };
+                    drop(entry);
+                    self.hits.fetch_add(1, Ordering::Relaxed);
+                    Some(r)
+                } else {
+                    drop(entry);
+                    self.results.remove(&key);
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
+                    self.misses.fetch_add(1, Ordering::Relaxed);
+                    None
+                }
+            }
+            None => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        };
+        self.total_lookup_ns
+            .fetch_add(t0.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        self.lookup_count.fetch_add(1, Ordering::Relaxed);
+        result
+    }
+
+    /// Tier-1 check: is this key known to be incompressible? Increments
+    /// `skip_hits` on a hit. Drops expired entries on the way through.
+    pub fn is_skipped(&self, key: u64) -> bool {
+        if let Some(entry) = self.skip.get(&key) {
+            if entry.inserted.elapsed() < self.ttl {
+                drop(entry);
+                self.skip_hits.fetch_add(1, Ordering::Relaxed);
+                return true;
+            }
+            drop(entry);
+            self.skip.remove(&key);
+            self.evictions.fetch_add(1, Ordering::Relaxed);
+        }
+        false
+    }
+
+    /// Store a compressed result in Tier 2. Overwrites any existing
+    /// entry for the same key — same content under the same hash is
+    /// idempotent.
+    pub fn put(&self, key: u64, compressed: String, ratio: f64, strategy: String) {
+        self.results.insert(
+            key,
+            ResultEntry {
+                compressed,
+                ratio,
+                strategy,
+                inserted: Instant::now(),
+            },
+        );
+    }
+
+    /// Mark a key as known-non-compressible (Tier 1). Cheap; the
+    /// router calls this when a compress attempt didn't improve the
+    /// payload.
+    pub fn mark_skip(&self, key: u64) {
+        self.skip.insert(
+            key,
+            SkipEntry {
+                inserted: Instant::now(),
+            },
+        );
+    }
+
+    /// Move a Tier-2 entry into Tier 1. Used when an external
+    /// threshold tightens (e.g. context pressure rose) and the
+    /// previously-cached result no longer qualifies as a worthwhile
+    /// compression. Removes the result entry.
+    pub fn move_to_skip(&self, key: u64) {
+        self.results.remove(&key);
+        self.skip.insert(
+            key,
+            SkipEntry {
+                inserted: Instant::now(),
+            },
+        );
+    }
+
+    /// Number of live Tier-2 result entries.
+    pub fn size(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Number of live Tier-1 skip entries.
+    pub fn skip_size(&self) -> usize {
+        self.skip.len()
+    }
+
+    /// Snapshot of all counters. Cheap; counters are atomic.
+    pub fn stats(&self) -> CacheStats {
+        let lookups = self.lookup_count.load(Ordering::Relaxed);
+        let total_ns = self.total_lookup_ns.load(Ordering::Relaxed);
+        CacheStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            skip_hits: self.skip_hits.load(Ordering::Relaxed),
+            evictions: self.evictions.load(Ordering::Relaxed),
+            size: self.results.len() as u64,
+            skip_size: self.skip.len() as u64,
+            avg_lookup_ns: if lookups > 0 {
+                total_ns as f64 / lookups as f64
+            } else {
+                0.0
+            },
+        }
+    }
+
+    /// Clear both tiers. Counter values are *not* reset — they remain
+    /// useful across cache lifecycles for telemetry. If you need
+    /// counter reset, build a fresh cache.
+    pub fn clear(&self) {
+        self.results.clear();
+        self.skip.clear();
+    }
+}
+
+impl Default for CompressionCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn put_then_get_returns_value() {
+        let c = CompressionCache::new();
+        c.put(42, "compressed".into(), 0.5, "smart_crusher".into());
+        let r = c.get(42).expect("hit");
+        assert_eq!(r.compressed, "compressed");
+        assert_eq!(r.ratio, 0.5);
+        assert_eq!(r.strategy, "smart_crusher");
+    }
+
+    #[test]
+    fn miss_returns_none_and_increments_misses() {
+        let c = CompressionCache::new();
+        assert!(c.get(7).is_none());
+        let s = c.stats();
+        assert_eq!(s.misses, 1);
+        assert_eq!(s.hits, 0);
+    }
+
+    #[test]
+    fn put_overwrites_under_same_key() {
+        let c = CompressionCache::new();
+        c.put(1, "first".into(), 0.5, "a".into());
+        c.put(1, "second".into(), 0.4, "b".into());
+        let r = c.get(1).unwrap();
+        assert_eq!(r.compressed, "second");
+        assert_eq!(c.size(), 1);
+    }
+
+    #[test]
+    fn ttl_expires_results_on_get() {
+        let c = CompressionCache::with_ttl(Duration::from_millis(10));
+        c.put(1, "v".into(), 0.5, "s".into());
+        std::thread::sleep(Duration::from_millis(25));
+        assert!(c.get(1).is_none());
+        assert_eq!(c.size(), 0);
+        assert!(c.stats().evictions >= 1);
+    }
+
+    #[test]
+    fn skip_set_blocks_compression() {
+        let c = CompressionCache::new();
+        c.mark_skip(99);
+        assert!(c.is_skipped(99));
+        assert_eq!(c.stats().skip_hits, 1);
+    }
+
+    #[test]
+    fn ttl_expires_skip_set() {
+        let c = CompressionCache::with_ttl(Duration::from_millis(10));
+        c.mark_skip(1);
+        std::thread::sleep(Duration::from_millis(25));
+        assert!(!c.is_skipped(1));
+        assert_eq!(c.skip_size(), 0);
+    }
+
+    #[test]
+    fn move_to_skip_clears_result() {
+        let c = CompressionCache::new();
+        c.put(1, "v".into(), 0.5, "s".into());
+        c.move_to_skip(1);
+        assert!(c.get(1).is_none());
+        assert!(c.is_skipped(1));
+    }
+
+    #[test]
+    fn clear_drops_both_tiers() {
+        let c = CompressionCache::new();
+        c.put(1, "v".into(), 0.5, "s".into());
+        c.mark_skip(2);
+        c.clear();
+        assert_eq!(c.size(), 0);
+        assert_eq!(c.skip_size(), 0);
+    }
+
+    #[test]
+    fn stats_avg_lookup_zero_when_no_lookups() {
+        let c = CompressionCache::new();
+        assert_eq!(c.stats().avg_lookup_ns, 0.0);
+    }
+
+    #[test]
+    fn cache_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CompressionCache>();
+    }
+
+    #[test]
+    fn concurrent_puts_and_gets_are_safe() {
+        // 8 threads, 1000 ops each, mix of put/get/mark_skip. Stress
+        // the DashMap-backed sharding under contention. The point is
+        // not "fast" but "doesn't panic / corrupt counters".
+        let c = std::sync::Arc::new(CompressionCache::new());
+        let mut handles = Vec::new();
+        for t in 0..8u64 {
+            let c = c.clone();
+            handles.push(thread::spawn(move || {
+                for i in 0..1000u64 {
+                    let key = t * 1000 + i;
+                    c.put(key, format!("c{key}"), 0.5, "s".into());
+                    let _ = c.get(key);
+                    if i % 7 == 0 {
+                        c.mark_skip(key);
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        let stats = c.stats();
+        // Sanity: hits + misses == lookup_count (we only call get).
+        assert_eq!(stats.hits + stats.misses, 8 * 1000);
+    }
+}

--- a/crates/headroom-core/src/transforms/content_router/config.rs
+++ b/crates/headroom-core/src/transforms/content_router/config.rs
@@ -1,0 +1,135 @@
+//! `ContentRouter` configuration.
+//!
+//! Mirrors the simple fields of
+//! `headroom.transforms.content_router.ContentRouterConfig`. The
+//! complex Python-only fields — `exclude_tools`, `read_lifecycle`,
+//! `tool_profiles` — feed the `apply()` proxy entry point and are
+//! ported in PR6 along with that pipeline. They're deliberately
+//! omitted here so PR2 stays focused on the dispatch-decision data.
+
+use super::types::CompressionStrategy;
+
+/// Configuration knobs the `ContentRouter` reads at compress time.
+/// All defaults match Python.
+#[derive(Debug, Clone)]
+pub struct ContentRouterConfig {
+    // ── Enable/disable specific compressors ──────────────────────────
+    /// Disabled by default — code passes through unmangled (Python:
+    /// `enable_code_aware = False`).
+    pub enable_code_aware: bool,
+    pub enable_kompress: bool,
+    pub enable_smart_crusher: bool,
+    pub enable_search_compressor: bool,
+    pub enable_log_compressor: bool,
+    pub enable_html_extractor: bool,
+    pub enable_image_optimizer: bool,
+
+    // ── Routing preferences ──────────────────────────────────────────
+    pub prefer_code_aware_for_code: bool,
+    /// Minimum number of distinct content types to consider a payload
+    /// "mixed". `2` matches Python.
+    pub mixed_content_threshold: usize,
+    /// Sections smaller than this don't justify the per-section
+    /// compress overhead.
+    pub min_section_tokens: usize,
+
+    /// Strategy applied when no compressor matches the detected type.
+    pub fallback_strategy: CompressionStrategy,
+
+    // ── Protection: "don't compress what's likely the analysis subject"
+    pub skip_user_messages: bool,
+    /// Don't compress code in the last N messages. `0` disables.
+    pub protect_recent_code: usize,
+    pub protect_analysis_context: bool,
+
+    /// Fraction of total messages to protect from compression for
+    /// adaptive Read protection. `0.0` = always exclude all (safest
+    /// for coding agents).
+    pub protect_recent_reads_fraction: f64,
+
+    // ── Adaptive compression ratio ───────────────────────────────────
+    /// Threshold when context is mostly empty.
+    pub min_ratio_relaxed: f64,
+    /// Threshold when context is nearly full.
+    pub min_ratio_aggressive: f64,
+
+    // ── CCR settings (forwarded to SmartCrusher) ─────────────────────
+    pub ccr_enabled: bool,
+    pub ccr_inject_marker: bool,
+
+    /// Tag protection: when `false`, entire `<custom-tag>...</custom-tag>`
+    /// blocks are protected verbatim. When `true`, only the markers are
+    /// protected and inner content is compressed.
+    pub compress_tagged_content: bool,
+    //
+    // Deferred to PR6 (proxy `apply()` port):
+    //   - exclude_tools: Option<HashSet<String>>
+    //   - read_lifecycle: ReadLifecycleConfig
+    //   - tool_profiles: Option<HashMap<String, CompressionProfile>>
+}
+
+impl Default for ContentRouterConfig {
+    fn default() -> Self {
+        Self {
+            enable_code_aware: false,
+            enable_kompress: true,
+            enable_smart_crusher: true,
+            enable_search_compressor: true,
+            enable_log_compressor: true,
+            enable_html_extractor: true,
+            enable_image_optimizer: true,
+            prefer_code_aware_for_code: false,
+            mixed_content_threshold: 2,
+            min_section_tokens: 20,
+            fallback_strategy: CompressionStrategy::Kompress,
+            skip_user_messages: true,
+            protect_recent_code: 4,
+            protect_analysis_context: true,
+            protect_recent_reads_fraction: 0.0,
+            min_ratio_relaxed: 0.85,
+            min_ratio_aggressive: 0.65,
+            ccr_enabled: true,
+            ccr_inject_marker: true,
+            compress_tagged_content: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_python() {
+        let c = ContentRouterConfig::default();
+        // Python defaults — copied verbatim from
+        // headroom/transforms/content_router.py:391-435.
+        assert!(!c.enable_code_aware);
+        assert!(c.enable_kompress);
+        assert!(c.enable_smart_crusher);
+        assert!(c.enable_search_compressor);
+        assert!(c.enable_log_compressor);
+        assert!(c.enable_html_extractor);
+        assert!(c.enable_image_optimizer);
+        assert!(!c.prefer_code_aware_for_code);
+        assert_eq!(c.mixed_content_threshold, 2);
+        assert_eq!(c.min_section_tokens, 20);
+        assert_eq!(c.fallback_strategy, CompressionStrategy::Kompress);
+        assert!(c.skip_user_messages);
+        assert_eq!(c.protect_recent_code, 4);
+        assert!(c.protect_analysis_context);
+        assert_eq!(c.protect_recent_reads_fraction, 0.0);
+        assert_eq!(c.min_ratio_relaxed, 0.85);
+        assert_eq!(c.min_ratio_aggressive, 0.65);
+        assert!(c.ccr_enabled);
+        assert!(c.ccr_inject_marker);
+        assert!(!c.compress_tagged_content);
+    }
+
+    #[test]
+    fn config_is_clone() {
+        let c = ContentRouterConfig::default();
+        let c2 = c.clone();
+        assert_eq!(c.mixed_content_threshold, c2.mixed_content_threshold);
+    }
+}

--- a/crates/headroom-core/src/transforms/content_router/mod.rs
+++ b/crates/headroom-core/src/transforms/content_router/mod.rs
@@ -1,0 +1,33 @@
+//! ContentRouter — strategy decision + dispatch (in-progress port).
+//!
+//! Direct port of `headroom/transforms/content_router.py`. The router
+//! sits in front of every compressor and decides which one runs based
+//! on detected content type. Originally pure-Python; moving in-process
+//! to Rust so the proxy hot path doesn't pay the cross-language cost
+//! per message.
+//!
+//! # Port progression
+//!
+//! | PR  | Scope                                                   |
+//! | --- | ------------------------------------------------------- |
+//! | PR1 | `ContentDetector` (regex-based detection)               |
+//! | PR2 | **Types + config + cache + strategy mapper (this PR)**  |
+//! | PR3 | Magika integration                                      |
+//! | PR4 | Mixed-content detection + section splitter              |
+//! | PR5 | `compress()` + dispatch (Rust → Rust direct, Rust →     |
+//! |     | Python via PyO3 callback for not-yet-ported compressors)|
+//! | PR6 | `apply()` proxy entrypoint                              |
+//! | PR7 | TOIN feedback loop                                      |
+//!
+//! This module re-exports the public surface from its submodules so
+//! callers can `use headroom_core::transforms::content_router::*`.
+
+pub mod cache;
+pub mod config;
+pub mod strategy_map;
+pub mod types;
+
+pub use cache::{CacheStats, CachedResult, CompressionCache, DEFAULT_TTL_SECONDS};
+pub use config::ContentRouterConfig;
+pub use strategy_map::{content_type_for_strategy, strategy_for_content_type};
+pub use types::{CompressionStrategy, ContentSection, RouterCompressionResult, RoutingDecision};

--- a/crates/headroom-core/src/transforms/content_router/strategy_map.rs
+++ b/crates/headroom-core/src/transforms/content_router/strategy_map.rs
@@ -1,0 +1,119 @@
+//! Bidirectional [`ContentType`] ↔ [`CompressionStrategy`] mapping.
+//!
+//! Direct port of `_strategy_from_detection_type` and
+//! `_content_type_from_strategy` from
+//! `headroom/transforms/content_router.py`. The two helpers are only
+//! quasi-inverses — the Python code maps both `Kompress` and
+//! `Passthrough` strategies back to `PlainText`, so the round-trip is
+//! lossy on those two strategies.
+
+use super::types::CompressionStrategy;
+use crate::transforms::ContentType;
+
+/// Map a detected content type to the strategy that handles it.
+/// Mirrors Python's `_strategy_from_detection_type`.
+///
+/// Python uses `mapping.get(content_type, self.config.fallback_strategy)`,
+/// but the mapping is total over `ContentType` today — every variant has
+/// an entry — so the fallback is dead-code-equivalent. We omit it here:
+/// this function always returns a specialized strategy, and
+/// `ContentRouter::_determine_strategy` (PR5) is where
+/// `config.fallback_strategy` actually applies — for low-confidence
+/// detections that bypass the mapping entirely.
+pub fn strategy_for_content_type(content_type: ContentType) -> CompressionStrategy {
+    match content_type {
+        ContentType::SourceCode => CompressionStrategy::CodeAware,
+        ContentType::JsonArray => CompressionStrategy::SmartCrusher,
+        ContentType::SearchResults => CompressionStrategy::Search,
+        ContentType::BuildOutput => CompressionStrategy::Log,
+        ContentType::GitDiff => CompressionStrategy::Diff,
+        ContentType::Html => CompressionStrategy::Html,
+        ContentType::PlainText => CompressionStrategy::Text,
+    }
+}
+
+/// Inverse of [`strategy_for_content_type`]. Mirrors Python's
+/// `_content_type_from_strategy`. Returns `PlainText` for strategies
+/// that don't have a unique content type (`Kompress`, `Passthrough`,
+/// `Mixed`) — same as Python.
+pub fn content_type_for_strategy(strategy: CompressionStrategy) -> ContentType {
+    match strategy {
+        CompressionStrategy::CodeAware => ContentType::SourceCode,
+        CompressionStrategy::SmartCrusher => ContentType::JsonArray,
+        CompressionStrategy::Search => ContentType::SearchResults,
+        CompressionStrategy::Log => ContentType::BuildOutput,
+        CompressionStrategy::Diff => ContentType::GitDiff,
+        CompressionStrategy::Html => ContentType::Html,
+        // Python's mapping returns PlainText for all of these:
+        CompressionStrategy::Text
+        | CompressionStrategy::Kompress
+        | CompressionStrategy::Passthrough
+        | CompressionStrategy::Mixed => ContentType::PlainText,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strategy_for_each_content_type_matches_python() {
+        let cases = [
+            (ContentType::SourceCode, CompressionStrategy::CodeAware),
+            (ContentType::JsonArray, CompressionStrategy::SmartCrusher),
+            (ContentType::SearchResults, CompressionStrategy::Search),
+            (ContentType::BuildOutput, CompressionStrategy::Log),
+            (ContentType::GitDiff, CompressionStrategy::Diff),
+            (ContentType::Html, CompressionStrategy::Html),
+            (ContentType::PlainText, CompressionStrategy::Text),
+        ];
+        for (ct, expected) in cases {
+            assert_eq!(
+                strategy_for_content_type(ct),
+                expected,
+                "ContentType::{:?}",
+                ct
+            );
+        }
+    }
+
+    #[test]
+    fn content_type_for_each_strategy_matches_python() {
+        let cases = [
+            (CompressionStrategy::CodeAware, ContentType::SourceCode),
+            (CompressionStrategy::SmartCrusher, ContentType::JsonArray),
+            (CompressionStrategy::Search, ContentType::SearchResults),
+            (CompressionStrategy::Log, ContentType::BuildOutput),
+            (CompressionStrategy::Diff, ContentType::GitDiff),
+            (CompressionStrategy::Html, ContentType::Html),
+            (CompressionStrategy::Text, ContentType::PlainText),
+            // Python collapses these three to PlainText:
+            (CompressionStrategy::Kompress, ContentType::PlainText),
+            (CompressionStrategy::Passthrough, ContentType::PlainText),
+            (CompressionStrategy::Mixed, ContentType::PlainText),
+        ];
+        for (s, expected) in cases {
+            assert_eq!(content_type_for_strategy(s), expected, "{:?}", s);
+        }
+    }
+
+    #[test]
+    fn round_trip_lossless_for_specialized_strategies() {
+        // For every specialized strategy, ContentType → Strategy →
+        // ContentType is the identity.
+        let specialized = [
+            CompressionStrategy::CodeAware,
+            CompressionStrategy::SmartCrusher,
+            CompressionStrategy::Search,
+            CompressionStrategy::Log,
+            CompressionStrategy::Diff,
+            CompressionStrategy::Html,
+            CompressionStrategy::Text,
+        ];
+        for s in specialized {
+            let ct = content_type_for_strategy(s);
+            let s2 = strategy_for_content_type(ct);
+            assert_eq!(s2, s, "round-trip {:?}", s);
+        }
+    }
+}

--- a/crates/headroom-core/src/transforms/content_router/types.rs
+++ b/crates/headroom-core/src/transforms/content_router/types.rs
@@ -1,0 +1,402 @@
+//! `ContentRouter` data types.
+//!
+//! Direct port of the enums and dataclasses at the top of
+//! `headroom/transforms/content_router.py`. String tags on
+//! [`CompressionStrategy`] match the Python `Enum` values so PyO3
+//! bridges and JSON fixtures cross the language boundary unchanged.
+
+use std::str::FromStr;
+
+use crate::transforms::ContentType;
+
+/// Available compression strategies. String tag (`as_str`) matches
+/// Python's `CompressionStrategy.<NAME>.value` 1:1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompressionStrategy {
+    CodeAware,
+    SmartCrusher,
+    Search,
+    Log,
+    Kompress,
+    Text,
+    Diff,
+    Html,
+    Mixed,
+    Passthrough,
+}
+
+impl CompressionStrategy {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CompressionStrategy::CodeAware => "code_aware",
+            CompressionStrategy::SmartCrusher => "smart_crusher",
+            CompressionStrategy::Search => "search",
+            CompressionStrategy::Log => "log",
+            CompressionStrategy::Kompress => "kompress",
+            CompressionStrategy::Text => "text",
+            CompressionStrategy::Diff => "diff",
+            CompressionStrategy::Html => "html",
+            CompressionStrategy::Mixed => "mixed",
+            CompressionStrategy::Passthrough => "passthrough",
+        }
+    }
+}
+
+/// Inverse of [`CompressionStrategy::as_str`]. Implemented as the
+/// stdlib `FromStr` trait so the parse path is discoverable; the error
+/// type is `()` because the only failure mode is "unknown tag" and
+/// callers (e.g. PyO3 bridge) build their own diagnostic from the
+/// rejected string.
+impl FromStr for CompressionStrategy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "code_aware" => Self::CodeAware,
+            "smart_crusher" => Self::SmartCrusher,
+            "search" => Self::Search,
+            "log" => Self::Log,
+            "kompress" => Self::Kompress,
+            "text" => Self::Text,
+            "diff" => Self::Diff,
+            "html" => Self::Html,
+            "mixed" => Self::Mixed,
+            "passthrough" => Self::Passthrough,
+            _ => return Err(()),
+        })
+    }
+}
+
+/// Record of a single routing decision (one section, one strategy).
+#[derive(Debug, Clone)]
+pub struct RoutingDecision {
+    pub content_type: ContentType,
+    pub strategy: CompressionStrategy,
+    pub original_tokens: usize,
+    pub compressed_tokens: usize,
+    pub confidence: f64,
+    pub section_index: usize,
+}
+
+impl RoutingDecision {
+    /// `compressed / original` (1.0 when original_tokens is 0 — matches
+    /// Python's safe-divide).
+    pub fn compression_ratio(&self) -> f64 {
+        if self.original_tokens == 0 {
+            1.0
+        } else {
+            self.compressed_tokens as f64 / self.original_tokens as f64
+        }
+    }
+}
+
+/// A typed slice of a larger payload (used by the mixed-content
+/// splitter — added in a later PR but the type lives here).
+#[derive(Debug, Clone)]
+pub struct ContentSection {
+    pub content: String,
+    pub content_type: ContentType,
+    pub language: Option<String>,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub is_code_fence: bool,
+}
+
+/// Result of a `ContentRouter::compress` call. Carries the compressed
+/// output alongside per-decision routing metadata for telemetry /
+/// debug logging.
+#[derive(Debug, Clone)]
+pub struct RouterCompressionResult {
+    pub compressed: String,
+    pub original: String,
+    pub strategy_used: CompressionStrategy,
+    pub routing_log: Vec<RoutingDecision>,
+    pub sections_processed: usize,
+}
+
+impl RouterCompressionResult {
+    pub fn new(compressed: String, original: String, strategy_used: CompressionStrategy) -> Self {
+        Self {
+            compressed,
+            original,
+            strategy_used,
+            routing_log: Vec::new(),
+            sections_processed: 1,
+        }
+    }
+
+    pub fn total_original_tokens(&self) -> usize {
+        self.routing_log.iter().map(|r| r.original_tokens).sum()
+    }
+
+    pub fn total_compressed_tokens(&self) -> usize {
+        self.routing_log.iter().map(|r| r.compressed_tokens).sum()
+    }
+
+    /// Total `compressed/original`. Returns 1.0 when no tokens were
+    /// recorded — matches Python's safe-divide.
+    pub fn compression_ratio(&self) -> f64 {
+        let orig = self.total_original_tokens();
+        if orig == 0 {
+            1.0
+        } else {
+            self.total_compressed_tokens() as f64 / orig as f64
+        }
+    }
+
+    pub fn tokens_saved(&self) -> usize {
+        self.total_original_tokens()
+            .saturating_sub(self.total_compressed_tokens())
+    }
+
+    /// Percent of tokens saved. `0.0` when no tokens were recorded.
+    pub fn savings_percentage(&self) -> f64 {
+        let orig = self.total_original_tokens();
+        if orig == 0 {
+            0.0
+        } else {
+            (self.tokens_saved() as f64 / orig as f64) * 100.0
+        }
+    }
+
+    /// Human-readable summary. Format matches Python's `summary()`
+    /// output verbatim, down to the thousand-separators and rounding,
+    /// so existing log scrapers keep working when the router moves
+    /// in-process.
+    pub fn summary(&self) -> String {
+        let total_orig = self.total_original_tokens();
+        let total_comp = self.total_compressed_tokens();
+        let pct = self.savings_percentage();
+        if self.strategy_used == CompressionStrategy::Mixed {
+            // Distinct strategies, sorted to match Python's set-formatting
+            // when display happens to round-trip the same order. Python's
+            // `{strategies}` print order is not guaranteed; we sort so
+            // the message is at least stable across runs.
+            let mut strategies: Vec<&'static str> = self
+                .routing_log
+                .iter()
+                .map(|r| r.strategy.as_str())
+                .collect();
+            strategies.sort_unstable();
+            strategies.dedup();
+            // Match Python's `{...}` set repr: `{'a', 'b'}`.
+            let formatted = if strategies.is_empty() {
+                "set()".to_string()
+            } else {
+                let inner = strategies
+                    .iter()
+                    .map(|s| format!("'{s}'"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{{{inner}}}")
+            };
+            format!(
+                "Mixed content: {sections} sections, routed to {fmt}. \
+                 {orig}→{comp} tokens ({pct:.0}% saved)",
+                sections = self.sections_processed,
+                fmt = formatted,
+                orig = thousands(total_orig),
+                comp = thousands(total_comp),
+                pct = pct,
+            )
+        } else {
+            format!(
+                "Pure {strategy}: {orig}→{comp} tokens ({pct:.0}% saved)",
+                strategy = self.strategy_used.as_str(),
+                orig = thousands(total_orig),
+                comp = thousands(total_comp),
+                pct = pct,
+            )
+        }
+    }
+}
+
+/// Python-style `{:,}` thousand-separator formatting for a `usize`.
+/// Avoids pulling a heavy formatter crate just for this one call site.
+fn thousands(mut n: usize) -> String {
+    if n == 0 {
+        return "0".to_string();
+    }
+    let mut groups: Vec<String> = Vec::new();
+    while n > 0 {
+        let g = n % 1000;
+        n /= 1000;
+        if n > 0 {
+            groups.push(format!("{g:03}"));
+        } else {
+            groups.push(g.to_string());
+        }
+    }
+    groups.reverse();
+    groups.join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strategy_string_tags_match_python() {
+        let cases = [
+            (CompressionStrategy::CodeAware, "code_aware"),
+            (CompressionStrategy::SmartCrusher, "smart_crusher"),
+            (CompressionStrategy::Search, "search"),
+            (CompressionStrategy::Log, "log"),
+            (CompressionStrategy::Kompress, "kompress"),
+            (CompressionStrategy::Text, "text"),
+            (CompressionStrategy::Diff, "diff"),
+            (CompressionStrategy::Html, "html"),
+            (CompressionStrategy::Mixed, "mixed"),
+            (CompressionStrategy::Passthrough, "passthrough"),
+        ];
+        for (s, tag) in cases {
+            assert_eq!(s.as_str(), tag);
+            assert_eq!(tag.parse::<CompressionStrategy>(), Ok(s));
+        }
+        assert_eq!("nope".parse::<CompressionStrategy>(), Err(()));
+    }
+
+    #[test]
+    fn routing_decision_ratio_handles_zero() {
+        let d = RoutingDecision {
+            content_type: ContentType::PlainText,
+            strategy: CompressionStrategy::Text,
+            original_tokens: 0,
+            compressed_tokens: 0,
+            confidence: 1.0,
+            section_index: 0,
+        };
+        assert_eq!(d.compression_ratio(), 1.0);
+    }
+
+    #[test]
+    fn routing_decision_ratio_normal_case() {
+        let d = RoutingDecision {
+            content_type: ContentType::JsonArray,
+            strategy: CompressionStrategy::SmartCrusher,
+            original_tokens: 200,
+            compressed_tokens: 50,
+            confidence: 1.0,
+            section_index: 0,
+        };
+        assert_eq!(d.compression_ratio(), 0.25);
+    }
+
+    #[test]
+    fn router_result_aggregates_log() {
+        let mut r =
+            RouterCompressionResult::new("out".into(), "in".into(), CompressionStrategy::Mixed);
+        r.routing_log.push(RoutingDecision {
+            content_type: ContentType::JsonArray,
+            strategy: CompressionStrategy::SmartCrusher,
+            original_tokens: 100,
+            compressed_tokens: 25,
+            confidence: 1.0,
+            section_index: 0,
+        });
+        r.routing_log.push(RoutingDecision {
+            content_type: ContentType::SourceCode,
+            strategy: CompressionStrategy::CodeAware,
+            original_tokens: 100,
+            compressed_tokens: 75,
+            confidence: 0.9,
+            section_index: 1,
+        });
+        r.sections_processed = 2;
+        assert_eq!(r.total_original_tokens(), 200);
+        assert_eq!(r.total_compressed_tokens(), 100);
+        assert_eq!(r.compression_ratio(), 0.5);
+        assert_eq!(r.tokens_saved(), 100);
+        assert_eq!(r.savings_percentage(), 50.0);
+    }
+
+    #[test]
+    fn router_result_handles_empty_log() {
+        let r = RouterCompressionResult::new(
+            "out".into(),
+            "in".into(),
+            CompressionStrategy::Passthrough,
+        );
+        assert_eq!(r.compression_ratio(), 1.0);
+        assert_eq!(r.savings_percentage(), 0.0);
+        assert_eq!(r.tokens_saved(), 0);
+    }
+
+    #[test]
+    fn tokens_saved_floors_at_zero() {
+        // Compressed > original is degenerate but possible (e.g. compressor
+        // adds metadata). Saturating-sub keeps `tokens_saved` non-negative.
+        let mut r =
+            RouterCompressionResult::new("out".into(), "in".into(), CompressionStrategy::Text);
+        r.routing_log.push(RoutingDecision {
+            content_type: ContentType::PlainText,
+            strategy: CompressionStrategy::Text,
+            original_tokens: 50,
+            compressed_tokens: 80,
+            confidence: 1.0,
+            section_index: 0,
+        });
+        assert_eq!(r.tokens_saved(), 0);
+    }
+
+    #[test]
+    fn summary_pure_strategy_format() {
+        let mut r = RouterCompressionResult::new(
+            "out".into(),
+            "in".into(),
+            CompressionStrategy::SmartCrusher,
+        );
+        r.routing_log.push(RoutingDecision {
+            content_type: ContentType::JsonArray,
+            strategy: CompressionStrategy::SmartCrusher,
+            original_tokens: 1500,
+            compressed_tokens: 750,
+            confidence: 1.0,
+            section_index: 0,
+        });
+        assert_eq!(
+            r.summary(),
+            "Pure smart_crusher: 1,500→750 tokens (50% saved)"
+        );
+    }
+
+    #[test]
+    fn summary_mixed_strategy_format() {
+        let mut r =
+            RouterCompressionResult::new("out".into(), "in".into(), CompressionStrategy::Mixed);
+        r.routing_log.push(RoutingDecision {
+            content_type: ContentType::JsonArray,
+            strategy: CompressionStrategy::SmartCrusher,
+            original_tokens: 5_000,
+            compressed_tokens: 1_000,
+            confidence: 1.0,
+            section_index: 0,
+        });
+        r.routing_log.push(RoutingDecision {
+            content_type: ContentType::SourceCode,
+            strategy: CompressionStrategy::CodeAware,
+            original_tokens: 5_000,
+            compressed_tokens: 4_000,
+            confidence: 0.9,
+            section_index: 1,
+        });
+        r.sections_processed = 2;
+        let s = r.summary();
+        assert!(
+            s.starts_with("Mixed content: 2 sections, routed to "),
+            "got: {s}"
+        );
+        assert!(s.contains("'smart_crusher'"));
+        assert!(s.contains("'code_aware'"));
+        assert!(s.ends_with("10,000→5,000 tokens (50% saved)"));
+    }
+
+    #[test]
+    fn thousands_formatting() {
+        assert_eq!(thousands(0), "0");
+        assert_eq!(thousands(1), "1");
+        assert_eq!(thousands(999), "999");
+        assert_eq!(thousands(1_000), "1,000");
+        assert_eq!(thousands(12_345), "12,345");
+        assert_eq!(thousands(1_234_567), "1,234,567");
+    }
+}

--- a/crates/headroom-core/src/transforms/mod.rs
+++ b/crates/headroom-core/src/transforms/mod.rs
@@ -18,11 +18,17 @@
 pub mod adaptive_sizer;
 pub mod anchor_selector;
 pub mod content_detector;
+pub mod content_router;
 pub mod diff_compressor;
 pub mod smart_crusher;
 
 pub use content_detector::{
     detect_content_type, is_json_array_of_dicts, ContentType, DetectionResult,
+};
+pub use content_router::{
+    content_type_for_strategy, strategy_for_content_type, CacheStats, CachedResult,
+    CompressionCache, CompressionStrategy, ContentRouterConfig, ContentSection,
+    RouterCompressionResult, RoutingDecision,
 };
 pub use diff_compressor::{
     DiffCompressionResult, DiffCompressor, DiffCompressorConfig, DiffCompressorStats,

--- a/crates/headroom-py/src/lib.rs
+++ b/crates/headroom-py/src/lib.rs
@@ -22,12 +22,17 @@ use headroom_core::transforms::smart_crusher::{
 };
 use headroom_core::transforms::{
     detect_content_type as rust_detect_content_type,
-    is_json_array_of_dicts as rust_is_json_array_of_dicts, ContentType as RustContentType,
-    DetectionResult as RustDetectionResult, DiffCompressionResult, DiffCompressor,
-    DiffCompressorConfig, DiffCompressorStats,
+    is_json_array_of_dicts as rust_is_json_array_of_dicts, CacheStats as RustCacheStats,
+    CachedResult as RustCachedResult, CompressionCache as RustCompressionCache,
+    CompressionStrategy as RustCompressionStrategy, ContentRouterConfig as RustContentRouterConfig,
+    ContentType as RustContentType, DetectionResult as RustDetectionResult, DiffCompressionResult,
+    DiffCompressor, DiffCompressorConfig, DiffCompressorStats,
 };
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
+use std::sync::Arc;
+use std::time::Duration;
 
 /// Identity stub used by the Python smoke test to verify linkage.
 #[pyfunction]
@@ -859,6 +864,348 @@ const _: fn() = || {
     let _ = RustContentType::PlainText;
 };
 
+// ─── ContentRouter — types + config + cache (PR2) ──────────────────────────
+
+/// Mirror of `headroom.transforms.content_router.ContentRouterConfig`.
+///
+/// PR2 ports the simple fields that drive dispatch decisions. The
+/// complex Python-only fields (`exclude_tools`, `read_lifecycle`,
+/// `tool_profiles`) come back in PR6 with the `apply()` proxy port.
+/// Constructor accepts every field as a kwarg with the same name and
+/// default as the Python dataclass.
+#[pyclass(name = "ContentRouterConfig", module = "headroom._core")]
+#[derive(Clone)]
+struct PyContentRouterConfig {
+    inner: RustContentRouterConfig,
+}
+
+#[pymethods]
+impl PyContentRouterConfig {
+    #[new]
+    #[pyo3(signature = (
+        enable_code_aware = false,
+        enable_kompress = true,
+        enable_smart_crusher = true,
+        enable_search_compressor = true,
+        enable_log_compressor = true,
+        enable_html_extractor = true,
+        enable_image_optimizer = true,
+        prefer_code_aware_for_code = false,
+        mixed_content_threshold = 2,
+        min_section_tokens = 20,
+        fallback_strategy = "kompress",
+        skip_user_messages = true,
+        protect_recent_code = 4,
+        protect_analysis_context = true,
+        protect_recent_reads_fraction = 0.0,
+        min_ratio_relaxed = 0.85,
+        min_ratio_aggressive = 0.65,
+        ccr_enabled = true,
+        ccr_inject_marker = true,
+        compress_tagged_content = false,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        enable_code_aware: bool,
+        enable_kompress: bool,
+        enable_smart_crusher: bool,
+        enable_search_compressor: bool,
+        enable_log_compressor: bool,
+        enable_html_extractor: bool,
+        enable_image_optimizer: bool,
+        prefer_code_aware_for_code: bool,
+        mixed_content_threshold: usize,
+        min_section_tokens: usize,
+        fallback_strategy: &str,
+        skip_user_messages: bool,
+        protect_recent_code: usize,
+        protect_analysis_context: bool,
+        protect_recent_reads_fraction: f64,
+        min_ratio_relaxed: f64,
+        min_ratio_aggressive: f64,
+        ccr_enabled: bool,
+        ccr_inject_marker: bool,
+        compress_tagged_content: bool,
+    ) -> PyResult<Self> {
+        let fallback_strategy = fallback_strategy
+            .parse::<RustCompressionStrategy>()
+            .map_err(|_| {
+                PyValueError::new_err(format!(
+                    "unknown fallback_strategy {fallback_strategy:?}; expected one of \
+                     code_aware, smart_crusher, search, log, kompress, text, diff, html, \
+                     mixed, passthrough"
+                ))
+            })?;
+        Ok(Self {
+            inner: RustContentRouterConfig {
+                enable_code_aware,
+                enable_kompress,
+                enable_smart_crusher,
+                enable_search_compressor,
+                enable_log_compressor,
+                enable_html_extractor,
+                enable_image_optimizer,
+                prefer_code_aware_for_code,
+                mixed_content_threshold,
+                min_section_tokens,
+                fallback_strategy,
+                skip_user_messages,
+                protect_recent_code,
+                protect_analysis_context,
+                protect_recent_reads_fraction,
+                min_ratio_relaxed,
+                min_ratio_aggressive,
+                ccr_enabled,
+                ccr_inject_marker,
+                compress_tagged_content,
+            },
+        })
+    }
+
+    // Read-only field accessors mirroring the Python dataclass.
+    #[getter]
+    fn enable_code_aware(&self) -> bool {
+        self.inner.enable_code_aware
+    }
+    #[getter]
+    fn enable_kompress(&self) -> bool {
+        self.inner.enable_kompress
+    }
+    #[getter]
+    fn enable_smart_crusher(&self) -> bool {
+        self.inner.enable_smart_crusher
+    }
+    #[getter]
+    fn enable_search_compressor(&self) -> bool {
+        self.inner.enable_search_compressor
+    }
+    #[getter]
+    fn enable_log_compressor(&self) -> bool {
+        self.inner.enable_log_compressor
+    }
+    #[getter]
+    fn enable_html_extractor(&self) -> bool {
+        self.inner.enable_html_extractor
+    }
+    #[getter]
+    fn enable_image_optimizer(&self) -> bool {
+        self.inner.enable_image_optimizer
+    }
+    #[getter]
+    fn prefer_code_aware_for_code(&self) -> bool {
+        self.inner.prefer_code_aware_for_code
+    }
+    #[getter]
+    fn mixed_content_threshold(&self) -> usize {
+        self.inner.mixed_content_threshold
+    }
+    #[getter]
+    fn min_section_tokens(&self) -> usize {
+        self.inner.min_section_tokens
+    }
+    #[getter]
+    fn fallback_strategy(&self) -> &'static str {
+        self.inner.fallback_strategy.as_str()
+    }
+    #[getter]
+    fn skip_user_messages(&self) -> bool {
+        self.inner.skip_user_messages
+    }
+    #[getter]
+    fn protect_recent_code(&self) -> usize {
+        self.inner.protect_recent_code
+    }
+    #[getter]
+    fn protect_analysis_context(&self) -> bool {
+        self.inner.protect_analysis_context
+    }
+    #[getter]
+    fn protect_recent_reads_fraction(&self) -> f64 {
+        self.inner.protect_recent_reads_fraction
+    }
+    #[getter]
+    fn min_ratio_relaxed(&self) -> f64 {
+        self.inner.min_ratio_relaxed
+    }
+    #[getter]
+    fn min_ratio_aggressive(&self) -> f64 {
+        self.inner.min_ratio_aggressive
+    }
+    #[getter]
+    fn ccr_enabled(&self) -> bool {
+        self.inner.ccr_enabled
+    }
+    #[getter]
+    fn ccr_inject_marker(&self) -> bool {
+        self.inner.ccr_inject_marker
+    }
+    #[getter]
+    fn compress_tagged_content(&self) -> bool {
+        self.inner.compress_tagged_content
+    }
+}
+
+/// Python-facing snapshot of `CompressionCache.stats()`. Matches the
+/// keys returned by Python's `CompressionCache.stats` property so
+/// existing telemetry scrapers keep working.
+#[pyclass(name = "CacheStats", module = "headroom._core")]
+#[derive(Clone)]
+struct PyCacheStats {
+    inner: RustCacheStats,
+}
+
+#[pymethods]
+impl PyCacheStats {
+    #[getter]
+    fn cache_hits(&self) -> u64 {
+        self.inner.hits
+    }
+    #[getter]
+    fn cache_skip_hits(&self) -> u64 {
+        self.inner.skip_hits
+    }
+    #[getter]
+    fn cache_misses(&self) -> u64 {
+        self.inner.misses
+    }
+    #[getter]
+    fn cache_evictions(&self) -> u64 {
+        self.inner.evictions
+    }
+    #[getter]
+    fn cache_size(&self) -> u64 {
+        self.inner.size
+    }
+    #[getter]
+    fn cache_skip_size(&self) -> u64 {
+        self.inner.skip_size
+    }
+    #[getter]
+    fn cache_avg_lookup_ns(&self) -> f64 {
+        self.inner.avg_lookup_ns
+    }
+
+    fn as_dict<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
+        // `unwrap()` is fine: every key is a static `&str` literal and
+        // every value is a primitive owned by us, so the `set_item`
+        // conversions can't fail. Pulling this out of `#[pymethods]`
+        // also dodges the pyo3 0.22 `clippy::useless_conversion`
+        // macro false-positive that fires on `?` inside method bodies.
+        let d = PyDict::new_bound(py);
+        d.set_item("cache_hits", self.inner.hits).unwrap();
+        d.set_item("cache_skip_hits", self.inner.skip_hits).unwrap();
+        d.set_item("cache_misses", self.inner.misses).unwrap();
+        d.set_item("cache_evictions", self.inner.evictions).unwrap();
+        d.set_item("cache_size", self.inner.size).unwrap();
+        d.set_item("cache_skip_size", self.inner.skip_size).unwrap();
+        d.set_item("cache_avg_lookup_ns", self.inner.avg_lookup_ns)
+            .unwrap();
+        d
+    }
+}
+
+/// Single cached result tuple — mirrors Python's
+/// `(compressed, ratio, strategy)` tuple from `CompressionCache.get`.
+/// Exposed as a class with attribute access so PR5 doesn't have to
+/// unpack a tuple.
+#[pyclass(name = "CachedResult", module = "headroom._core")]
+#[derive(Clone)]
+struct PyCachedResult {
+    inner: RustCachedResult,
+}
+
+#[pymethods]
+impl PyCachedResult {
+    #[getter]
+    fn compressed(&self) -> &str {
+        &self.inner.compressed
+    }
+    #[getter]
+    fn ratio(&self) -> f64 {
+        self.inner.ratio
+    }
+    #[getter]
+    fn strategy(&self) -> &str {
+        &self.inner.strategy
+    }
+
+    fn as_tuple<'py>(&self, py: Python<'py>) -> Bound<'py, pyo3::types::PyTuple> {
+        pyo3::types::PyTuple::new_bound(
+            py,
+            [
+                self.inner.compressed.clone().into_py(py),
+                self.inner.ratio.into_py(py),
+                self.inner.strategy.clone().into_py(py),
+            ],
+        )
+    }
+}
+
+/// Mirror of `headroom.transforms.content_router.CompressionCache`.
+///
+/// Backed by an `Arc<RustCompressionCache>` so multiple Python handles
+/// to the same logical cache share storage. The proxy hot path will
+/// hold one cache per worker pool; tests can build their own.
+#[pyclass(name = "CompressionCache", module = "headroom._core")]
+struct PyCompressionCache {
+    inner: Arc<RustCompressionCache>,
+}
+
+#[pymethods]
+impl PyCompressionCache {
+    #[new]
+    #[pyo3(signature = (ttl_seconds = 1800))]
+    fn new(ttl_seconds: u64) -> Self {
+        Self {
+            inner: Arc::new(RustCompressionCache::with_ttl(Duration::from_secs(
+                ttl_seconds,
+            ))),
+        }
+    }
+
+    fn get(&self, key: u64) -> Option<PyCachedResult> {
+        self.inner.get(key).map(|r| PyCachedResult { inner: r })
+    }
+
+    fn is_skipped(&self, key: u64) -> bool {
+        self.inner.is_skipped(key)
+    }
+
+    fn put(&self, key: u64, compressed: &str, ratio: f64, strategy: &str) {
+        self.inner
+            .put(key, compressed.to_string(), ratio, strategy.to_string());
+    }
+
+    fn mark_skip(&self, key: u64) {
+        self.inner.mark_skip(key);
+    }
+
+    fn move_to_skip(&self, key: u64) {
+        self.inner.move_to_skip(key);
+    }
+
+    #[getter]
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    #[getter]
+    fn skip_size(&self) -> usize {
+        self.inner.skip_size()
+    }
+
+    #[getter]
+    fn stats(&self) -> PyCacheStats {
+        PyCacheStats {
+            inner: self.inner.stats(),
+        }
+    }
+
+    fn clear(&self) {
+        self.inner.clear();
+    }
+}
+
 // ─── Module init ───────────────────────────────────────────────────────────
 
 #[pymodule]
@@ -874,5 +1221,9 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDetectionResult>()?;
     m.add_function(wrap_pyfunction!(detect_content_type, m)?)?;
     m.add_function(wrap_pyfunction!(is_json_array_of_dicts, m)?)?;
+    m.add_class::<PyContentRouterConfig>()?;
+    m.add_class::<PyCacheStats>()?;
+    m.add_class::<PyCachedResult>()?;
+    m.add_class::<PyCompressionCache>()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

PR2 of the ContentRouter migration. Ports the data layer that dispatch reads from — types, config, cache, strategy mapper. No compress logic yet (PR5).

**Stacked on #295 (PR1).** The strategy mapper and `RoutingDecision` reference `ContentType` from PR1. Will rebase to `main` once #295 merges.

## What's in this PR
- `content_router/types.rs` — `CompressionStrategy` enum (10 variants, `FromStr` + `as_str` matching Python tags); `RoutingDecision`, `ContentSection`, `RouterCompressionResult` with derived metrics (`ratio`, `tokens_saved`, `savings_percentage`). `summary()` reproduces Python's exact format including thousand-separators and sorted set-repr — lock-step with existing log scrapers.
- `content_router/config.rs` — `ContentRouterConfig` with all simple fields, defaults locked to Python. Complex fields (`exclude_tools`, `read_lifecycle`, `tool_profiles`) deferred to PR6 (proxy `apply()` port) — they don't affect dispatch decisions, so PR5 can ship without them.
- `content_router/cache.rs` — `CompressionCache`: TTL-based two-tier (results + skip set) backed by `DashMap` for sharded concurrent access on the hot path. Atomic counters so the stats snapshot is lock-free. Includes an 8-thread stress test.
- `content_router/strategy_map.rs` — bidirectional `ContentType` ↔ `CompressionStrategy` helpers. Dropped the `fallback` parameter on the forward mapping after confirming Python's `mapping.get(ct, fallback)` is dead-code — the mapping is total over `ContentType`. Documented why and where the actual fallback applies (PR5's `_determine_strategy`).
- `headroom-py/src/lib.rs` — PyO3 bridge: `PyContentRouterConfig` (kwarg surface matches the Python dataclass; rejects unknown `fallback_strategy` with a helpful error), `PyCompressionCache` (Arc-shared so Python can hold multiple handles), `PyCacheStats` with both attribute access and `as_dict()` returning Python's stats key shape.
- `dashmap = \"6\"` added to `headroom-core` deps.

## Test plan
- [x] 26 new unit tests (cache, types, config, strategy mapper) — all pass
- [x] Concurrent stress test for cache (8 threads × 1,000 ops, no panics, counters consistent)
- [x] PyO3 bridge smoke-tested end-to-end from Python
- [x] `make ci-precheck` PASSED — rust fmt + clippy + workspace tests + 185 python tests + commitlint

## Up next
- PR3: Magika via the Rust `magika` crate
- PR4: Mixed-content detection + section splitter
- PR5: `compress()` + dispatch (the value-delivery PR — direct Rust calls for Diff/SmartCrusher, PyO3 callbacks for not-yet-ported compressors)