### PR TITLE
fix(ci): docker per-arch bake needs explicit image name in output

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -124,11 +124,17 @@ jobs:
           # tells buildx to push the per-platform manifest with no tags
           # — only the digest is recorded — so multiple per-arch builds
           # can coexist in the registry until the manifest job stitches
-          # them. GHA cache is scoped per (variant, arch) so the two
-          # arches don't fight over the same cache key.
+          # them. `name=<registry>/<image>` is REQUIRED here: with no
+          # `bake-file-tags` in scope (tags belong on the manifest, not
+          # per-arch), bake has no way to know the push target without
+          # the explicit `name=`. Removing it surfaces as the
+          # misleading "ERROR: tag is needed when pushing to registry"
+          # — see PR #378 (regression from #376). GHA cache is scoped
+          # per (variant, arch) so the two arches don't fight over the
+          # same cache key.
           set: |
             *.platform=${{ matrix.arch.platform }}
-            *.output=type=image,push-by-digest=true,name-canonical=true,push=true
+            *.output=type=image,name=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true
             *.cache-from=type=gha,scope=${{ matrix.variant.name || 'root' }}-${{ matrix.arch.name }}
             *.cache-to=type=gha,mode=max,scope=${{ matrix.variant.name || 'root' }}-${{ matrix.arch.name }}
 

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -405,6 +405,44 @@ def test_docker_workflow_builds_on_native_arch_runners() -> None:
     assert "docker buildx imagetools create" in content
 
 
+def test_docker_per_arch_build_specifies_image_name_in_output() -> None:
+    """STRUCTURAL INVARIANT: the per-arch bake's `*.output` spec must
+    include `name=<registry>/<image>` — without it, buildx fails with
+    the misleading `ERROR: tag is needed when pushing to registry`.
+
+    Background: pre-#377 each docker variant ran with bake-file-tags
+    (multi-arch tagged push), which gave bake the registry/image name
+    via the tag strings. PR #376 split into per-arch fan-out and
+    correctly removed bake-file-tags from the per-arch step (tags
+    belong on the multi-arch manifest, not on per-arch images). But
+    that left bake without ANY reference for the push target — no
+    tags AND no explicit `name=` in the output spec.
+
+    The first release after #376 merged failed every docker-build job
+    with "ERROR: tag is needed when pushing to registry". The fix is
+    to explicitly pass `name=<registry>/<image>` in the output spec
+    so bake knows the push target without needing tags.
+
+    A future refactor that removes the explicit name (e.g., "we
+    already have labels, surely buildx can figure it out") will
+    silently re-break this. This test pins it.
+    """
+    content = (ROOT / ".github" / "workflows" / "docker.yml").read_text(encoding="utf-8")
+
+    # Find the per-arch build's *.output set line. Must contain
+    # `name=` with the registry+image-name expression.
+    output_line_present = (
+        "*.output=type=image,name=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true"
+        in content
+    )
+    assert output_line_present, (
+        "per-arch bake `*.output` must include `name=<registry>/<image>`. "
+        "Without it, buildx fails the push with 'tag is needed when pushing "
+        "to registry' because no tags AND no explicit name = no push target. "
+        "This is a regression of the docker-build break right after PR #376."
+    )
+
+
 def test_npm_publish_jobs_do_not_download_dist_artifact() -> None:
     """`publish-npm` and `publish-github-packages` `npm pack`+`npm publish`
     directly from the checked-out source tree; they never read the


### PR DESCRIPTION
## Summary

Hotfix for the docker publish failure on main after PR #376 merged. Every release-time docker-build job was failing with the misleading message:

```
ERROR: tag is needed when pushing to registry
```

Run that surfaced this: https://github.com/chopratejas/headroom/actions/runs/25337785811

## Root cause

PR #376's per-arch fan-out correctly removed \`bake-file-tags\` from the per-arch \`docker-build\` step (tags belong on the multi-arch manifest, not on per-arch images). But that left bake without **any** reference for the push target — no tags AND no explicit \`name=\` in the output spec.

Buildx's actual constraint: "no tags AND no \`name=\` in the output spec = no push target." The error message says "tag is needed" but really means "I have no idea where to push this image."

## Fix

Add \`name=\${{ env.REGISTRY }}/\${{ steps.image-name.outputs.image_name }}\` directly to the \`*.output\` spec. Tags are still applied later, only on the multi-arch manifest by \`docker-manifest\`. Push-by-digest discards tags anyway, so the only thing bake needed was the registry+image-name reference.

## Regression test

\`tests/test_release_workflows.py::test_docker_per_arch_build_specifies_image_name_in_output\` pins the \`name=\` substring so a future "the labels block already has the registry, surely buildx can figure it out" refactor will fail at PR time rather than 2 minutes into the next release.

## Verification

- \`make ci-precheck\` green locally (rust + python + commitlint).
- All 16 workflow regression tests pass (13 pre-#376 + 2 from #376 + 1 new from this hotfix).

## Test plan
- [ ] Confirm next push to main triggers docker.yml without "tag is needed" error.
- [ ] All 16 \`docker-build\` matrix jobs (8 variants × 2 arches) push by digest successfully.
- [ ] All 8 \`docker-manifest\` jobs merge digests into multi-arch tagged manifests.