### PR TITLE
fix(ci): force-link glibc shim with -Wl,-u for aarch64

### DIFF
--- a/crates/headroom-py/build.rs
+++ b/crates/headroom-py/build.rs
@@ -34,4 +34,30 @@ fn main() {
         .flag_if_supported("-fPIC")
         .opt_level(2)
         .compile("headroom_glibc_compat");
+
+    // Force the linker to pull our shim's objects into _core.so even
+    // if at archive-scan time no UND `__isoc23_*` reference exists
+    // yet. Without this, the ORT prebuilt static archives — which
+    // are downloaded by ort-sys and link AFTER our shim's archive
+    // on aarch64 (observed in PR #386's release run) — leave the
+    // `__isoc23_*` references unresolved at the .so level even
+    // though our archive defines them. The audit then rightly
+    // rejects the wheel.
+    //
+    // `-u <sym>` (a.k.a. `--undefined`) tells the linker: "treat
+    // this symbol as undefined at the start of linking, which forces
+    // any archive defining it to be scanned and its members pulled
+    // in." Once our archive's objects are in, the shim's strong
+    // definitions are present in `_core.so` and ORT's later
+    // references resolve to them. On x86_64 the ORT archive
+    // happened to scan first; on aarch64 it did not, so this gate
+    // is the load-bearing fix that makes the shim work uniformly.
+    for sym in [
+        "__isoc23_strtol",
+        "__isoc23_strtoll",
+        "__isoc23_strtoul",
+        "__isoc23_strtoull",
+    ] {
+        println!("cargo:rustc-link-arg=-Wl,-u,{sym}");
+    }
 }


### PR DESCRIPTION
## Summary

Hotfix for the aarch64 wheel build's audit failure in run [25358313722](https://github.com/chopratejas/headroom/actions/runs/25358313722/job/74352499792). PR #385's shim works on x86_64 but is silently dropped from \`_core.so\` on aarch64.

## Root cause

\`cc::Build::compile()\` produces a static archive that cargo passes to the linker. On aarch64 the link order happens to place our shim's archive BEFORE the ORT prebuilt archives. When the linker scans our archive, no UND \`__isoc23_*\` reference exists yet (ORT hasn't been scanned), so our shim's \`.o\` is dropped (the linker only includes archive members that satisfy a current UND). ORT scans next, registers UND, but our archive isn't rescanned. Result: \`_core.so\` still has UND \`__isoc23_*\` and the audit (correctly) rejects the wheel.

On x86_64 the relative order happened to be opposite (ORT first → UND registered → our archive scans next → satisfies → pulled in). Order is implementation-defined and clearly arch-dependent — exactly the kind of \"works locally / breaks in CI\" trap that the audit was designed to catch.

## Fix

\`build.rs\` now emits \`cargo:rustc-link-arg=-Wl,-u,<sym>\` for each \`__isoc23_*\` symbol. The linker's \`-u <sym>\` flag pre-registers the symbol as undefined at the start of linking, forcing any archive that defines it to be scanned and its members pulled in regardless of relative archive order. Shim is now uniformly linked on both arches.

This is a standard workaround for the static-library-link-order problem when the consumer scans after the provider. Documented inline in \`build.rs\`.

## Validation
- Local \`cargo check -p headroom-py\` clean.
- The audit script will now find \`__isoc23_*\` symbols defined locally (T) instead of UND on both Linux x86_64 and aarch64 wheels.

## Test plan
- [ ] Next release run's \`build-wheels (aarch64-unknown-linux-gnu)\` audit step passes.
- [ ] Both x86_64 and aarch64 wheels show \`__isoc23_strtoll\` as type T (defined) under \`objdump -T\`.