### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@v0.3.0
+      - uses: Jwrede/tokentoll@v0.4.0

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,17 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@v0.3.0

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@v0.4.0
+      - uses: Jwrede/tokentoll@a4c8ce5f97e751f34498f6503087e5583c02cbbc

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@a4c8ce5f97e751f34498f6503087e5583c02cbbc
+      - uses: Jwrede/tokentoll@cfc9307c2e820de1223fc707ee7e945f6f972379  # v0.5.2

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@ff50a35604b7858d9064cca6354b6229a94f7235  # v0.6.0
+      - uses: Jwrede/tokentoll@753ca4d1150c74169b52a843439049b65e256d2b  # v0.6.1

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@cfc9307c2e820de1223fc707ee7e945f6f972379  # v0.5.2
+      - uses: Jwrede/tokentoll@ff50a35604b7858d9064cca6354b6229a94f7235  # v0.6.0

--- a/.tokentoll.yml
+++ b/.tokentoll.yml
@@ -1,0 +1,1 @@
+default_model: gpt-4o

--- a/.tokentoll.yml
+++ b/.tokentoll.yml
@@ -1,1 +1,0 @@
-default_model: gpt-4o


### PR DESCRIPTION
## Summary

Add [tokentoll](https://github.com/Jwrede/tokentoll) GitHub Action to analyze LLM API cost changes on pull requests.

When a PR modifies code that makes LLM API calls (model swaps, max_tokens changes, new call sites), tokentoll posts a comment showing the projected cost impact. It stays silent on PRs that don't touch LLM code.

## What it detects

tokentoll uses Python AST analysis (zero runtime dependencies) to find calls to:
- OpenAI (`chat.completions.create`, `responses.create`, `embeddings.create`)
- Anthropic (`messages.create`)
- Google GenAI (`generate_content`)
- LiteLLM (`completion`, `embedding`)
- LangChain (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`)
- Zhipu AI / GLM (`ZhipuAiClient`, `ZhipuAI`)

## Current scan of this project

## tokentoll Scan Report

| File | Line | SDK | Model | Est. Cost/Call | Monthly |
|------|------|-----|-------|---------------|---------|
| `benchmarks/compression_benchmark.py` | 413 | openai | gpt-4o-mini | $0.001200 | $1.20 |
| `benchmarks/compression_benchmark.py` | 558 | openai | gpt-4o-mini | $0.000300 | $0.30 |
| `benchmarks/headroom_adversarial_benchmark.py` | 449 | openai | gpt-4o-mini | $0.001275 | $1.27 |
| `benchmarks/headroom_worst_case_benchmark.py` | 660 | openai | gpt-4o-mini | $0.002475 | $2.47 |
| `benchmarks/real_world_agent_benchmark.py` | 564 | openai | gpt-4o-mini | $0.000675 | $0.67 |
| `examples/langchain_demo/run_comparison.py` | 251 | langchain | gpt-4o-mini | $0.002533 | $2.53 |
| `examples/langchain_demo/run_comparison.py` | 160 | langchain | gpt-4o-mini | $0.002533 | $2.53 |
| `examples/mcp_demo/run_agent_eval.py` | 322 | openai | gpt-4o-mini | $0.000675 | $0.67 |
| `examples/test_intelligent_context_toin_ccr.py` | 318 | openai | gpt-4o-mini | $0.000375 | $0.37 |
| `headroom/backends/litellm.py` | 698 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `headroom/backends/litellm.py` | 820 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `headroom/backends/litellm.py` | 1026 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `headroom/backends/litellm.py` | 1159 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `headroom/cli/evals.py` | 480 | litellm | gpt-4o (default) | $0.001502 | $1.50 |
| `headroom/evals/batch_compression_eval.py` | 1064 | openai | gpt-4o (default) | $0.01 | $11.49 |
| `headroom/evals/batch_compression_eval.py` | 1056 | anthropic | claude-sonnet-4-20250514 (default) | $0.02 | $16.86 |
| `headroom/evals/html_extraction.py` | 371 | openai | gpt-4o (default) | $0.005003 | $5.00 |
| `headroom/evals/html_extraction.py` | 270 | openai | gpt-4o (default) | $0.002002 | $2.00 |
| `headroom/evals/html_extraction.py` | 383 | anthropic | claude-sonnet-4-20250514 (default) | $0.007503 | $7.50 |
| `headroom/evals/html_extraction.py` | 296 | anthropic | claude-sonnet-4-20250514 (default) | $0.003003 | $3.00 |
| `headroom/evals/html_extraction.py` | 397 | litellm | gpt-4o (default) | $0.005003 | $5.00 |
| `headroom/evals/html_extraction.py` | 324 | litellm | gpt-4o (default) | $0.002002 | $2.00 |
| `headroom/evals/memory/judge.py` | 85 | openai | gpt-4o | $0.002002 | $2.00 |
| `headroom/evals/memory/judge.py` | 136 | anthropic | gpt-4o | $0.002002 | $2.00 |
| `headroom/evals/memory/judge.py` | 181 | litellm | gpt-4o | $0.002002 | $2.00 |
| `headroom/evals/memory/runner.py` | 325 | litellm | gpt-4o (default) | $0.02 | $20.00 |
| `headroom/evals/prompt_comparison.py` | 271 | openai | gpt-4o | $0.005003 | $5.00 |
| `headroom/evals/runners/before_after.py` | 149 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `headroom/evals/runners/before_after.py` | 178 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `headroom/evals/runners/before_after.py` | 170 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $240.00 |
| `headroom/learn/analyzer.py` | 502 | litellm | gpt-4o (default) | $0.04 | $40.97 |
| `headroom/memory/adapters/embedders.py` | 540 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `headroom/memory/backends/direct_mem0.py` | 264 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `scripts/smoke_issue_327.py` | 112 | anthropic | claude-haiku-4-5-20251001 | $0.001140 | $1.14 |
| `scripts/smoke_issue_327.py` | 107 | anthropic | claude-haiku-4-5-20251001 | $0.001140 | $1.14 |
| `tests/test_bundled_tools_savings.py` | 285 | openai | gpt-4o-mini | $0.000011 | $0.01 |
| `tests/test_bundled_tools_savings.py` | 294 | openai | gpt-4o-mini | $0.000011 | $0.01 |
| `tests/test_bundled_tools_savings.py` | 344 | anthropic | claude-haiku-4-5-20251001 | $0.000088 | $0.09 |
| `tests/test_bundled_tools_savings.py` | 350 | anthropic | claude-haiku-4-5-20251001 | $0.000088 | $0.09 |
| `tests/test_compression/test_llm_eval.py` | 276 | openai | gpt-4o-mini | $0.000300 | $0.30 |
| `tests/test_evals/test_html_oss_benchmarks.py` | 189 | openai | gpt-4o-mini | $0.000060 | $0.06 |
| `tests/test_evals/test_html_oss_benchmarks.py` | 258 | openai | gpt-4o-mini | $0.000060 | $0.06 |
| `tests/test_integrations/langchain/test_langchain_live.py` | 58 | langchain | gpt-4o-mini | $0.002533 | $2.53 |
| `tests/test_integrations/langchain/test_langchain_live.py` | 70 | langchain | claude-sonnet-4-20250514 | $0.24 | $241.50 |
| `tests/test_memory_integration.py` | 245 | openai | gpt-4o-mini | $0.002464 | $2.46 |
| `tests/test_memory_integration.py` | 296 | openai | gpt-4o-mini | $0.002461 | $2.46 |
| `tests/test_memory_integration.py` | 525 | openai | gpt-4o-mini | $0.002461 | $2.46 |
| `tests/test_memory_integration.py` | 546 | openai | gpt-4o-mini | $0.002459 | $2.46 |

**Total estimated monthly cost: $970.35**

<details>
<summary>Assumptions</summary>

- 1000 calls/month per call site

</details>

*Generated by [tokentoll](https://github.com/Jwrede/tokentoll)*

## How it works

- Runs only on PRs, compares base vs head
- Posts a sticky comment (updates in place, no duplicates)
- Only comments when LLM calls are added, removed, or modified
- First run posts an initial scan (this PR) so you can see the output
- Zero runtime dependencies, ~1s scan time for most projects
- [PyPI](https://pypi.org/project/tokentoll/) | [GitHub](https://github.com/Jwrede/tokentoll)

## Changes

- Adds `.github/workflows/llm-costs.yml` (17 lines)
- No code changes, no new dependencies
