### PR TITLE
fix(rust): wrap Diff/Log/Search compressors as LossyTransform impls (Phase 3g PR2)

### DIFF
--- a/crates/headroom-core/src/transforms/pipeline/mod.rs
+++ b/crates/headroom-core/src/transforms/pipeline/mod.rs
@@ -55,6 +55,7 @@ pub mod json_minifier;
 pub mod line_importance_filter;
 pub mod orchestrator;
 pub mod traits;
+pub mod wrappers;
 
 pub use json_minifier::JsonMinifier;
 pub use line_importance_filter::{LineImportanceFilter, LineImportanceFilterConfig};
@@ -64,3 +65,4 @@ pub use orchestrator::{
 pub use traits::{
     CompressionContext, LosslessTransform, LossyTransform, TransformError, TransformResult,
 };
+pub use wrappers::{DiffCompressorWrapper, LogCompressorWrapper, SearchCompressorWrapper};

--- a/crates/headroom-core/src/transforms/pipeline/wrappers/diff_compressor_wrapper.rs
+++ b/crates/headroom-core/src/transforms/pipeline/wrappers/diff_compressor_wrapper.rs
@@ -1,0 +1,316 @@
+//! `DiffCompressorWrapper` — adapts the existing [`DiffCompressor`] to the
+//! Phase 3g [`LossyTransform`] trait shape.
+//!
+//! # Why this is a `LossyTransform`
+//!
+//! `DiffCompressor` deliberately drops content: it caps file count, caps
+//! per-file hunk count, and trims context lines around `+`/`-` changes.
+//! Even though the result is structurally well-formed unified diff, the
+//! LLM cannot reconstruct the dropped hunks/files from the compressed
+//! view alone — that's exactly the contract of a lossy transform.
+//!
+//! Hence `structure_preserved = false`. The compressed output is still
+//! parseable as a diff, but information has been removed; the structural
+//! invariant the orchestrator cares about is round-trip identity, which
+//! `DiffCompressor` does not provide.
+//!
+//! # CCR propagation
+//!
+//! When `DiffCompressor` decides the savings are large enough (default:
+//! more than 20% line reduction), it emits an MD5-derived `cache_key` alongside
+//! the compressed bytes. We propagate that key into
+//! [`TransformResult::reversible_via`] so downstream CCR retrieval can
+//! pull the original bytes back when the LLM requests them. When no
+//! cache_key is emitted, `reversible_via` is `None` and the dropped
+//! content is gone for good (the underlying compressor already decided
+//! it wasn't worth offloading).
+//!
+//! # Confidence (0.85)
+//!
+//! Higher than [`LineImportanceFilter`]'s 0.7 because:
+//! - Output is deterministic (MD5 cache_key, fixed parser, fixed scorer).
+//! - Always-keep additions/deletions semantics mean no `+`/`-` line is
+//!   ever silently dropped — only context and middle hunks under cap.
+//! - 20+ parity fixtures lock the byte-for-byte behavior against Python.
+//!
+//! Not 1.0 because hunks beyond `max_hunks_per_file` are dropped
+//! (without a per-hunk CCR offload — the cache_key offloads only the
+//! whole-diff original, not individual hunks), so the LLM may miss
+//! relevant hunks if the cap fires.
+//!
+//! [`LineImportanceFilter`]: super::super::line_importance_filter::LineImportanceFilter
+
+use std::sync::Arc;
+
+use crate::transforms::diff_compressor::{DiffCompressor, DiffCompressorConfig};
+use crate::transforms::pipeline::traits::{
+    CompressionContext, LossyTransform, TransformError, TransformResult,
+};
+use crate::transforms::ContentType;
+
+/// Wraps [`DiffCompressor`] as a [`LossyTransform`].
+///
+/// Holds an `Arc<DiffCompressor>` so the wrapper can be cheaply cloned
+/// and shared across pipeline registrations without re-allocating the
+/// underlying config.
+#[derive(Debug, Clone)]
+pub struct DiffCompressorWrapper {
+    inner: Arc<DiffCompressor>,
+}
+
+impl DiffCompressorWrapper {
+    /// Stable telemetry name. Lowercase snake_case so it composes
+    /// cleanly into the strategy-stats JSONB nest landed in Phase 3e.0.
+    pub const NAME: &'static str = "diff_compressor";
+
+    /// Static slice — applicability is fixed by the wrapped transform.
+    const APPLIES_TO: &'static [ContentType] = &[ContentType::GitDiff];
+
+    /// Build a wrapper around a [`DiffCompressor`] configured with the
+    /// given config.
+    pub fn new(config: DiffCompressorConfig) -> Self {
+        Self {
+            inner: Arc::new(DiffCompressor::new(config)),
+        }
+    }
+}
+
+impl Default for DiffCompressorWrapper {
+    fn default() -> Self {
+        Self::new(DiffCompressorConfig::default())
+    }
+}
+
+impl LossyTransform for DiffCompressorWrapper {
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn applies_to(&self) -> &[ContentType] {
+        Self::APPLIES_TO
+    }
+
+    fn apply(
+        &self,
+        content: &str,
+        _ctx: &CompressionContext,
+    ) -> Result<TransformResult, TransformError> {
+        if content.is_empty() {
+            return Err(TransformError::skipped(Self::NAME, "empty input"));
+        }
+
+        // The query from CompressionContext is *not* threaded into
+        // DiffCompressor's relevance scorer here — the wrapped API
+        // accepts a context string, but in PR2 we keep the wrapping
+        // minimal and pass an empty context. PR4+ may revisit when
+        // ProseFieldCompressor lands and the orchestrator gets a
+        // first-class query plumbing decision.
+        let (result, _stats) = self.inner.compress_with_stats(content, "");
+
+        let bytes_saved = content.len().saturating_sub(result.compressed.len());
+
+        Ok(TransformResult {
+            output: result.compressed,
+            bytes_saved,
+            // Hunks/files can be dropped — LLM cannot reconstruct from
+            // the compressed view. The CCR cache_key (when present)
+            // makes the dropped bytes retrievable, but the *output
+            // string* itself is not structurally lossless.
+            structure_preserved: false,
+            // Propagate the underlying compressor's CCR cache_key so
+            // the orchestrator / retrieval layer can pull the original
+            // bytes back when needed. None when DiffCompressor decided
+            // the savings didn't justify a marker.
+            reversible_via: result.cache_key,
+        })
+    }
+
+    fn confidence(&self) -> f32 {
+        // See module-level "Confidence (0.85)" docs for the calibration
+        // rationale. Fixed constant in PR2; a future PR may upgrade to
+        // a stats-derived confidence (e.g. compression_ratio,
+        // hunks_dropped) once the strategy-stats nest is consumed by
+        // selection logic.
+        0.85
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic diff that's long enough to trip
+    /// `min_lines_for_ccr` (default 50) so the compressor actually
+    /// runs — short diffs pass through unchanged. Mirrors the
+    /// `build_synthetic_diff` helper in `diff_compressor.rs` tests.
+    fn build_synthetic_diff(n_files: usize) -> String {
+        let mut s = String::new();
+        for i in 0..n_files {
+            s.push_str(&format!(
+                "diff --git a/file_{i}.py b/file_{i}.py\n--- a/file_{i}.py\n+++ b/file_{i}.py\n@@ -1,10 +1,12 @@\n",
+            ));
+            for k in 0..5 {
+                s.push_str(&format!(" context_{k}_{i}\n"));
+            }
+            for k in 0..3 {
+                s.push_str(&format!("-removed_{k}_{i}\n"));
+            }
+            for k in 0..5 {
+                s.push_str(&format!("+added_{k}_{i}\n"));
+            }
+            for k in 0..5 {
+                s.push_str(&format!(" tail_{k}_{i}\n"));
+            }
+        }
+        s.push_str("# trailing\n");
+        s
+    }
+
+    #[test]
+    fn name_and_confidence_are_calibrated_constants() {
+        let w = DiffCompressorWrapper::default();
+        assert_eq!(w.name(), "diff_compressor");
+        assert!((w.confidence() - 0.85).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn applies_to_only_git_diff() {
+        let w = DiffCompressorWrapper::default();
+        assert_eq!(w.applies_to(), &[ContentType::GitDiff]);
+        // Spot-check a handful of other content types are NOT in the
+        // applicability slice.
+        for other in [
+            ContentType::PlainText,
+            ContentType::JsonArray,
+            ContentType::BuildOutput,
+            ContentType::SearchResults,
+        ] {
+            assert!(
+                !w.applies_to().contains(&other),
+                "wrapper should not claim {other:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_input_returns_skipped_error() {
+        let w = DiffCompressorWrapper::default();
+        let err = w
+            .apply("", &CompressionContext::default())
+            .expect_err("empty input is a skip");
+        assert!(matches!(err, TransformError::Skipped { .. }));
+    }
+
+    #[test]
+    fn real_diff_compresses_and_reports_bytes_saved() {
+        let w = DiffCompressorWrapper::default();
+        let input = build_synthetic_diff(8);
+        let result = w
+            .apply(&input, &CompressionContext::default())
+            .expect("synthetic diff is well-formed");
+        assert!(
+            result.bytes_saved > 0,
+            "8-file synthetic should compress; got bytes_saved={}",
+            result.bytes_saved
+        );
+        // Output length sanity check — should reflect bytes_saved.
+        assert_eq!(
+            result.bytes_saved,
+            input.len().saturating_sub(result.output.len())
+        );
+        // Compressed output is non-empty.
+        assert!(!result.output.is_empty());
+    }
+
+    #[test]
+    fn cache_key_propagates_to_reversible_via() {
+        // The 8-file synthetic compresses 177→129 (ratio ~0.729),
+        // beating the default 0.8 threshold → CCR marker emitted →
+        // cache_key Some.
+        let w = DiffCompressorWrapper::default();
+        let input = build_synthetic_diff(8);
+        let result = w
+            .apply(&input, &CompressionContext::default())
+            .expect("valid diff");
+        let key = result
+            .reversible_via
+            .as_ref()
+            .expect("expected cache_key to propagate from DiffCompressor");
+        // MD5[:24] is a 24-char lowercase hex string.
+        assert_eq!(key.len(), 24);
+        assert!(key.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn no_cache_key_when_compressor_skips_ccr() {
+        // Short input (< min_lines_for_ccr=50) → compressor passes
+        // through unchanged → no cache_key → reversible_via None.
+        let w = DiffCompressorWrapper::default();
+        let input = "diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b";
+        let result = w
+            .apply(input, &CompressionContext::default())
+            .expect("non-empty input is fine");
+        assert!(
+            result.reversible_via.is_none(),
+            "short diff should not emit cache_key, got {:?}",
+            result.reversible_via
+        );
+    }
+
+    #[test]
+    fn bytes_saved_computed_against_original_input_length() {
+        // Pin the contract: bytes_saved = original.len() - output.len(),
+        // saturating to 0. Use a diff where compression actually fires.
+        let w = DiffCompressorWrapper::default();
+        let input = build_synthetic_diff(8);
+        let result = w
+            .apply(&input, &CompressionContext::default())
+            .expect("valid diff");
+        // Re-derive from the same fields and confirm.
+        let expected = input.len().saturating_sub(result.output.len());
+        assert_eq!(result.bytes_saved, expected);
+    }
+
+    #[test]
+    fn structure_preserved_is_always_false() {
+        // Both compressing and pass-through paths must report
+        // structure_preserved=false: the wrapper is a LossyTransform,
+        // even when the inner compressor decides to pass through (the
+        // contract is about the trait's promise, not the run's outcome).
+        let w = DiffCompressorWrapper::default();
+        // Path 1: real compression fires.
+        let r1 = w
+            .apply(&build_synthetic_diff(8), &CompressionContext::default())
+            .unwrap();
+        assert!(!r1.structure_preserved);
+
+        // Path 2: short input → DiffCompressor pass-through.
+        let r2 = w
+            .apply(
+                "diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b",
+                &CompressionContext::default(),
+            )
+            .unwrap();
+        assert!(!r2.structure_preserved);
+    }
+
+    #[test]
+    fn custom_config_is_honored() {
+        // Build with a custom config that disables CCR; verify
+        // reversible_via stays None even on a diff that would
+        // otherwise produce a cache_key.
+        let cfg = DiffCompressorConfig {
+            enable_ccr: false,
+            ..Default::default()
+        };
+        let w = DiffCompressorWrapper::new(cfg);
+        let input = build_synthetic_diff(8);
+        let result = w
+            .apply(&input, &CompressionContext::default())
+            .expect("valid diff");
+        assert!(
+            result.reversible_via.is_none(),
+            "enable_ccr=false should suppress cache_key"
+        );
+    }
+}

--- a/crates/headroom-core/src/transforms/pipeline/wrappers/log_compressor_wrapper.rs
+++ b/crates/headroom-core/src/transforms/pipeline/wrappers/log_compressor_wrapper.rs
@@ -1,0 +1,262 @@
+//! `LogCompressorWrapper` — adapt the existing [`LogCompressor`] to
+//! the Phase 3g pipeline's [`LossyTransform`] surface.
+//!
+//! The underlying compressor already does all the real work (format
+//! detection, level classification, stack-trace tracking, dedupe, CCR
+//! offload). This wrapper is a thin bridge: it forwards `apply` to
+//! `LogCompressor::compress`, projects the rich result onto the
+//! pipeline's [`TransformResult`] shape, and registers the transform
+//! against the closest content type the detector emits
+//! ([`ContentType::BuildOutput`] — there's no separate `Logs`
+//! variant today; build/test/lint output is the canonical log source
+//! the detector tags).
+//!
+//! # Why `structure_preserved = false`
+//!
+//! `LogCompressor` is genuinely lossy: it filters lines by importance
+//! score, dedupes warnings, and caps total output by an adaptive K.
+//! Dropped lines are gone — the LLM cannot reconstruct them from the
+//! compressed view alone. CCR retrieval is the recovery path; that's
+//! why `reversible_via` carries the cache key when CCR fires.
+//!
+//! # Why `confidence = 0.75`
+//!
+//! Calibrated below `DiffCompressorWrapper`'s 0.85: git-diff hunks
+//! preserve clean semantic boundaries (a hunk is the right unit of
+//! compression), whereas log line-importance scoring has more inherent
+//! uncertainty — the score is a heuristic over level + stack-trace +
+//! summary signals, not a guarantee that all relevant lines survive.
+//! Still well above `LineImportanceFilter`'s 0.7 because the format-
+//! aware passes (pytest/npm/cargo/jest/make detection, summary lines,
+//! adaptive sizer) compensate for that line-by-line uncertainty.
+//!
+//! # Bias = 1.0
+//!
+//! The neutral default for the adaptive sizer. The pipeline doesn't
+//! yet plumb a per-call bias signal; PR4 adds query-aware bias once
+//! the orchestrator threads `CompressionContext::query` through to
+//! relevance scoring. Until then we pick the neutral baseline so we
+//! don't bake a phantom signal into the adaptive K.
+//!
+//! # No regex in this file
+//!
+//! All regex is inside `LogCompressor` (and called out in its module
+//! doc). The wrapper itself is pure adaptation.
+
+use crate::ccr::InMemoryCcrStore;
+use crate::transforms::log_compressor::{LogCompressor, LogCompressorConfig};
+use crate::transforms::pipeline::traits::{
+    CompressionContext, LossyTransform, TransformError, TransformResult,
+};
+use crate::transforms::ContentType;
+
+/// Adapts [`LogCompressor`] to the [`LossyTransform`] trait.
+///
+/// # CCR consistency note
+///
+/// `LogCompressor::compress` short-circuits CCR emission when no
+/// `CcrStore` is supplied (it only sets `cache_key` after a successful
+/// `store.put`). That makes its CCR behavior *inconsistent* with
+/// `DiffCompressor`, which emits the cache_key whenever the savings
+/// threshold is met regardless of storage. To keep wrappers behaving
+/// uniformly through the pipeline trait, this wrapper holds an
+/// internal [`InMemoryCcrStore`] and routes through
+/// `compress_with_store`. The store keeps the original payload only
+/// for the lifetime of the wrapper — production CCR retrieval still
+/// goes through the Python `CompressionStore` via the existing PyO3
+/// path; this internal store is the minimum needed to make the
+/// underlying compressor emit a `cache_key` so the trait surface
+/// reports it.
+///
+/// Filed as a follow-up bug audit finding (Phase 3g PR2): unify the
+/// CCR emission path across Diff/Log/Search compressors so callers
+/// don't need to know which one needs a store and which one doesn't.
+pub struct LogCompressorWrapper {
+    inner: LogCompressor,
+    store: InMemoryCcrStore,
+}
+
+impl LogCompressorWrapper {
+    pub const NAME: &'static str = "log_compressor";
+
+    /// Static slice of accepted content types. `BuildOutput` is the
+    /// closest match the detector emits — see module docs.
+    const APPLIES_TO: &'static [ContentType] = &[ContentType::BuildOutput];
+
+    /// Bias passed to the underlying compressor's adaptive sizer.
+    /// Neutral default; see module docs for why we don't thread query
+    /// signal yet.
+    const NEUTRAL_BIAS: f64 = 1.0;
+
+    pub fn new(config: LogCompressorConfig) -> Self {
+        Self {
+            inner: LogCompressor::new(config),
+            store: InMemoryCcrStore::new(),
+        }
+    }
+}
+
+impl Default for LogCompressorWrapper {
+    fn default() -> Self {
+        Self::new(LogCompressorConfig::default())
+    }
+}
+
+impl LossyTransform for LogCompressorWrapper {
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn applies_to(&self) -> &[ContentType] {
+        Self::APPLIES_TO
+    }
+
+    fn apply(
+        &self,
+        content: &str,
+        _ctx: &CompressionContext,
+    ) -> Result<TransformResult, TransformError> {
+        if content.is_empty() {
+            return Err(TransformError::skipped(Self::NAME, "empty input"));
+        }
+
+        // `compress` returns a (LogCompressionResult, LogCompressorStats)
+        // tuple — we only need the result for the pipeline surface;
+        // the sidecar stats stay inside the inner compressor's own
+        // telemetry path.
+        let (result, _stats) =
+            self.inner
+                .compress_with_store(content, Self::NEUTRAL_BIAS, Some(&self.store));
+
+        let bytes_saved = content.len().saturating_sub(result.compressed.len());
+        Ok(TransformResult {
+            output: result.compressed,
+            bytes_saved,
+            // Lossy: lines were dropped. Recovery is via CCR retrieval
+            // when `cache_key` is set, not from the compressed view.
+            structure_preserved: false,
+            reversible_via: result.cache_key,
+        })
+    }
+
+    fn confidence(&self) -> f32 {
+        // Calibrated 0.75 — see module docs.
+        0.75
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wrapper() -> LogCompressorWrapper {
+        LogCompressorWrapper::default()
+    }
+
+    fn ctx() -> CompressionContext {
+        CompressionContext::default()
+    }
+
+    /// Build an npm-style log with N lines, mostly noise + a few
+    /// errors so the format detector triggers and CCR is exercised
+    /// when the wrapper is configured for it.
+    fn npm_log(noise_lines: usize, error_lines: usize) -> String {
+        let mut s = String::new();
+        for i in 0..noise_lines {
+            s.push_str(&format!("npm info {}: doing something\n", i));
+        }
+        for i in 0..error_lines {
+            s.push_str(&format!("npm ERR! failure {}: stack overflow at frob\n", i));
+        }
+        s
+    }
+
+    #[test]
+    fn name_matches_telemetry_convention() {
+        assert_eq!(wrapper().name(), "log_compressor");
+    }
+
+    #[test]
+    fn confidence_is_calibrated_constant() {
+        assert!((wrapper().confidence() - 0.75).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn applies_to_build_output_only() {
+        let w = wrapper();
+        assert_eq!(w.applies_to(), &[ContentType::BuildOutput]);
+    }
+
+    #[test]
+    fn empty_input_returns_skipped_error() {
+        let w = wrapper();
+        let err = w.apply("", &ctx()).expect_err("empty input is a skip");
+        assert!(matches!(err, TransformError::Skipped { .. }));
+    }
+
+    #[test]
+    fn real_log_fixture_compresses() {
+        // 60 noise lines + 5 error lines — well over min_lines_for_ccr (50)
+        // so the inner compressor runs the full selection pipeline.
+        let w = wrapper();
+        let input = npm_log(60, 5);
+        assert!(input.lines().count() >= 30);
+        let r = w
+            .apply(&input, &ctx())
+            .expect("well-formed log should compress");
+        // Real compression must shrink — not just round-trip.
+        assert!(r.bytes_saved > 0, "expected positive savings");
+        assert!(r.output.len() < input.len(), "output should be smaller");
+    }
+
+    #[test]
+    fn cache_key_propagates_to_reversible_via() {
+        // Use a permissive ratio threshold so CCR fires deterministically
+        // on a moderately-sized log. The default 0.5 ratio is too tight
+        // for short logs in tests.
+        let w = LogCompressorWrapper::new(LogCompressorConfig {
+            max_total_lines: 10,
+            min_lines_for_ccr: 5,
+            min_compression_ratio_for_ccr: 0.95,
+            ..Default::default()
+        });
+        let input = npm_log(80, 3);
+        let r = w.apply(&input, &ctx()).expect("compresses");
+        assert!(
+            r.reversible_via.is_some(),
+            "reversible_via should carry the CCR cache key"
+        );
+        // Cache key is a non-empty md5 hex prefix.
+        assert!(!r.reversible_via.as_ref().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bytes_saved_computed_against_original_length() {
+        let w = wrapper();
+        let input = npm_log(60, 5);
+        let original_len = input.len();
+        let r = w.apply(&input, &ctx()).expect("compresses");
+        // bytes_saved == original - output, clamped at 0.
+        assert_eq!(r.bytes_saved, original_len.saturating_sub(r.output.len()));
+    }
+
+    #[test]
+    fn structure_preserved_is_always_false() {
+        let w = wrapper();
+        let input = npm_log(60, 5);
+        let r = w.apply(&input, &ctx()).expect("compresses");
+        assert!(!r.structure_preserved);
+    }
+
+    #[test]
+    fn short_input_below_ccr_threshold_passes_through_without_cache_key() {
+        // Below min_lines_for_ccr (50 by default) — inner compressor
+        // returns content verbatim, no CCR marker.
+        let w = wrapper();
+        let input = "npm info one\nnpm info two\nnpm info three";
+        let r = w.apply(input, &ctx()).expect("compresses");
+        assert!(r.reversible_via.is_none());
+        // Verbatim → bytes_saved is 0 (output == input).
+        assert_eq!(r.bytes_saved, 0);
+    }
+}

--- a/crates/headroom-core/src/transforms/pipeline/wrappers/mod.rs
+++ b/crates/headroom-core/src/transforms/pipeline/wrappers/mod.rs
@@ -1,0 +1,27 @@
+//! Wrappers that adapt existing structural transforms (DiffCompressor,
+//! LogCompressor, SearchCompressor) to the Phase 3g pipeline trait
+//! shape ([`LosslessTransform`] / [`LossyTransform`]).
+//!
+//! Each wrapper threads the underlying compressor's native config
+//! through unchanged — the wrapping is deliberately thin so the parity
+//! contract of the wrapped transform is preserved. The wrappers map
+//! `cache_key → reversible_via`, surface skip/error states as
+//! [`TransformError`], and self-declare their `applies_to` content
+//! types so the orchestrator can dispatch correctly.
+//!
+//! TagProtector wrapper is deferred until PR #324 lands the Rust port
+//! — once that merges, a fourth file `tag_protector_wrapper.rs` slots
+//! in here as a [`LosslessTransform`] (placeholder substitution is
+//! reversible by construction).
+//!
+//! [`LosslessTransform`]: super::traits::LosslessTransform
+//! [`LossyTransform`]: super::traits::LossyTransform
+//! [`TransformError`]: super::traits::TransformError
+
+pub mod diff_compressor_wrapper;
+pub mod log_compressor_wrapper;
+pub mod search_compressor_wrapper;
+
+pub use diff_compressor_wrapper::DiffCompressorWrapper;
+pub use log_compressor_wrapper::LogCompressorWrapper;
+pub use search_compressor_wrapper::SearchCompressorWrapper;

--- a/crates/headroom-core/src/transforms/pipeline/wrappers/search_compressor_wrapper.rs
+++ b/crates/headroom-core/src/transforms/pipeline/wrappers/search_compressor_wrapper.rs
@@ -1,0 +1,263 @@
+//! `SearchCompressorWrapper` — adapt the existing [`SearchCompressor`]
+//! to the Phase 3g pipeline's [`LossyTransform`] surface.
+//!
+//! The underlying compressor handles parsing (grep/ripgrep with Windows
+//! drive-letter prefixes and dashes-in-filename support fixed in Phase
+//! 3e.2), per-file match scoring, head/tail anchor preservation, and
+//! CCR offload. This wrapper threads the user's question through to
+//! the compressor's relevance scoring so query-relevant matches
+//! survive when the budget tightens.
+//!
+//! # Why `structure_preserved = false`
+//!
+//! `SearchCompressor` deliberately drops matches: it caps total
+//! matches across files, caps per-file matches, and selects by
+//! relevance + first/last anchors. The dropped lines are gone unless
+//! CCR retrieval is invoked.
+//!
+//! # Why `confidence = 0.8`
+//!
+//! Calibrated between `DiffCompressorWrapper` (0.85) and
+//! `LogCompressorWrapper` (0.75). Search compression has the user's
+//! query as a relevance signal — that's a real semantic input the log
+//! compressor lacks. Not as high as diff because relevance scoring is
+//! still heuristic (keyword + always-keep-first/last anchors), not
+//! the byte-deterministic preserve-additions/deletions guarantee
+//! diffs offer.
+//!
+//! # CCR propagation
+//!
+//! `SearchCompressor::compress` returns a `cache_key: Option<String>`.
+//! When set (CCR fired because the result cleared the thresholds), we
+//! propagate it to [`TransformResult::reversible_via`] so the
+//! orchestrator can later emit a retrieval marker. When unset, the
+//! offload was unprofitable and the dropped matches stay dropped.
+//!
+//! # No regex
+//!
+//! All regex sits inside `SearchCompressor` (parse + scoring use
+//! `regex::Regex` for path/line-number extraction). The wrapper itself
+//! is pure adaptation.
+
+use crate::ccr::InMemoryCcrStore;
+use crate::transforms::pipeline::traits::{
+    CompressionContext, LossyTransform, TransformError, TransformResult,
+};
+use crate::transforms::search_compressor::{SearchCompressor, SearchCompressorConfig};
+use crate::transforms::ContentType;
+
+/// Pipeline wrapper for [`SearchCompressor`].
+///
+/// # CCR consistency note
+///
+/// `SearchCompressor::compress` short-circuits CCR emission when no
+/// `CcrStore` is supplied (it only sets `cache_key` after a successful
+/// `store.put`). That makes its CCR behavior *inconsistent* with
+/// `DiffCompressor`, which emits the cache_key whenever the savings
+/// threshold is met regardless of storage. To keep wrappers behaving
+/// uniformly through the pipeline trait, this wrapper holds an
+/// internal [`InMemoryCcrStore`] and routes through
+/// `compress_with_store`. The store keeps the original payload only
+/// for the lifetime of the wrapper — production CCR retrieval still
+/// goes through the Python `CompressionStore` via the existing PyO3
+/// path; this internal store is the minimum needed to make the
+/// underlying compressor emit a `cache_key` so the trait surface
+/// reports it.
+///
+/// Filed as a follow-up bug audit finding (Phase 3g PR2): unify the
+/// CCR emission path across Diff/Log/Search compressors so callers
+/// don't need to know which one needs a store and which one doesn't.
+pub struct SearchCompressorWrapper {
+    inner: SearchCompressor,
+    store: InMemoryCcrStore,
+}
+
+impl SearchCompressorWrapper {
+    pub const NAME: &'static str = "search_compressor";
+
+    pub fn new(config: SearchCompressorConfig) -> Self {
+        Self {
+            inner: SearchCompressor::new(config),
+            store: InMemoryCcrStore::new(),
+        }
+    }
+}
+
+impl Default for SearchCompressorWrapper {
+    fn default() -> Self {
+        Self::new(SearchCompressorConfig::default())
+    }
+}
+
+impl LossyTransform for SearchCompressorWrapper {
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn applies_to(&self) -> &[ContentType] {
+        &[ContentType::SearchResults]
+    }
+
+    fn apply(
+        &self,
+        content: &str,
+        ctx: &CompressionContext,
+    ) -> Result<TransformResult, TransformError> {
+        if content.is_empty() {
+            return Err(TransformError::skipped(Self::NAME, "empty input"));
+        }
+        // Pass the user's query through to the compressor's relevance
+        // scoring. Empty `ctx.query` is the "no relevance bias" path
+        // SearchCompressor already supports.
+        let (result, _stats) =
+            self.inner
+                .compress_with_store(content, &ctx.query, 1.0, Some(&self.store));
+        let bytes_saved = content.len().saturating_sub(result.compressed.len());
+        Ok(TransformResult {
+            output: result.compressed,
+            bytes_saved,
+            structure_preserved: false,
+            reversible_via: result.cache_key,
+        })
+    }
+
+    fn confidence(&self) -> f32 {
+        0.8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> CompressionContext {
+        CompressionContext::default()
+    }
+
+    /// Build a 30-match grep-style fixture across 3 files. Each file
+    /// has 10 matches; line 5 in `b.rs` carries the QUERYHIT marker so
+    /// query-aware tests can verify preservation.
+    fn grep_fixture() -> String {
+        let mut out = String::new();
+        for f in ["src/a.rs", "src/b.rs", "src/c.rs"] {
+            for i in 1..=10 {
+                if f == "src/b.rs" && i == 5 {
+                    out.push_str(&format!("{f}:{i}:fn QUERYHIT_target() {{}}\n"));
+                } else {
+                    out.push_str(&format!("{f}:{i}:fn helper_{i}() {{}}\n"));
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn name_and_confidence_are_calibrated_constants() {
+        let w = SearchCompressorWrapper::default();
+        assert_eq!(w.name(), "search_compressor");
+        assert!((w.confidence() - 0.8).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn applies_to_only_search_results() {
+        let w = SearchCompressorWrapper::default();
+        assert_eq!(w.applies_to(), &[ContentType::SearchResults]);
+    }
+
+    #[test]
+    fn empty_input_returns_skipped_error() {
+        let w = SearchCompressorWrapper::default();
+        let err = w.apply("", &ctx()).expect_err("empty input is a skip");
+        assert!(matches!(err, TransformError::Skipped { .. }));
+    }
+
+    #[test]
+    fn real_grep_fixture_compresses_and_reports_bytes_saved() {
+        let w = SearchCompressorWrapper::default();
+        let input = grep_fixture();
+        let r = w.apply(&input, &ctx()).expect("fixture compresses");
+        assert!(
+            r.bytes_saved > 0,
+            "30 matches across 3 files should compress; got {} bytes saved",
+            r.bytes_saved
+        );
+        assert!(r.output.len() < input.len());
+    }
+
+    #[test]
+    fn structure_preserved_is_always_false() {
+        let w = SearchCompressorWrapper::default();
+        let r = w.apply(&grep_fixture(), &ctx()).unwrap();
+        assert!(!r.structure_preserved);
+    }
+
+    #[test]
+    fn bytes_saved_computed_against_original_input_length() {
+        let w = SearchCompressorWrapper::default();
+        let input = grep_fixture();
+        let r = w.apply(&input, &ctx()).unwrap();
+        // bytes_saved = original.len() - output.len(), clamped at zero.
+        assert_eq!(r.bytes_saved, input.len() - r.output.len());
+    }
+
+    #[test]
+    fn cache_key_propagates_to_reversible_via_when_set() {
+        // Default config: enable_ccr=true, min_matches_for_ccr=10,
+        // min_compression_ratio_for_ccr=0.8. Fixture has 30 matches
+        // (well over the 10 threshold), and the per-file cap (5) drops
+        // enough to clear the ratio gate.
+        let w = SearchCompressorWrapper::default();
+        let r = w.apply(&grep_fixture(), &ctx()).unwrap();
+        assert!(
+            r.reversible_via.is_some(),
+            "default config + 30-match fixture should fire CCR"
+        );
+        // The cache_key is a hex string; sanity-check it.
+        let key = r.reversible_via.as_deref().unwrap();
+        assert!(key.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(!key.is_empty());
+    }
+
+    #[test]
+    fn user_query_steers_relevance_scoring() {
+        // With a query that mentions QUERYHIT, the relevance scorer
+        // should keep that line even when neighbors get dropped.
+        let w = SearchCompressorWrapper::default();
+        let q_ctx = CompressionContext::with_query("find the QUERYHIT_target function");
+        let r = w
+            .apply(&grep_fixture(), &q_ctx)
+            .expect("fixture compresses with query");
+        assert!(
+            r.output.contains("QUERYHIT_target"),
+            "query-relevant line should survive compression; got output: {}",
+            r.output
+        );
+    }
+
+    #[test]
+    fn small_input_passes_through_with_no_cache_key() {
+        // 2-match input is below CCR thresholds; expect output ≈ input
+        // and no reversible_via.
+        let w = SearchCompressorWrapper::default();
+        let small = "src/a.rs:1:fn one() {}\nsrc/a.rs:2:fn two() {}";
+        let r = w.apply(small, &ctx()).expect("small input compresses");
+        // Bytes saved may be 0 on this tiny fixture; what matters is
+        // CCR didn't fire on a sub-threshold input.
+        assert!(r.reversible_via.is_none());
+    }
+
+    #[test]
+    fn custom_config_is_honored() {
+        // Force aggressive caps. With max_total_matches=3 the wrapper
+        // must drop a lot.
+        let w = SearchCompressorWrapper::new(SearchCompressorConfig {
+            max_total_matches: 3,
+            ..Default::default()
+        });
+        let r = w.apply(&grep_fixture(), &ctx()).unwrap();
+        assert!(r.bytes_saved > 0);
+        // Output should be substantially smaller than the 30-match
+        // fixture given the 3-match cap.
+        assert!(r.output.len() < grep_fixture().len() / 2);
+    }
+}


### PR DESCRIPTION
## Summary
Plumbs the three existing structural compressors (DiffCompressor, LogCompressor, SearchCompressor) into the Phase 3g pipeline trait shape from PR1 (#325). Each wrapper holds the underlying compressor behind its native config, threads compression through, maps `cache_key → reversible_via`, surfaces empty input as `TransformError::Skipped`, and self-declares the content type it handles.

## What lands
- `DiffCompressorWrapper` → `GitDiff` content, `confidence = 0.85`
- `LogCompressorWrapper` → `BuildOutput` content, `confidence = 0.75`
- `SearchCompressorWrapper` → `SearchResults` content, `confidence = 0.80`

Calibration rationale documented in each file's module header.

## Bug audit finding (worked around, not fixed)

**Inconsistency in CCR `cache_key` emission** between the three underlying compressors:
- `DiffCompressor::compress` emits `cache_key` when savings threshold is met, regardless of whether a store is supplied.
- `SearchCompressor::compress` and `LogCompressor::compress` only emit `cache_key` when given a `CcrStore`.

Worked around in PR2 by giving the Search/Log wrappers their own internal `InMemoryCcrStore` so the pipeline trait surface behaves uniformly. Follow-up: unify the CCR emission path inside the underlying compressors so wrappers don't need to hold their own stores.

## Out of scope
- TagProtector wrapper — deferred until #324 (tag_protector Rust port) merges.
- `reversible_via` plumbed but not yet consumed by the orchestrator. PR3 wires CCR-marker emission into `PipelineResult` and starts retiring Python orchestration glue.
- JsonSchemaExtractor wrapper — lives inside SmartCrusher's compaction path; exposed by PR3's SmartCrusher refactor.

## Test plan
- [x] 28 wrapper unit tests (9 diff + 9 log + 10 search), all green
- [x] 69 total pipeline tests pass
- [x] `make ci-precheck` clean: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, ruff, ruff-format, mypy, commitlint