### PR TITLE
ci: native arm64 runners — drop QEMU, cut wheel + docker build time

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,28 +29,36 @@ permissions:
   id-token: write # For cosign keyless signing via Sigstore OIDC
 
 jobs:
-  docker-variant-tags:
-    runs-on: ubuntu-latest
+  # ─── Per-arch fan-out ──────────────────────────────────────────────────────
+  # Build each variant on its native architecture in parallel:
+  #   linux/amd64 → ubuntu-24.04 (native x86_64)
+  #   linux/arm64 → ubuntu-24.04-arm (native aarch64, GA Jan 2025)
+  #
+  # Pre-#377 we ran a single matrix job per variant on `ubuntu-latest` and
+  # let bake's `platforms = ["linux/amd64", "linux/arm64"]` do multi-arch
+  # via QEMU emulation — ~1h per variant. Native arm64 runners drop QEMU
+  # entirely and cut each variant to ~10 min on each arch in parallel.
+  #
+  # Each per-arch build pushes by digest only (no tags). The
+  # `docker-manifest` job below combines the per-arch digests into the
+  # final multi-arch tagged manifest, which is what users pull by tag.
+  docker-build:
+    runs-on: ${{ matrix.arch.runs_on }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - variant: ""
-            bake_target: runtime
-          - variant: nonroot
-            bake_target: runtime-nonroot
-          - variant: code
-            bake_target: runtime-code
-          - variant: code-nonroot
-            bake_target: runtime-code-nonroot
-          - variant: slim
-            bake_target: runtime-slim
-          - variant: slim-nonroot
-            bake_target: runtime-slim-nonroot
-          - variant: code-slim
-            bake_target: runtime-code-slim
-          - variant: code-slim-nonroot
-            bake_target: runtime-code-slim-nonroot
+        variant:
+          - { name: "", bake_target: runtime }
+          - { name: nonroot, bake_target: runtime-nonroot }
+          - { name: code, bake_target: runtime-code }
+          - { name: code-nonroot, bake_target: runtime-code-nonroot }
+          - { name: slim, bake_target: runtime-slim }
+          - { name: slim-nonroot, bake_target: runtime-slim-nonroot }
+          - { name: code-slim, bake_target: runtime-code-slim }
+          - { name: code-slim-nonroot, bake_target: runtime-code-slim-nonroot }
+        arch:
+          - { name: amd64, runs_on: ubuntu-24.04, platform: linux/amd64 }
+          - { name: arm64, runs_on: ubuntu-24.04-arm, platform: linux/arm64 }
 
     steps:
       - uses: actions/checkout@v6
@@ -84,8 +92,132 @@ jobs:
         run: |
           python scripts/version-sync.py --version ${{ steps.version.outputs.version }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Labels (not tags) for the per-arch image. Tags belong on the
+      # multi-arch index manifest and are applied in docker-manifest.
+      - name: Extract image labels
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+
+      - name: Build and push by digest (single platform)
+        id: bake
+        uses: docker/bake-action@v7
+        with:
+          files: |
+            ./docker-bake.hcl
+            cwd://${{ steps.meta.outputs.bake-file-labels }}
+          targets: ${{ matrix.variant.bake_target }}
+          push: true
+          # `*.platform` overrides the [amd64,arm64] default in
+          # docker-bake.hcl. `push-by-digest=true,name-canonical=true`
+          # tells buildx to push the per-platform manifest with no tags
+          # — only the digest is recorded — so multiple per-arch builds
+          # can coexist in the registry until the manifest job stitches
+          # them. GHA cache is scoped per (variant, arch) so the two
+          # arches don't fight over the same cache key.
+          set: |
+            *.platform=${{ matrix.arch.platform }}
+            *.output=type=image,push-by-digest=true,name-canonical=true,push=true
+            *.cache-from=type=gha,scope=${{ matrix.variant.name || 'root' }}-${{ matrix.arch.name }}
+            *.cache-to=type=gha,mode=max,scope=${{ matrix.variant.name || 'root' }}-${{ matrix.arch.name }}
+
+      - name: Export digest
+        id: digest
+        env:
+          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
+        run: |
+          # Bake's metadata is one entry per target; for a single-target
+          # single-platform build it has exactly one digest. Pipe the
+          # JSON through a file (same ARG_MAX rationale as before) and
+          # extract that digest.
+          cat > "${RUNNER_TEMP}/bake_meta.json" <<'__HEADROOM_BAKE_META_EOF__'
+          ${{ steps.bake.outputs.metadata }}
+          __HEADROOM_BAKE_META_EOF__
+          digest="$(jq -r 'to_entries[0].value."containerimage.digest" // empty' \
+              "${RUNNER_TEMP}/bake_meta.json")"
+          if [ -z "$digest" ]; then
+            echo "ERROR: no digest in bake metadata" >&2
+            cat "${RUNNER_TEMP}/bake_meta.json" >&2
+            exit 1
+          fi
+          printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
+          # Stage a marker file named after the bare hex digest. The
+          # manifest job downloads all per-arch markers for a variant
+          # and reconstructs `IMAGE@sha256:<digest>` references from
+          # the filenames.
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest marker
+        uses: actions/upload-artifact@v4
+        with:
+          # Variant + arch in the artifact name so the manifest job can
+          # download with `pattern: digests-<variant>-*` to gather all
+          # arches for one variant. `root` substitutes the empty-string
+          # variant since GHA artifact names can't end in a hyphen.
+          name: digests-${{ matrix.variant.name || 'root' }}-${{ matrix.arch.name }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ─── Per-variant manifest merge ────────────────────────────────────────────
+  # One job per variant, after both arch builds for that variant complete.
+  # `docker buildx imagetools create` stitches the two per-arch digests
+  # into a single multi-arch index manifest, applies the metadata-action
+  # tags, and that manifest is what users pull by `:tag`.
+  docker-manifest:
+    needs: docker-build
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - { name: "", bake_target: runtime }
+          - { name: nonroot, bake_target: runtime-nonroot }
+          - { name: code, bake_target: runtime-code }
+          - { name: code-nonroot, bake_target: runtime-code-nonroot }
+          - { name: slim, bake_target: runtime-slim }
+          - { name: slim-nonroot, bake_target: runtime-slim-nonroot }
+          - { name: code-slim, bake_target: runtime-code-slim }
+          - { name: code-slim-nonroot, bake_target: runtime-code-slim-nonroot }
+
+    steps:
+      # No `actions/checkout` here: the manifest job only calls
+      # `docker buildx imagetools` against the registry and runs
+      # cosign — neither needs the repo on disk. Skipping checkout
+      # saves a few seconds across 8 parallel manifest jobs.
+      - name: Normalize image name
+        id: image-name
+        run: |
+          image_name="$(printf '%s' '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          printf 'image_name=%s\n' "$image_name" >> "$GITHUB_OUTPUT"
+
+      - name: Determine image version
+        id: version
+        env:
+          MANUAL_VERSION: ${{ inputs.version || github.event.inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${MANUAL_VERSION#v}"
+          if [ -z "$version" ] && [ -n "$RELEASE_TAG" ]; then
+            version="${RELEASE_TAG#v}"
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Compute short SHA
+        id: short-sha
+        run: printf 'sha=%s\n' "${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -97,83 +229,111 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compute short SHA
-        id: short-sha
-        run: printf 'sha=%s\n' "${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+      - name: Download per-arch digests for this variant
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digests-${{ matrix.variant.name || 'root' }}-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
 
+      # Same tag rules as the pre-fan-out workflow — preserve every
+      # tag flavor (semver, ref, sha-prefixed, version-suffixed,
+      # bare variant) so existing pull URLs keep working.
       - name: Extract metadata (variant)
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
           tags: |
-            type=ref,event=branch,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
-            type=ref,event=pr,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
-            type=raw,value=${{ steps.version.outputs.version }}-${{ steps.short-sha.outputs.sha }},enable=${{ steps.version.outputs.version != '' && matrix.variant == '' }}
-            type=raw,value=${{ steps.version.outputs.version }}-${{ matrix.variant }}-${{ steps.short-sha.outputs.sha }},enable=${{ steps.version.outputs.version != '' && matrix.variant != '' }}
-            type=semver,pattern={{version}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
-            type=semver,pattern={{major}}.{{minor}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
-            type=semver,pattern={{major}},suffix=${{ matrix.variant != '' && format('-{0}', matrix.variant) || '' }}
-            type=sha,format=short,prefix=${{ matrix.variant != '' && format('{0}-', matrix.variant) || 'sha-' }}
-            type=raw,value=${{ matrix.variant }},enable=${{ matrix.variant != '' }}
+            type=ref,event=branch,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
+            type=ref,event=pr,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
+            type=raw,value=${{ steps.version.outputs.version }}-${{ steps.short-sha.outputs.sha }},enable=${{ steps.version.outputs.version != '' && matrix.variant.name == '' }}
+            type=raw,value=${{ steps.version.outputs.version }}-${{ matrix.variant.name }}-${{ steps.short-sha.outputs.sha }},enable=${{ steps.version.outputs.version != '' && matrix.variant.name != '' }}
+            type=semver,pattern={{version}},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
+            type=semver,pattern={{major}}.{{minor}},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
+            type=semver,pattern={{major}},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
+            type=sha,format=short,prefix=${{ matrix.variant.name != '' && format('{0}-', matrix.variant.name) || 'sha-' }}
+            type=raw,value=${{ matrix.variant.name }},enable=${{ matrix.variant.name != '' }}
 
-      - name: Build and push variant (bake)
-        id: bake
-        uses: docker/bake-action@v7
-        with:
-          files: |
-            ./docker-bake.hcl
-            cwd://${{ steps.meta.outputs.bake-file-tags }}
-            cwd://${{ steps.meta.outputs.bake-file-labels }}
-          targets: ${{ matrix.bake_target }}
-          push: true
-          set: |
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+      - name: Create multi-arch manifest
+        id: manifest
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          DIGEST_DIR: ${{ runner.temp }}/digests
+        run: |
+          # Reconstruct full image references from the digest marker
+          # filenames (each file is named after the bare hex digest
+          # of one per-arch manifest).
+          if ! ls "${DIGEST_DIR}"/* >/dev/null 2>&1; then
+            echo "ERROR: no digests downloaded for variant '${{ matrix.variant.name || 'root' }}'" >&2
+            exit 1
+          fi
+          digest_refs=()
+          for f in "${DIGEST_DIR}"/*; do
+            digest="$(basename "$f")"
+            digest_refs+=("${IMAGE}@sha256:${digest}")
+          done
+
+          # Build `--tag` args from the metadata-action JSON output.
+          # Empty tags array is valid (PR builds without ref-tags
+          # enabled emit nothing); skip manifest creation in that case.
+          tag_args=()
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && tag_args+=("--tag" "$tag")
+          done < <(jq -r '.tags[]?' <<< '${{ steps.meta.outputs.json }}')
+
+          if [ "${#tag_args[@]}" -eq 0 ]; then
+            echo "No tags to apply for variant '${{ matrix.variant.name || 'root' }}'; skipping manifest."
+            exit 0
+          fi
+
+          docker buildx imagetools create \
+            "${tag_args[@]}" \
+            "${digest_refs[@]}"
+
+          # Resolve the index manifest digest of the freshly pushed
+          # multi-arch manifest so cosign can sign it directly. We
+          # ask the registry via `imagetools inspect` and read the
+          # `.manifest.digest` field — that's the registry's own
+          # record of the index digest (no client-side hashing).
+          first_tag="$(jq -r '.tags[0]' <<< '${{ steps.meta.outputs.json }}')"
+          index_digest="$(docker buildx imagetools inspect "${first_tag}" \
+              --format '{{ json . }}' | jq -r '.manifest.digest')"
+          if [ -z "$index_digest" ] || [ "$index_digest" = "null" ]; then
+            echo "ERROR: could not resolve index digest for ${first_tag}" >&2
+            exit 1
+          fi
+          printf 'index_digest=%s\n' "$index_digest" >> "$GITHUB_OUTPUT"
+          printf 'first_tag=%s\n' "$first_tag" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
+        if: steps.manifest.outputs.index_digest != ''
         uses: sigstore/cosign-installer@v3
 
-      - name: Sign images with cosign (keyless via Sigstore OIDC)
+      - name: Sign multi-arch index manifest with cosign
+        if: steps.manifest.outputs.index_digest != ''
         env:
-          # Route signatures to a sibling GHCR package so the main image's
-          # package version list stays clean. GHCR does not implement the OCI 1.1
-          # referrers API yet (community discussion #163029, June 2025), so
-          # cosign's OCI 1.1 mode falls back to writing referrer tags into the
-          # *image's* repo. Using legacy signature mode here lets COSIGN_REPOSITORY
-          # actually relocate the artifacts. Verifiers must export the same
-          # COSIGN_REPOSITORY value when running 'cosign verify'.
+          # Same routing as before: keep signature artifacts in a
+          # sibling GHCR package so the main image's version listing
+          # stays clean. Verifiers must export the same
+          # COSIGN_REPOSITORY when running 'cosign verify'. See the
+          # pre-#377 workflow for the GHCR/OCI-1.1 referrers context.
           COSIGN_REPOSITORY: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}-signatures
+          IMAGE: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          INDEX_DIGEST: ${{ steps.manifest.outputs.index_digest }}
         run: |
-          # Write bake metadata to a file rather than pass it through
-          # the `env:` block. The `code-nonroot` and `runtime-code-nonroot`
-          # bake targets emit metadata blobs large enough that combined
-          # argv+env at bash spawn exceeds Linux ARG_MAX (~128 KiB on
-          # ubuntu-latest), failing with `E2BIG: Argument list too long`
-          # before the script can run. The heredoc puts the JSON in the
-          # script body (which is read from a temp file by bash, no
-          # ARG_MAX limit) and we read it back via `jq -f`-style file
-          # input. Sentinel chosen long enough that no JSON payload is
-          # plausibly going to collide with it.
-          cat > "${RUNNER_TEMP}/bake_meta.json" <<'__HEADROOM_BAKE_META_EOF__'
-          ${{ steps.bake.outputs.metadata }}
-          __HEADROOM_BAKE_META_EOF__
-
-          jq -r 'to_entries[].value."containerimage.digest" // empty' \
-              "${RUNNER_TEMP}/bake_meta.json" | while read -r digest; do
-            image="${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}@${digest}"
-            echo "Signing ${image} (signatures -> ${COSIGN_REPOSITORY})"
-            cosign sign --yes "${image}"
-          done
+          target="${IMAGE}@${INDEX_DIGEST}"
+          echo "Signing ${target} (signatures -> ${COSIGN_REPOSITORY})"
+          cosign sign --yes "${target}"
 
   promote-latest:
     # Re-push the :latest tag pointing at the root variant *after* every
-    # variant matrix job has finished, so GHCR's package version listing
-    # (sorted by created_at) shows the root image with :latest at the top
-    # instead of whichever variant happened to finish last.
-    needs: docker-variant-tags
-    runs-on: ubuntu-latest
+    # variant manifest job has finished, so GHCR's package version
+    # listing (sorted by created_at) shows the root image with :latest
+    # at the top instead of whichever variant happened to finish last.
+    needs: docker-manifest
+    runs-on: ubuntu-24.04
     steps:
       - name: Normalize image name
         id: image-name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,10 +186,18 @@ jobs:
           # compiles OpenSSL from source so the system version doesn't
           # matter, but pinning the floor keeps us off CentOS 7's ancient
           # gcc/glibc surface anyway.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             manylinux: 2_28
-          - os: ubuntu-latest
+          # Native arm64 runner (`ubuntu-24.04-arm`, GA Jan 2025, free
+          # for public repos) replaces the previous `ubuntu-latest` +
+          # QEMU path. Building inside `manylinux_2_28_aarch64` natively
+          # on an ARM host cuts the aarch64 wheel build from ~50–60 min
+          # (emulated) to ~10 min. Wheel ABI is unchanged — the
+          # `manylinux: 2_28` field still pins the runtime glibc floor;
+          # `cargo tree` regression in tests/test_release_workflows.py
+          # keeps the resolved build graph identical.
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             manylinux: 2_28
           # NOTE: `macos-15-intel` (x86_64-apple-darwin) is intentionally

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -297,6 +297,114 @@ def test_build_wheels_matrix_excludes_intel_macos() -> None:
     assert "macos-15-intel" not in matrix_os
 
 
+def test_aarch64_wheel_uses_native_arm64_runner() -> None:
+    """STRUCTURAL INVARIANT: the aarch64 wheel matrix row must run on a
+    native arm64 runner (`ubuntu-24.04-arm`), NOT a QEMU-emulated x64
+    runner (`ubuntu-latest`).
+
+    Pre-#377 we built the aarch64 wheel on `ubuntu-latest` (x86_64) inside
+    `manylinux_2_28_aarch64` via QEMU emulation, taking ~50–60 min. Native
+    arm64 GitHub-hosted runners (GA Jan 2025, free for public repos) drop
+    QEMU and complete the same build in ~10 min.
+
+    A future "let me unify all wheel rows on `ubuntu-latest`" refactor
+    would silently re-introduce QEMU and slow CI back down — this test
+    pins the runner.
+    """
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    bw_start = content.index("\n  build-wheels:")
+    bw_end = content.index("\n  collect-dist:")
+    body = content[bw_start:bw_end]
+
+    # Walk the matrix.include rows. Each row is a contiguous block of
+    # `key: value` lines starting with `os:` (the first key in our
+    # convention). Pair `os:` with the immediately-following `target:`
+    # so we can assert per-row.
+    rows: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for raw in body.splitlines():
+        stripped = raw.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if stripped.startswith("- os:"):
+            if current:
+                rows.append(current)
+            current = {"os": stripped.split(":", 1)[1].strip()}
+        elif stripped.startswith("target:") and current:
+            current["target"] = stripped.split(":", 1)[1].strip()
+        elif stripped.startswith("manylinux:") and current:
+            current["manylinux"] = stripped.split(":", 1)[1].strip()
+    if current:
+        rows.append(current)
+
+    aarch64_linux = [r for r in rows if r.get("target") == "aarch64-unknown-linux-gnu"]
+    assert len(aarch64_linux) == 1, f"expected exactly one aarch64-linux row; got {aarch64_linux}"
+    assert aarch64_linux[0]["os"] == "ubuntu-24.04-arm", (
+        f"aarch64-unknown-linux-gnu must run on native arm64 runner "
+        f"`ubuntu-24.04-arm`, not {aarch64_linux[0]['os']!r}. Reverting "
+        f"to `ubuntu-latest` re-introduces QEMU emulation and ~6× slower "
+        f"wheel builds."
+    )
+
+    # The amd64 Linux row should also be pinned to ubuntu-24.04 (not
+    # `ubuntu-latest`, which is a moving target). Pinning keeps the
+    # wheel-build environment reproducible across runner image rolls.
+    amd64_linux = [r for r in rows if r.get("target") == "x86_64-unknown-linux-gnu"]
+    assert len(amd64_linux) == 1
+    assert amd64_linux[0]["os"] == "ubuntu-24.04", (
+        f"x86_64-unknown-linux-gnu should pin `ubuntu-24.04`, not "
+        f"{amd64_linux[0]['os']!r} — `ubuntu-latest` is a moving alias "
+        f"and reproducibility benefits from explicit pinning."
+    )
+
+
+def test_docker_workflow_builds_on_native_arch_runners() -> None:
+    """STRUCTURAL INVARIANT: the docker variant build must fan out per
+    arch onto native runners — `linux/amd64` on `ubuntu-24.04`,
+    `linux/arm64` on `ubuntu-24.04-arm`. No QEMU.
+
+    Pre-#377 each variant ran `docker bake` with
+    `platforms = ["linux/amd64","linux/arm64"]` on a single x64 runner
+    using QEMU for arm64 emulation — ~1h per variant. Splitting into
+    16 native single-arch builds (8 variants × 2 arches) + a manifest
+    merge job per variant cuts wall-clock to ~10 min and removes the
+    QEMU surface that contributed to transient build failures.
+    """
+    content = (ROOT / ".github" / "workflows" / "docker.yml").read_text(encoding="utf-8")
+
+    # The fan-out job must exist with both runners in its arch matrix.
+    assert "docker-build:" in content, "docker-build fan-out job missing"
+    assert "runs_on: ubuntu-24.04, platform: linux/amd64" in content, (
+        "amd64 arch matrix entry must bind ubuntu-24.04 (native x86_64)"
+    )
+    assert "runs_on: ubuntu-24.04-arm, platform: linux/arm64" in content, (
+        "arm64 arch matrix entry must bind ubuntu-24.04-arm (native aarch64)"
+    )
+
+    # Per-arch builds must push by digest only — tags belong on the
+    # multi-arch manifest, applied later by docker-manifest.
+    assert "push-by-digest=true,name-canonical=true,push=true" in content, (
+        "per-arch builds must push by digest only; tags applied at manifest merge step"
+    )
+
+    # The QEMU action must NOT be invoked anywhere — its presence would
+    # mean someone re-introduced an emulated build path.
+    non_comment = "\n".join(
+        line for line in content.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "docker/setup-qemu-action" not in non_comment, (
+        "docker.yml must not invoke `docker/setup-qemu-action` — native "
+        "arm64 runners replaced QEMU. A new reference here means someone "
+        "re-emulated arm64 on an x64 runner."
+    )
+
+    # Manifest merge job must exist and depend on docker-build.
+    assert "docker-manifest:" in content
+    assert "needs: docker-build" in content
+    assert "docker buildx imagetools create" in content
+
+
 def test_npm_publish_jobs_do_not_download_dist_artifact() -> None:
     """`publish-npm` and `publish-github-packages` `npm pack`+`npm publish`
     directly from the checked-out source tree; they never read the


### PR DESCRIPTION
## Summary
- Switch the aarch64 wheel build (`build-wheels` in `release.yml`) and the multi-arch docker matrix (`docker.yml`) off `ubuntu-latest` + QEMU emulation onto **`ubuntu-24.04-arm`** — GitHub-hosted Linux arm64 runners that went GA in Aug 2025 and are **free for public repositories**.
- Drops the aarch64 wheel from ~50–60 min (emulated) to ~10 min (native).
- Drops each docker variant from ~1h (emulated arm64 leg in a single bake job) to ~10 min (per-arch fan-out + manifest merge running natively in parallel).

## Changes
**`.github/workflows/release.yml`** — wheel matrix
- `aarch64-unknown-linux-gnu`: `ubuntu-latest` → `ubuntu-24.04-arm`. `maturin-action` still runs inside `quay.io/pypa/manylinux_2_28_aarch64`; the container now executes natively on an aarch64 kernel instead of through QEMU.
- `x86_64-unknown-linux-gnu`: `ubuntu-latest` → `ubuntu-24.04` (pin the moving alias for reproducibility; no semantic change).

**`.github/workflows/docker.yml`** — fan-out + manifest merge
- Pre-#377: one matrix job per variant on `ubuntu-latest`, bake's `platforms = [amd64, arm64]` with QEMU for arm64.
- Post-#377: split into
  - `docker-build` (variant × arch = 16 parallel jobs, each on its native runner, `*.platform=linux/<arch>` + `push-by-digest=true,name-canonical=true,push=true`); and
  - `docker-manifest` (per variant, downloads both arch digests, runs `docker buildx imagetools create` to emit the multi-arch tagged manifest, signs the index manifest with cosign).
- `docker/setup-qemu-action` removed entirely — there's no QEMU left.
- Per-(variant, arch) GHA cache scopes so the two arches don't collide.
- `promote-latest` rewired to depend on `docker-manifest`.

**`tests/test_release_workflows.py`** — structural regression tests
- `test_aarch64_wheel_uses_native_arm64_runner` pins the aarch64 row to `ubuntu-24.04-arm` (and amd64 to `ubuntu-24.04`, not `-latest`), so a future "let me unify on `ubuntu-latest`" refactor surfaces the QEMU regression at PR time.
- `test_docker_workflow_builds_on_native_arch_runners` pins the matrix arch entries, asserts push-by-digest, asserts `setup-qemu-action` is absent from non-comment lines, asserts the manifest-merge job exists.

## Behavior change worth flagging
Cosign now signs only the **multi-arch index digest** per variant, not each per-platform image. `cosign verify <repo>:tag` (the typical flow) is unchanged because cosign resolves the tag to the index digest. Verifiers pinning a specific per-arch digest will need to verify the index digest instead.

## Verification
- `ubuntu-24.04-arm` is the correct label — GA 2025-08-07, free for public repos ([GitHub changelog](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/), [actions/partner-runner-images](https://github.com/actions/partner-runner-images)).
- `docker buildx imagetools inspect <tag> --format '{{ json . }}'` exposes the index digest at `.manifest.digest` ([Docker reference](https://docs.docker.com/reference/cli/docker/buildx/imagetools/inspect/)).
- Both workflow files parse as valid YAML; expected job graph (`docker-build` → `docker-manifest` → `promote-latest`, 16 fan-out jobs, 8 manifest jobs).
- `make ci-precheck-rust` + `make ci-precheck-python` both pass locally.
- `tests/test_release_workflows.py` is 15/15 green (13 existing + 2 new).

## Test plan
- [ ] Wheel matrix: aarch64 row should run on `ubuntu-24.04-arm` and complete in ~10 min instead of ~1h.
- [ ] Docker fan-out: 16 build jobs run in parallel; each completes in ~10 min on its native runner.
- [ ] Docker manifest merge: 8 manifest jobs each emit a multi-arch tagged image; `docker manifest inspect ghcr.io/chopratejas/headroom:<tag>` shows both `linux/amd64` and `linux/arm64` entries.
- [ ] Cosign signature: `COSIGN_REPOSITORY=ghcr.io/chopratejas/headroom-signatures cosign verify --certificate-identity-regexp ... ghcr.io/chopratejas/headroom:<tag>` succeeds.
- [ ] No `docker/setup-qemu-action` invocations in workflow logs.