### PR TITLE
fix(rust): PyO3 bridge for Rust ICM — PR-C

### DIFF
--- a/crates/headroom-py/src/lib.rs
+++ b/crates/headroom-py/src/lib.rs
@@ -15,9 +15,16 @@
 
 use std::collections::BTreeMap;
 
+use headroom_core::ccr::{CcrStore, InMemoryCcrStore};
+use headroom_core::context::{
+    ApplyCtx as RustApplyCtx, IcmConfig as RustIcmConfig,
+    IntelligentContextManager as RustIntelligentContextManager,
+};
+use headroom_core::scoring::ScoringWeights as RustScoringWeights;
 use headroom_core::signals::{
     ImportanceCategory, ImportanceContext, KeywordDetector, KeywordRegistry, LineImportanceDetector,
 };
+use headroom_core::tokenizer::{EstimatingCounter, Tokenizer};
 use headroom_core::transforms::smart_crusher::compaction::DocumentCompactor;
 use headroom_core::transforms::smart_crusher::{
     CrushResult as RustCrushResult, SmartCrusher as RustSmartCrusher,
@@ -1459,6 +1466,252 @@ fn known_html_tag_names() -> Vec<&'static str> {
 
 // ─── Module init ───────────────────────────────────────────────────────────
 
+// ─── IntelligentContextManager (Rust ICM core) — PR-C ──────────────────────
+//
+// Rust-backed `IntelligentContextManager`. The Python shim
+// `headroom.transforms.intelligent_context.IntelligentContextManager`
+// (PR-D will reshim it) constructs and calls this directly. Single
+// instance per process, reused across requests; releases the GIL on
+// `apply()` so concurrent Python threads keep running through the
+// score-and-drop work.
+
+/// Mirror of `headroom.context.config.IcmConfig`. Six fields — the
+/// simplified OSS surface. Strategy-specific knobs (compress
+/// thresholds, summarization callbacks, memory tiers) are not here;
+/// they belong to Enterprise strategies that get registered separately.
+#[pyclass(name = "IcmConfig", module = "headroom._core")]
+#[derive(Clone)]
+struct PyIcmConfig {
+    inner: RustIcmConfig,
+}
+
+#[pymethods]
+impl PyIcmConfig {
+    #[new]
+    #[pyo3(signature = (
+        enabled = true,
+        keep_system = true,
+        keep_last_turns = 2,
+        output_buffer_tokens = 4000,
+        ccr_on_drop = true,
+        // Scoring weights as separate kwargs so the shim can pass
+        // them positionally or via `**asdict(weights)`.
+        recency = 0.20,
+        semantic_similarity = 0.20,
+        toin_importance = 0.25,
+        error_indicator = 0.15,
+        forward_reference = 0.15,
+        token_density = 0.05,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        enabled: bool,
+        keep_system: bool,
+        keep_last_turns: usize,
+        output_buffer_tokens: usize,
+        ccr_on_drop: bool,
+        recency: f32,
+        semantic_similarity: f32,
+        toin_importance: f32,
+        error_indicator: f32,
+        forward_reference: f32,
+        token_density: f32,
+    ) -> Self {
+        Self {
+            inner: RustIcmConfig {
+                enabled,
+                keep_system,
+                keep_last_turns,
+                output_buffer_tokens,
+                scoring_weights: RustScoringWeights {
+                    recency,
+                    semantic_similarity,
+                    toin_importance,
+                    error_indicator,
+                    forward_reference,
+                    token_density,
+                },
+                ccr_on_drop,
+            },
+        }
+    }
+
+    #[getter]
+    fn enabled(&self) -> bool {
+        self.inner.enabled
+    }
+    #[getter]
+    fn keep_system(&self) -> bool {
+        self.inner.keep_system
+    }
+    #[getter]
+    fn keep_last_turns(&self) -> usize {
+        self.inner.keep_last_turns
+    }
+    #[getter]
+    fn output_buffer_tokens(&self) -> usize {
+        self.inner.output_buffer_tokens
+    }
+    #[getter]
+    fn ccr_on_drop(&self) -> bool {
+        self.inner.ccr_on_drop
+    }
+}
+
+/// Result of `IntelligentContextManager.apply()`. Mirrors
+/// `headroom_core::context::ApplyResult`. Messages come back as a
+/// JSON string — same wire shape as the inputs — so the Python shim
+/// can `json.loads` them straight into the dataclass world.
+#[pyclass(name = "ApplyResult", module = "headroom._core")]
+struct PyApplyResult {
+    messages_json: String,
+    tokens_before: usize,
+    tokens_after: usize,
+    strategies_applied: Vec<String>,
+    markers_inserted: Vec<String>,
+}
+
+#[pymethods]
+impl PyApplyResult {
+    #[getter]
+    fn messages_json(&self) -> &str {
+        &self.messages_json
+    }
+    #[getter]
+    fn tokens_before(&self) -> usize {
+        self.tokens_before
+    }
+    #[getter]
+    fn tokens_after(&self) -> usize {
+        self.tokens_after
+    }
+    #[getter]
+    fn strategies_applied(&self) -> Vec<String> {
+        self.strategies_applied.clone()
+    }
+    #[getter]
+    fn markers_inserted(&self) -> Vec<String> {
+        self.markers_inserted.clone()
+    }
+}
+
+/// Helper: parse a JSON-encoded message list. Panics on bad JSON to
+/// match the existing pyo3-bridge convention (see `crush_array_json`)
+/// — pyo3 0.22's `#[pymethods]` macro hits a `clippy::useless_conversion`
+/// false positive on `PyResult<MyPyclass>` return types, and rewriting
+/// every callsite to dodge it isn't worth the noise. Realistic callers
+/// always pass valid JSON; the Python shim can defensively try/except
+/// if it ever needs to.
+fn parse_messages_json(messages_json: &str) -> Vec<serde_json::Value> {
+    serde_json::from_str(messages_json)
+        .unwrap_or_else(|e| panic!("messages_json must parse as a JSON array: {e}"))
+}
+
+/// Helper: run the cascade and project to the FFI-friendly result.
+/// Panics if re-serialization fails (it can't — we just deserialized
+/// the same shape successfully).
+fn run_icm_apply(
+    icm: &RustIntelligentContextManager,
+    py: Python<'_>,
+    messages: Vec<serde_json::Value>,
+    ctx: RustApplyCtx,
+) -> PyApplyResult {
+    let result = py.allow_threads(|| icm.apply(messages, ctx));
+    let messages_json = serde_json::to_string(&result.messages)
+        .expect("re-serializing already-parsed JSON cannot fail");
+    PyApplyResult {
+        messages_json,
+        tokens_before: result.tokens_before,
+        tokens_after: result.tokens_after,
+        strategies_applied: result
+            .strategies_applied
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        markers_inserted: result.markers_inserted,
+    }
+}
+
+/// Rust-backed `IntelligentContextManager`.
+///
+/// One instance per process. The internal state (`MessageScorer`'s
+/// embedding cache, the strategy list) is `Send + Sync` and shared
+/// across all `apply()` calls. Construct once at proxy startup and
+/// reuse — same lifecycle as the Python implementation.
+///
+/// CCR store is owned internally — an `InMemoryCcrStore` by default.
+/// Sharing the proxy's existing CCR store across SmartCrusher and ICM
+/// is a follow-up; for PR-C the simplest correct contract is a
+/// per-manager store.
+#[pyclass(name = "IntelligentContextManager", module = "headroom._core")]
+struct PyIntelligentContextManager {
+    inner: RustIntelligentContextManager,
+}
+
+#[pymethods]
+impl PyIntelligentContextManager {
+    /// Construct with config + an `InMemoryCcrStore`. The store is
+    /// not surfaced to Python yet — drop persistence and retrieval
+    /// happen entirely inside Rust. PR-D's cutover may wire the
+    /// proxy's existing CCR store through a separate constructor.
+    #[new]
+    #[pyo3(signature = (config = None))]
+    fn new(config: Option<&PyIcmConfig>) -> Self {
+        let cfg = config.map(|c| c.inner.clone()).unwrap_or_default();
+        // EstimatingCounter (chars/4) is the OSS-default tokenizer for
+        // the message-list `count_messages` accounting. Production
+        // proxies that want exact tiktoken can swap via a future
+        // builder; the OSS budget gate is approximate by design.
+        let tokenizer: std::sync::Arc<dyn Tokenizer> =
+            std::sync::Arc::new(EstimatingCounter::default());
+        let store: std::sync::Arc<dyn CcrStore> = std::sync::Arc::new(InMemoryCcrStore::new());
+        Self {
+            inner: RustIntelligentContextManager::new(cfg, tokenizer, Some(store)),
+        }
+    }
+
+    /// `apply(messages_json, model_limit, output_buffer=None, frozen_message_count=0) -> ApplyResult`.
+    ///
+    /// `messages_json` is the OpenAI/Anthropic chat-shape array as a
+    /// JSON string. Returning JSON keeps the FFI surface narrow —
+    /// the Python shim parses on the way out and the proxy already
+    /// has the messages in JSON form anyway.
+    ///
+    /// Releases the GIL across the cascade. Concurrent Python threads
+    /// in the proxy keep running through the scoring + drop walk.
+    #[pyo3(signature = (messages_json, model_limit, output_buffer = None, frozen_message_count = 0))]
+    fn apply(
+        &self,
+        py: Python<'_>,
+        messages_json: &str,
+        model_limit: usize,
+        output_buffer: Option<usize>,
+        frozen_message_count: usize,
+    ) -> PyApplyResult {
+        let messages = parse_messages_json(messages_json);
+        run_icm_apply(
+            &self.inner,
+            py,
+            messages,
+            RustApplyCtx {
+                model_limit,
+                output_buffer,
+                frozen_message_count,
+            },
+        )
+    }
+
+    /// `should_apply(messages_json, model_limit, output_buffer) -> bool`.
+    /// Cheap pre-check; returns `false` when no work is needed and the
+    /// caller can pass-through. Mirrors Python's `should_apply` gate.
+    #[pyo3(signature = (messages_json, model_limit, output_buffer))]
+    fn should_apply(&self, messages_json: &str, model_limit: usize, output_buffer: usize) -> bool {
+        let messages = parse_messages_json(messages_json);
+        self.inner
+            .should_apply(&messages, model_limit, output_buffer)
+    }
+}
+
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(hello, m)?)?;
@@ -1487,5 +1740,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score_line, m)?)?;
     m.add_function(wrap_pyfunction!(content_has_error_indicators, m)?)?;
     m.add_function(wrap_pyfunction!(keyword_registry_snapshot, m)?)?;
