### PR TITLE
fix(proxy): defer file logging install to create_app()

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -188,9 +188,6 @@ logger = logging.getLogger("headroom.proxy")
 
 _MULTI_WORKER_CONFIG_ENV = "HEADROOM_PROXY_CONFIG_JSON"
 
-# Always-on file logging to ~/.headroom/logs/ for `headroom perf` analysis
-_setup_file_logging()
-
 
 # Compression pipeline timeout in seconds
 
@@ -1063,6 +1060,12 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         raise ImportError("FastAPI required. Install: pip install fastapi uvicorn httpx")
 
     from contextlib import asynccontextmanager
+
+    # Always-on file logging to ~/.headroom/logs/ for `headroom perf` analysis.
+    # Installed here (not at module import) so importing headroom.proxy.server
+    # in tests or library contexts does not silently attach a RotatingFileHandler
+    # to the user's live proxy.log.
+    _setup_file_logging()
 
     config = config or ProxyConfig()
     proxy = HeadroomProxy(config)

--- a/tests/test_pr208_changes.py
+++ b/tests/test_pr208_changes.py
@@ -371,6 +371,39 @@ class TestSetupFileLogging:
         # Should not raise
         _setup_file_logging()
 
+    def test_importing_server_does_not_install_file_handler(self, tmp_path: Path) -> None:
+        """Importing headroom.proxy.server must NOT attach a RotatingFileHandler
+        to the user's live proxy.log. The handler is installed by create_app()
+        instead, so test runs and library imports do not pollute logs.
+        """
+        import os
+        import subprocess
+        import sys
+        import textwrap
+
+        script = textwrap.dedent(
+            """
+            import logging
+            from logging.handlers import RotatingFileHandler
+            import headroom.proxy.server  # noqa: F401
+            hr = logging.getLogger("headroom")
+            installed = any(isinstance(h, RotatingFileHandler) for h in hr.handlers)
+            print("INSTALLED" if installed else "CLEAN")
+            """
+        ).strip()
+        env = {**os.environ, "HEADROOM_WORKSPACE_DIR": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+        assert result.stdout.strip() == "CLEAN", (
+            f"Importing headroom.proxy.server attached a file handler: {result.stdout!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Repro script URL helpers and stats tests


### PR DESCRIPTION
## Summary

Move `_setup_file_logging()` from module-level import to inside `create_app()`, so importing `headroom.proxy.server` in tests or library contexts no longer silently attaches a `RotatingFileHandler` to the user's live `~/.headroom/logs/proxy.log`.

This is the follow-up agreed on in [PR #303's review thread](https://github.com/chopratejas/headroom/pull/303) — the test-log-pollution side finding from the compression-timeout diagnostics work.

### Why this matters

Previously, anything that did `from headroom.proxy.server import …` (the test suite, scripts, library users) would inherit the rotating file handler at import time. That's how PR #303's `test_proxy_anthropic_compression_diagnostics.py` ended up writing `Optimization failed: TimeoutError` entries into the user's real `proxy.log` and was briefly mistaken for a live #296 reproduction.

### Approach

- Remove the module-level call to `_setup_file_logging()` from `headroom/proxy/server.py`.
- Call it once at the top of `create_app()` instead — that's the only path where a real proxy server is being stood up.
- Existing idempotency guard (`if not any(isinstance(h, RotatingFileHandler) …)`) still prevents duplicate handlers when `create_app()` is called multiple times in a process.

### Regression test

Added `test_importing_server_does_not_install_file_handler` (in `tests/test_pr208_changes.py::TestSetupFileLogging`). It launches a subprocess, imports `headroom.proxy.server`, and asserts no `RotatingFileHandler` is attached to the `headroom` logger. The subprocess is needed because once the parent test process imports the module the side effect would persist across tests.

## Test plan

- [x] `pytest tests/test_pr208_changes.py::TestSetupFileLogging` — 3 passed
- [x] `pytest tests/test_pr208_changes.py tests/test_proxy_anthropic_cache_stability.py tests/test_proxy_healthchecks.py tests/test_proxy_compress_endpoint.py` — 82 passed, 1 skipped
- [x] Manual: `create_app(ProxyConfig())` still installs the handler (verified `before_create_app=False after_create_app=True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)