### PR TITLE
fix(ci): unbreak release pipeline — wheel openssl + dead npm artifact downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,12 +206,51 @@ jobs:
         run: |
           python scripts/version-sync.py --version ${{ needs.detect-version.outputs.npm_version }}
 
+      # macOS Intel runner does NOT have OpenSSL on the openssl-sys
+      # default lookup path; aarch64 finds it via /opt/homebrew/opt/openssl@3
+      # but x86_64 runners use /usr/local/Cellar which openssl-sys does
+      # not auto-discover. Resolve OPENSSL_DIR explicitly so openssl-sys
+      # (transitive via fastembed → hf-hub → ureq → native-tls) builds
+      # on both Apple silicon and Intel.
+      - name: Install OpenSSL (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          brew install openssl@3 pkg-config
+          openssl_dir="$(brew --prefix openssl@3)"
+          {
+            echo "OPENSSL_DIR=$openssl_dir"
+            echo "OPENSSL_LIB_DIR=$openssl_dir/lib"
+            echo "OPENSSL_INCLUDE_DIR=$openssl_dir/include"
+            echo "PKG_CONFIG_PATH=$openssl_dir/lib/pkgconfig"
+          } >> "$GITHUB_ENV"
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter python3.10 python3.11 python3.12 python3.13
           manylinux: ${{ matrix.manylinux }}
+          # cibuildwheel/maturin-action spins up its own manylinux
+          # container; the e2e Dockerfiles' yum install openssl-devel
+          # is not inherited. Install build-time native deps inside
+          # whatever distro the manylinux image happens to be (RHEL
+          # family uses yum, Debian-family musllinux uses apt). Without
+          # this, openssl-sys (pulled by fastembed → hf-hub → ureq →
+          # native-tls) fails: "pkg-config exited with status code 1 —
+          # Package openssl was not found". Only runs for Linux builds;
+          # macOS sets up via the brew step above.
+          before-script-linux: |
+            set -euo pipefail
+            if command -v yum >/dev/null 2>&1; then
+              yum install -y openssl-devel pkgconfig perl-IPC-Cmd
+            elif command -v apt-get >/dev/null 2>&1; then
+              apt-get update
+              apt-get install -y --no-install-recommends libssl-dev pkg-config
+            else
+              echo "::error::No supported package manager (yum/apt-get) found in manylinux container" >&2
+              exit 1
+            fi
         env:
           # PyO3 0.22 supports up to Python 3.13; allow forward-compat
           # builds for 3.14+ until we bump PyO3 (tracked separately).
@@ -315,11 +354,14 @@ jobs:
           node-version: "20"
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
-      - name: Download dist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
+      # No artifact download required: the publish steps below pack and
+      # publish directly from the checked-out source tree (sdk/typescript
+      # and plugins/openclaw) via `npm pack` + `npm publish`. The
+      # `dist` artifact is a Python-distribution aggregate produced by
+      # `collect-dist`; it has no npm content. Earlier versions of
+      # this workflow downloaded it speculatively, which now fails as
+      # "Artifact not found" because publish-npm is not gated on
+      # collect-dist. Removing the dead step is the right fix.
 
       - name: Publish ${{ env.NPM_SDK_PACKAGE }} (TypeScript SDK) to npmjs.org
         id: npm-sdk-publish
@@ -374,11 +416,11 @@ jobs:
           node-version: "20"
           registry-url: ${{ env.GITHUB_PACKAGES_REGISTRY_URL }}
 
-      - name: Download dist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
+      # No artifact download required: the publish-github-packages flow
+      # below `npm pack`s its own scoped tarball into a workdir and
+      # publishes that. Same reasoning as publish-npm — the speculative
+      # `dist` download was failing "Artifact not found" because this
+      # job is not gated on `collect-dist`.
 
       - name: Publish ${{ env.NPM_SDK_PACKAGE }} to GitHub Package Registry
         id: gpr-sdk-publish

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -67,3 +67,63 @@ def test_ci_commitlint_skips_default_github_merge_commits() -> None:
 
     assert "github.event_name != 'push'" in content
     assert "!startsWith(github.event.head_commit.message, 'Merge pull request ')" in content
+
+
+def test_build_wheels_installs_openssl_devel_on_linux_via_before_script() -> None:
+    """The wheel matrix uses PyO3/maturin-action's manylinux container,
+    which does not inherit our e2e Dockerfiles' yum installs. Without an
+    explicit before-script-linux, openssl-sys (transitive via fastembed
+    → hf-hub → ureq → native-tls) fails to find pkg-config'd OpenSSL
+    and the Linux x86_64/aarch64 wheels never build.
+    """
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert "before-script-linux:" in content
+    assert "yum install -y openssl-devel" in content
+    # apt-get fallback for non-RHEL manylinux variants
+    assert "libssl-dev pkg-config" in content
+
+
+def test_build_wheels_resolves_openssl_dir_explicitly_on_macos() -> None:
+    """macOS Intel runners (`macos-15-intel`) keep Homebrew under
+    `/usr/local/Cellar`, which `openssl-sys` does not auto-discover.
+    aarch64 runners use `/opt/homebrew/opt/openssl@3` which IS on the
+    default path. Setting OPENSSL_DIR explicitly fixes Intel without
+    regressing aarch64.
+    """
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert "Install OpenSSL (macOS)" in content
+    assert "if: runner.os == 'macOS'" in content
+    assert "brew install openssl@3" in content
+    assert 'echo "OPENSSL_DIR=$openssl_dir"' in content
+
+
+def test_npm_publish_jobs_do_not_download_dist_artifact() -> None:
+    """`publish-npm` and `publish-github-packages` `npm pack`+`npm publish`
+    directly from the checked-out source tree; they never read the
+    Python `dist` artifact. The earlier speculative download was failing
+    "Artifact not found" because neither job is gated on `collect-dist`.
+    Ensure no future refactor re-adds the dead step.
+    """
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    # Locate publish-npm + publish-github-packages bodies and assert
+    # neither contains a download-artifact step that pulls `name: dist`.
+    npm_start = content.index("\n  publish-npm:")
+    npm_end = content.index("\n  publish-github-packages:")
+    publish_npm_body = content[npm_start:npm_end]
+
+    gpr_start = content.index("\n  publish-github-packages:")
+    gpr_end = content.index("\n  publish-docker:")
+    publish_gpr_body = content[gpr_start:gpr_end]
+
+    for body, label in (
+        (publish_npm_body, "publish-npm"),
+        (publish_gpr_body, "publish-github-packages"),
+    ):
+        assert "download-artifact" not in body, (
+            f"{label} must not download the `dist` artifact — it `npm pack`s "
+            f"its own tarball and the speculative download fails when "
+            f"collect-dist hasn't run."
+        )


### PR DESCRIPTION
## Summary

The post-merge release run for PR #360 fails on five jobs:

| Job | Failure |
|---|---|
| `build-wheels (ubuntu-x86_64)` | `openssl-sys` can't find OpenSSL via pkg-config |
| `build-wheels (aarch64-unknown-linux-gnu)` | same — manylinux container has no `openssl-devel` |
| `build-wheels (macos-15-intel)` | same — `/usr/local/Cellar` not on `openssl-sys` lookup path |
| `publish-npm` | `Artifact not found for name: dist` (speculative download) |
| `publish-github-packages` | same |

Run reference: https://github.com/chopratejas/headroom/actions/runs/25292378094

All three classes are introduced by PR #360's release-workflow restructure and only surface on a real `push: main` event. PR-level CI runs `ci.yml`, not `release.yml`, so the regressions weren't caught at PR time.

## Fixes

### 1. Linux wheels — install OpenSSL inside `maturin-action`'s container

Added `before-script-linux:` to the `PyO3/maturin-action@v1` step with a yum/apt-get conditional:

- RHEL family (manylinux2014, manylinux_2_28): `yum install -y openssl-devel pkgconfig perl-IPC-Cmd`
- Debian family (musllinux variants we don't currently use, but defensive): `apt-get install libssl-dev pkg-config`

The e2e Dockerfiles already do this — the maturin-action's container is independent and didn't inherit them.

### 2. macOS — explicit `OPENSSL_DIR`

`aarch64-apple-darwin` happens to find OpenSSL via `/opt/homebrew/opt/openssl@3` (on `openssl-sys`'s default discovery path). `x86_64-apple-darwin` uses `/usr/local/Cellar` (NOT discovered). New step before the maturin step:

```yaml
- name: Install OpenSSL (macOS)
  if: runner.os == 'macOS'
  run: |
    brew install openssl@3 pkg-config
    openssl_dir="$(brew --prefix openssl@3)"
    echo "OPENSSL_DIR=$openssl_dir" >> $GITHUB_ENV
    # ... LIB_DIR, INCLUDE_DIR, PKG_CONFIG_PATH
```

Setting these explicitly fixes Intel without regressing aarch64.

### 3. `publish-npm` and `publish-github-packages` — remove dead `dist` download

Both jobs `npm pack` + `npm publish` directly from the checked-out source tree. They never read the `dist` artifact. The download step was vestigial — it worked by accident before #360 (the old `build` job uploaded `dist`); now `dist` is produced by `collect-dist` and these jobs aren't gated on it (loose npm/PyPI coupling is intentional).

Removing the dead step is the correct fix. `create-release` still requires every publish to succeed before tagging, so the strict coupling lives where it should.

## Tests

3 regression tests added to `tests/test_release_workflows.py` — all 9 release-workflow tests pass:

- `test_build_wheels_installs_openssl_devel_on_linux_via_before_script`
- `test_build_wheels_resolves_openssl_dir_explicitly_on_macos`
- `test_npm_publish_jobs_do_not_download_dist_artifact`

`make ci-precheck` PASSED locally.

## Test plan

- [ ] CI green on this PR
- [ ] Merge → next push to main runs the release pipeline → all 4 wheel matrix entries build, both npm publishers succeed, `collect-dist` aggregates, `publish-pypi` runs, `create-release` tags