### PR TITLE
fix(memory): make numpy import optional for proxy boot path

### DIFF
--- a/headroom/memory/adapters/sqlite.py
+++ b/headroom/memory/adapters/sqlite.py
@@ -14,12 +14,13 @@ import re
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
-
-import numpy as np
+from typing import TYPE_CHECKING, Any
 
 from ..models import Memory, ScopeLevel
 from ..ports import MemoryFilter
+
+if TYPE_CHECKING:
+    import numpy as np
 
 # Regex pattern for safe metadata keys: alphanumeric, underscores, hyphens only
 # This prevents JSON path injection attacks via malicious key names
@@ -165,6 +166,8 @@ class SQLiteMemoryStore:
         """Serialize numpy array to bytes for BLOB storage."""
         if embedding is None:
             return None
+        import numpy as np
+
         return bytes(embedding.astype(np.float32).tobytes())
 
     def _deserialize_embedding(
@@ -173,6 +176,8 @@ class SQLiteMemoryStore:
         """Deserialize bytes back to numpy array."""
         if data is None:
             return None
+        import numpy as np
+
         arr = np.frombuffer(data, dtype=np.float32)
         return arr
 

--- a/headroom/memory/ports.py
+++ b/headroom/memory/ports.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Protocol, runtime_checkable
-
-import numpy as np
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from headroom.memory.models import Memory, ScopeLevel
+
+if TYPE_CHECKING:
+    import numpy as np
 
 # =============================================================================
 # Filter Dataclasses


### PR DESCRIPTION
## Summary

Fixes #332. The proxy startup chain eagerly loads `headroom.memory.adapters`, which imports `ports.py` and `sqlite.py`. Both files declared `import numpy as np` at module top, but numpy is not in base dependencies — only under `[all]`, `[dev]`, `[evals]`, and `[relevance]` extras. So `pipx install 'headroom-ai[mcp]' && headroom proxy` fails with `ModuleNotFoundError: No module named 'numpy'` even when memory features are disabled (the default).

## Change

Both files already use `from __future__ import annotations`, so `np.ndarray` type hints are strings at runtime — numpy is only needed for static type checkers. Move the module-level `import numpy as np` under a `TYPE_CHECKING` guard. For the only runtime callers — `SQLiteMemoryStore._serialize_embedding` and `_deserialize_embedding` — add a local `import numpy as np` so a missing numpy raises a clear `ImportError` only when embeddings are actually persisted.

Net effect: the proxy boots without numpy installed; memory features that actually use numpy still work when its optional deps are present. Diff is 12 insertions / 6 deletions across 2 files, no behavioral change to memory features that already had numpy available.

## Test plan

- [x] `ruff check` and `ruff format --check` clean on both files
- [x] `mypy headroom` clean (annotations remain valid because `from __future__ import annotations` makes them strings, and the `TYPE_CHECKING` import is visible to type checkers)
- [x] `pre-commit run --all-files` passes (sync-plugin-versions, ruff, ruff-format, mypy)
- [x] Smoke: `from headroom.memory.ports import TextFilter` and `SQLiteMemoryStore(...)` both succeed; `_serialize_embedding(np.array([...]))` and `_deserialize_embedding(b)` round-trip correctly.
- [ ] CI: full test suite (will run on this PR)

## Out of scope

The `[all]` extra is currently uninstallable on Python 3.14 because `rapidocr-onnxruntime>=1.4.0` has no 3.14-compatible release (max is 1.2.3) and `pillow>=10.0.0` fails to build a wheel. That's a separate dependency-pinning issue worth tracking but not addressed here.