### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/headroom/providers/__init__.py
+++ b/headroom/providers/__init__.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
         ModelCapabilities,
         OpenAICompatibleProvider,
         create_anyscale_provider,
+        create_astraflow_cn_provider,
+        create_astraflow_provider,
         create_fireworks_provider,
         create_groq_provider,
         create_lmstudio_provider,
@@ -64,6 +66,8 @@ __all__ = [
     "create_anyscale_provider",
     "create_vllm_provider",
     "create_lmstudio_provider",
+    "create_astraflow_provider",
+    "create_astraflow_cn_provider",
     "create_litellm_provider",
 ]
 
@@ -103,6 +107,14 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "create_lmstudio_provider": (
         "headroom.providers.openai_compatible",
         "create_lmstudio_provider",
+    ),
+    "create_astraflow_provider": (
+        "headroom.providers.openai_compatible",
+        "create_astraflow_provider",
+    ),
+    "create_astraflow_cn_provider": (
+        "headroom.providers.openai_compatible",
+        "create_astraflow_cn_provider",
     ),
     "create_litellm_provider": ("headroom.providers.litellm", "create_litellm_provider"),
 }

--- a/headroom/providers/openai_compatible.py
+++ b/headroom/providers/openai_compatible.py
@@ -519,3 +519,55 @@ def create_lmstudio_provider(
         name="lmstudio",
         base_url=base_url,
     )
+
+
+def create_astraflow_provider(
+    api_key: str | None = None,
+) -> OpenAICompatibleProvider:
+    """Create provider for Astraflow (global endpoint).
+
+    Astraflow (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation
+    platform supporting 200+ models.
+
+    Global endpoint: https://api-us-ca.umodelverse.ai/v1
+
+    Args:
+        api_key: Astraflow API key. If not provided, reads from the
+            ``ASTRAFLOW_API_KEY`` environment variable.
+
+    Returns:
+        Configured provider.
+    """
+    import os
+
+    return OpenAICompatibleProvider(
+        name="astraflow",
+        base_url="https://api-us-ca.umodelverse.ai/v1",
+        api_key=api_key or os.environ.get("ASTRAFLOW_API_KEY"),
+    )
+
+
+def create_astraflow_cn_provider(
+    api_key: str | None = None,
+) -> OpenAICompatibleProvider:
+    """Create provider for Astraflow (China endpoint).
+
+    Astraflow (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation
+    platform supporting 200+ models.
+
+    China endpoint: https://api.modelverse.cn/v1
+
+    Args:
+        api_key: Astraflow CN API key. If not provided, reads from the
+            ``ASTRAFLOW_CN_API_KEY`` environment variable.
+
+    Returns:
+        Configured provider.
+    """
+    import os
+
+    return OpenAICompatibleProvider(
+        name="astraflow_cn",
+        base_url="https://api.modelverse.cn/v1",
+        api_key=api_key or os.environ.get("ASTRAFLOW_CN_API_KEY"),
+    )


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://www.ucloud.cn/) (by UCloud / 优刻得) as a supported OpenAI-compatible provider. Astraflow is a model aggregation platform supporting 200+ models.

### What's changed

- **`headroom/providers/openai_compatible.py`**: Added two pre-configured factory functions:
  - `create_astraflow_provider()` — Global endpoint (`https://api-us-ca.umodelverse.ai/v1`), reads `ASTRAFLOW_API_KEY` from environment.
  - `create_astraflow_cn_provider()` — China endpoint (`https://api.modelverse.cn/v1`), reads `ASTRAFLOW_CN_API_KEY` from environment.

- **`headroom/providers/__init__.py`**: Exported both factory functions via `TYPE_CHECKING`, `__all__`, and `_LAZY_EXPORTS`.

### Usage

```python
import os
from headroom.providers import create_astraflow_provider

# Global endpoint
provider = create_astraflow_provider(api_key=os.environ["ASTRAFLOW_API_KEY"])

# China endpoint
from headroom.providers import create_astraflow_cn_provider
provider_cn = create_astraflow_cn_provider(api_key=os.environ["ASTRAFLOW_CN_API_KEY"])
```

Because Astraflow is fully OpenAI-compatible, no new SDK or subpackage is needed — this reuses the existing `OpenAICompatibleProvider` infrastructure.