+    m.add_class::<PyIcmConfig>()?;
+    m.add_class::<PyApplyResult>()?;
+    m.add_class::<PyIntelligentContextManager>()?;
     Ok(())
 }

--- a/tests/test_rust_icm_bridge.py
+++ b/tests/test_rust_icm_bridge.py
@@ -1,0 +1,103 @@
+"""Smoke tests for the Rust-backed `IntelligentContextManager` PyO3 bridge.
+
+These tests verify the FFI contract — construction, getter access on
+`IcmConfig`, the `should_apply` gate, and the basic shape of
+`apply()`'s return value. The Rust unit tests in
+`crates/headroom-core/src/context/` cover the algorithm itself; this
+file only checks that the Python surface stays wired correctly.
+
+PR-D will add the higher-level Python tests against the new shim.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# Hard import — if the wheel isn't built, fail loudly. Same pattern as
+# the existing diff_compressor / smart_crusher tests.
+from headroom._core import IcmConfig, IntelligentContextManager
+
+
+def _msg(role: str, content: str) -> dict:
+    return {"role": role, "content": content}
+
+
+@pytest.fixture
+def manager() -> IntelligentContextManager:
+    cfg = IcmConfig(keep_last_turns=1, output_buffer_tokens=0, ccr_on_drop=True)
+    return IntelligentContextManager(cfg)
+
+
+def test_icm_config_defaults_match_oss_intent():
+    cfg = IcmConfig()
+    assert cfg.enabled is True
+    assert cfg.keep_system is True
+    assert cfg.keep_last_turns == 2
+    assert cfg.output_buffer_tokens == 4000
+    assert cfg.ccr_on_drop is True
+
+
+def test_icm_config_accepts_kwargs():
+    cfg = IcmConfig(keep_last_turns=5, output_buffer_tokens=100, ccr_on_drop=False)
+    assert cfg.keep_last_turns == 5
+    assert cfg.output_buffer_tokens == 100
+    assert cfg.ccr_on_drop is False
+
+
+def test_should_apply_false_under_budget(manager):
+    msgs = [_msg("user", "hello")]
+    assert manager.should_apply(json.dumps(msgs), model_limit=128_000, output_buffer=4_000) is False
+
+
+def test_should_apply_true_over_budget(manager):
+    msgs = [_msg("user", "x" * 10_000)]
+    assert manager.should_apply(json.dumps(msgs), model_limit=100, output_buffer=0) is True
+
+
+def test_apply_under_budget_is_passthrough(manager):
+    msgs = [_msg("user", "hello"), _msg("assistant", "hi")]
+    result = manager.apply(json.dumps(msgs), model_limit=128_000)
+    assert result.tokens_before == result.tokens_after
+    assert result.strategies_applied == []
+    out = json.loads(result.messages_json)
+    assert out == msgs
+
+
+def test_apply_over_budget_drops_messages_and_emits_marker(manager):
+    msgs = [_msg("user" if i % 2 == 0 else "assistant", f"msg {i} " * 30) for i in range(8)]
+    msgs.append(_msg("user", "final"))
+    initial_json = json.dumps(msgs)
+
+    result = manager.apply(initial_json, model_limit=200, output_buffer=0)
+    out = json.loads(result.messages_json)
+
+    assert result.strategies_applied == ["drop_by_score"]
+    assert result.tokens_after < result.tokens_before
+    assert len(out) < len(msgs)
+    # Final user message is protected by keep_last_turns=1.
+    assert out[-1]["content"] == "final"
+    # CCR marker emitted.
+    assert any("ccr_retrieve" in m for m in result.markers_inserted)
+
+
+def test_apply_invalid_json_raises(manager):
+    # The bridge panics on bad JSON to match the SmartCrusher convention;
+    # pyo3 surfaces panics as `pyo3.PanicException` (a subclass of
+    # `BaseException` outside the normal Exception hierarchy). Accept any
+    # raised exception — realistic callers always pass valid JSON.
+    with pytest.raises(BaseException):  # noqa: B017,PT011
+        manager.apply("not json", model_limit=1000)
+
+
+def test_apply_respects_frozen_message_count(manager):
+    msgs = [_msg("user", "FROZEN " * 50)]
+    for i in range(15):
+        msgs.append(_msg("user", f"filler {i} " * 20))
+    initial_json = json.dumps(msgs)
+
+    result = manager.apply(initial_json, model_limit=200, output_buffer=0, frozen_message_count=1)
+    out = json.loads(result.messages_json)
+    # The first message (frozen) must still be present.
+    assert "FROZEN" in out[0]["content"]


### PR DESCRIPTION
## Summary

PR-C of the simplified IntelligentContext port. Exposes the Rust `IntelligentContextManager` (PR-B) to Python as `headroom._core.IntelligentContextManager` + `IcmConfig` + `ApplyResult`.

**Stack:** rust-message-scorer-port (#338) → rust-icm-core (#340) → **rust-icm-pyo3 (this PR)** → rust-icm-cutover (PR-D, deletes Python).

## Pattern

Mirrors SmartCrusher exactly: one `#[pyclass]` per process, GIL released across `apply()` via `py.allow_threads(...)` so concurrent Python threads keep running through the score-and-drop work. Messages cross the FFI boundary as JSON strings — same wire shape the proxy already has — keeping the binding surface narrow.

## Tests

8 Python smoke tests in `tests/test_rust_icm_bridge.py`:
- `IcmConfig` defaults match OSS intent + accept kwargs
- `should_apply` gates correctly (under/over budget)
- `apply` is passthrough when under budget
- `apply` over budget drops messages, emits CCR marker, preserves last turn
- Frozen prefix is never dropped
- Bad JSON raises (matches SmartCrusher convention)

## Notes

- **Bad JSON panics** (raised as `PanicException`), matching the existing `crush_array_json` convention. Realistic callers always pass valid JSON; the Python shim in PR-D can catch defensively if needed. This dodges a `clippy::useless_conversion` false positive in pyo3 0.22's `#[pymethods]` macro for `PyResult<MyPyclass>` return types.
- An `InMemoryCcrStore` is owned per-manager. Sharing the proxy's existing CCR store across SmartCrusher and ICM is a follow-up; PR-C ships the simplest correct contract.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `pytest tests/test_rust_icm_bridge.py` — 8/8 passing
- [x] `make ci-precheck` passes
- [x] Manual smoke: construct, apply on 8-message over-budget convo, verify drops + CCR marker

## Next

- **PR-D**: Reshim `headroom/transforms/intelligent_context.py` to delegate to `headroom._core`, prune ~27 strategy tests, delete the Python implementation body + `progressive_summarizer.py`.