### PR TITLE
fix(ci): rebuild sdist on the renamed wheel-matrix host

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,8 +247,18 @@ jobs:
           # builds for 3.14+ until we bump PyO3 (tracked separately).
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 
+      # Build sdist exactly once across the matrix. We key the
+      # conditional on `target` only — sdist is platform-independent
+      # so any single matrix row is a fine host. Earlier this
+      # conditional was `matrix.os == 'ubuntu-latest' && matrix.target
+      # == 'x86_64-unknown-linux-gnu'`. PR #376 pinned `os` to
+      # `ubuntu-24.04` (instead of the moving `ubuntu-latest` alias)
+      # and silently broke this `if`, so sdist never built and
+      # `gh release upload release-assets/*.tar.gz` failed with
+      # "no matches found". Keying on `target` decouples the sdist
+      # build from any future `os` rename.
       - name: Build sdist (linux x86_64 only — sdist is platform-independent)
-        if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
         uses: PyO3/maturin-action@v1
         with:
           command: sdist

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -443,6 +443,50 @@ def test_docker_per_arch_build_specifies_image_name_in_output() -> None:
     )
 
 
+def test_sdist_build_conditional_keyed_on_target_not_os() -> None:
+    """STRUCTURAL INVARIANT: the sdist build's `if` conditional must
+    key on `matrix.target`, not `matrix.os`.
+
+    Background: PR #376 changed the wheel matrix from `os: ubuntu-latest`
+    to `os: ubuntu-24.04` (explicit pinning, no semantic change in
+    practice). It silently broke the sdist build, whose `if` was
+    `matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'`
+    — the literal `'ubuntu-latest'` no longer matched. Sdist never
+    built, `release-assets/*.tar.gz` was empty, and the create-release
+    job failed `gh release upload release-assets/*.tar.gz` with
+    "no matches found".
+
+    The fix is to key the conditional on `matrix.target` only — sdist
+    is platform-independent, so any single matrix row is a fine host.
+    `target` is more semantically meaningful than `os` here AND is
+    decoupled from any future host-runner rename.
+
+    This test pins the `target`-only conditional so a future "let's
+    add `os` back to the conditional for clarity" refactor will fail
+    at PR time, not 8 minutes into a release.
+    """
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    # Locate the "Build sdist" step.
+    sdist_marker = "name: Build sdist"
+    assert sdist_marker in content, "sdist build step missing from release.yml"
+
+    # Walk forward to the next `if:` line — that's the conditional.
+    sdist_idx = content.index(sdist_marker)
+    if_idx = content.index("if:", sdist_idx)
+    if_line_end = content.index("\n", if_idx)
+    if_line = content[if_idx:if_line_end]
+
+    # Must reference `matrix.target`. Must NOT reference `matrix.os`.
+    assert "matrix.target == 'x86_64-unknown-linux-gnu'" in if_line, (
+        f"sdist build conditional must check `matrix.target`; got: {if_line!r}"
+    )
+    assert "matrix.os" not in if_line, (
+        f"sdist build conditional must NOT depend on `matrix.os` — that's "
+        f"how PR #376 silently disabled the sdist build. Got: {if_line!r}"
+    )
+
+
 def test_npm_publish_jobs_do_not_download_dist_artifact() -> None:
     """`publish-npm` and `publish-github-packages` `npm pack`+`npm publish`
     directly from the checked-out source tree; they never read the


### PR DESCRIPTION
## Summary

Hotfix for the create-release failure on v0.20.22 (run [25345276838](https://github.com/chopratejas/headroom/actions/runs/25345276838)). Sdist never built → \`gh release upload release-assets/*.tar.gz\` failed with "no matches found".

## Root cause

PR #376 changed the wheel matrix's \`os: ubuntu-latest\` → \`os: ubuntu-24.04\` (explicit pinning). It silently broke the sdist build, whose conditional was:

\`\`\`yaml
if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
\`\`\`

The literal \`'ubuntu-latest'\` no longer matched, sdist never built, and \`create-release\` failed at the \`gh release upload\` step.

## Fix

Key the conditional on \`matrix.target\` only — sdist is platform-independent, so any single matrix row is fine. Using \`target\` decouples the sdist build from any future host-runner rename.

## Regression test

\`tests/test_release_workflows.py::test_sdist_build_conditional_keyed_on_target_not_os\` pins the target-only form. A future "let's add \`os\` back for clarity" refactor will fail at PR time, not 8 minutes into a release.

## Related

This is the second hotfix following PR #376 — same root-cause class as PR #379 (docker bake \`name=\`). PR #376's matrix-shape rename silently broke downstream conditionals/literals tied to the OLD shape. With both hotfixes pinned by tests, the surface should be stable.

## Verification
- \`make ci-precheck\` PASSED locally (rust + python + commitlint)
- All 17 workflow regression tests pass (16 pre-fix + 1 new)

## Test plan
- [ ] Next push to main publishes a release with both \`*.whl\` AND \`*.tar.gz\` in \`release-assets/\`
- [ ] \`gh release upload\` step succeeds without "no matches found"
- [ ] Sdist appears on the GitHub Release page