### PR TITLE
fix(ci): vendored OpenSSL must live in headroom-py, not headroom-proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
  "fastembed",
  "flate2",
  "hf-hub 0.4.3",
- "http",
+ "http 1.4.0",
  "magika",
  "md-5",
  "proptest",
@@ -1892,6 +1892,7 @@ name = "headroom-py"
 version = "0.1.0"
 dependencies = [
  "headroom-core",
+ "openssl",
  "pyo3",
  "serde_json",
 ]

--- a/crates/headroom-py/Cargo.toml
+++ b/crates/headroom-py/Cargo.toml
@@ -25,3 +25,19 @@ extension-module = ["pyo3/extension-module"]
 headroom-core = { path = "../headroom-core" }
 pyo3 = { workspace = true }
 serde_json = { workspace = true }
+# `headroom-core` pulls `openssl-sys` transitively via fastembed →
+# hf-hub → ureq → native-tls. The wheel matrix's manylinux_2_28
+# x86_64 container has no `openssl-devel`, and even with one the
+# manylinux2014 fallback ships OpenSSL 1.0.2k which `openssl-sys 0.9`
+# rejects. We force the `vendored` feature on `openssl` so cargo
+# compiles OpenSSL from source as part of the wheel build, removing
+# the system-OpenSSL dependency entirely.
+#
+# Why this dep lives HERE (the wheel-producing crate) rather than
+# headroom-proxy: cargo's feature unification only applies to the
+# resolution graph that's actually built. `maturin build --manifest-path
+# crates/headroom-py/Cargo.toml` resolves from headroom-py's deps
+# only — headroom-proxy's `openssl/vendored` enable doesn't propagate
+# because headroom-py never depends on headroom-proxy. Pinning the
+# vendored feature on headroom-py's own deps is the right fix.
+openssl = { version = "0.10", features = ["vendored"] }

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -69,21 +69,30 @@ def test_ci_commitlint_skips_default_github_merge_commits() -> None:
     assert "!startsWith(github.event.head_commit.message, 'Merge pull request ')" in content
 
 
-def test_headroom_proxy_vendors_openssl() -> None:
+def test_headroom_py_vendors_openssl() -> None:
     """`hf-hub` (transitive via `fastembed`) hard-codes `native-tls` as a
-    default feature, forcing `openssl-sys` for the entire workspace
+    default feature, forcing `openssl-sys` for the entire build graph
     despite our `reqwest`/`tokio-tungstenite`/`tokio-rustls` preferences.
-    The wheel matrix breaks on every Linux + Intel-macOS target where
-    the manylinux container's system OpenSSL is too old (manylinux2014
-    ships 1.0.2k) or the cross-compile sysroot has none (aarch64).
-    Enabling the `vendored` Cargo feature on `openssl` instructs
-    `openssl-sys` to compile OpenSSL from source — works on every
-    target uniformly.
-    """
-    cargo_toml = (ROOT / "crates" / "headroom-proxy" / "Cargo.toml").read_text(encoding="utf-8")
 
-    # Guard against a future refactor that re-removes the vendored dep.
-    assert 'openssl = { version = "0.10", features = ["vendored"] }' in cargo_toml
+    Critically: this dep MUST live in `headroom-py/Cargo.toml` (the
+    wheel-producing crate) — NOT in `headroom-proxy/Cargo.toml`. Cargo's
+    feature unification only applies to the resolution graph that's
+    actually built. `maturin build --manifest-path crates/headroom-py/
+    Cargo.toml` resolves headroom-py's deps only; headroom-py does NOT
+    depend on headroom-proxy, so a `vendored` feature enable in
+    headroom-proxy never propagates to the wheel build. The earlier
+    hot-fix put it in headroom-proxy and the wheel still failed with
+    "Could not find directory of OpenSSL installation" — fixed by
+    moving the dep to headroom-py.
+    """
+    py_cargo = (ROOT / "crates" / "headroom-py" / "Cargo.toml").read_text(encoding="utf-8")
+
+    # Guard against a future refactor that re-removes the vendored dep
+    # from headroom-py (would silently break the wheel build again).
+    assert 'openssl = { version = "0.10", features = ["vendored"] }' in py_cargo, (
+        "headroom-py/Cargo.toml must declare openssl with the vendored feature; "
+        "without it the manylinux wheel build cannot find system OpenSSL."
+    )
 
 
 def test_build_wheels_installs_perl_ipc_cmd_for_vendored_openssl() -> None:


### PR DESCRIPTION
## What's failing

After PR #369 (aarch64 perl install fix) landed, the next release run on `1323830f` showed aarch64 + macOS wheels build successfully — but **x86_64 Linux still fails**:

```
The system library `openssl` required by crate `openssl-sys` was not found.
HINT: you may need to install a package such as openssl, openssl-dev or openssl-devel.
```

Run reference: https://github.com/chopratejas/headroom/actions/runs/25299008222

## Why my previous reasoning was wrong

PR #367 added `openssl = { features = ["vendored"] }` to `crates/headroom-proxy/Cargo.toml` expecting cargo's feature unification to propagate vendored across the whole workspace.

**Cargo's feature unification only applies to the resolution graph that's actually built.**

`maturin build --manifest-path crates/headroom-py/Cargo.toml` resolves only headroom-py's deps — and headroom-py does NOT depend on headroom-proxy. So the `openssl/vendored` enable in headroom-proxy never propagates to the wheel build.

`cargo tree -p headroom-py -e features` confirms:
- Before this fix: `openssl-sys feature "default"` only, no vendored
- After this fix: `openssl-sys feature "vendored"` → pulls `openssl-src v300.6.0+3.6.2`

(I missed this when testing locally because `cargo build -p headroom-py` from the workspace root reads the workspace's Cargo.lock — already populated with `openssl-src` from when I added the dep to headroom-proxy. The CI job does a fresh resolution against headroom-py's manifest where the vendored feature isn't enabled. **My local test was a false positive.**)

## Fix

Move the openssl dep from `headroom-proxy/Cargo.toml` to `headroom-py/Cargo.toml`. The wheel-producing crate now declares the feature directly. Local `cargo build --release -p headroom-py` confirms openssl-src is compiled (35s wheel build).

## Tests

- `test_headroom_py_vendors_openssl` (renamed) gates the dep on the right crate
- Docstring explains WHY it must live in headroom-py so a future refactor doesn't move it back to headroom-proxy and silently re-break the wheel build

All 11 release-workflow tests pass. `make ci-precheck` PASSED.

## Test plan

- [ ] CI green on this PR
- [ ] Merge → next push triggers release pipeline → x86_64 Linux wheel completes (it's the last gating job; aarch64 Linux + aarch64 macOS already work) → `collect-dist` → `publish-pypi` → `create-release` tags v0.20.16+