### PR TITLE
fix(ci): X1 — smoke-import wheels on customer-representative envs before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,10 +455,10 @@ jobs:
                 aarch64-unknown-linux-gnu) arch_tag=manylinux_2_28_aarch64 ;;
                 *) echo "ERROR: unknown wheel target $WHEEL_TARGET" >&2; exit 1 ;;
               esac
-              whl=$(ls /wheels/headroom_ai-*-${py_tag}-${py_tag}-${arch_tag}.whl 2>/dev/null | head -1)
+              whl=$(find /wheels -maxdepth 1 -type f -name "headroom_ai-*-${py_tag}-${py_tag}-${arch_tag}.whl" -print -quit)
               if [ -z "$whl" ]; then
                 echo "ERROR: no wheel matching python=$PYTHON_VERSION arch=$arch_tag in /wheels/" >&2
-                ls -la /wheels/ >&2
+                find /wheels -maxdepth 1 -type f -printf "%f\n" >&2
                 exit 1
               fi
               echo "Installing: $whl"
@@ -487,10 +487,10 @@ jobs:
           set -e
           py_tag=cp$(echo "$PYTHON_VERSION" | tr -d .)
           # macOS wheels are tagged macosx_*_arm64 (Apple Silicon only).
-          whl=$(ls dist/headroom_ai-*-${py_tag}-${py_tag}-macosx_*_arm64.whl 2>/dev/null | head -1)
+          whl=$(find dist -maxdepth 1 -type f -name "headroom_ai-*-${py_tag}-${py_tag}-macosx_*_arm64.whl" -print -quit)
           if [ -z "$whl" ]; then
             echo "ERROR: no macOS wheel matching python=$PYTHON_VERSION"
-            ls -la dist/
+            find dist -maxdepth 1 -type f -exec basename {} \;
             exit 1
           fi
           echo "Installing: $whl"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,8 +331,184 @@ jobs:
           name: release-assets-merged
           path: release-assets/
 
+  # ─── Wheel smoke-import gate ───────────────────────────────────────────────
+  # Issue #355's bug class: `manylinux_2_28` wheels that build cleanly,
+  # pass clippy/tests on the build host, pass auditwheel — and then
+  # fail to import on a customer's box because of a runtime symbol
+  # mismatch (#355: `__isoc23_strtoll` from gcc-14 ORT prebuilts;
+  # earlier #371: openssl-sys's C23 wrappers).
+  #
+  # This job spins up a matrix of representative customer environments
+  # — the manylinux floor we promise + common older/newer glibc + macOS
+  # native — and runs the actual `import headroom._core` check the
+  # proxy's `_check_rust_core` does at startup. Failure here BLOCKS
+  # publish-pypi, publish-docker, and create-release. Better to find
+  # a broken wheel here than 8 minutes after `pypa/gh-action-pypi-publish`
+  # has already pushed it to the world.
+  #
+  # See also `scripts/audit_wheel_glibc_symbols.py` (the static-symbol
+  # gate added in PR #384). The audit catches symbol references above
+  # the floor; this smoke matrix catches the dynamic-link failures
+  # that survive the static check (linker order quirks, runtime
+  # dlopen RPATH issues, missing transitive native deps).
+  smoke-import-wheels:
+    needs: [build-wheels]
+    if: github.event.inputs.dry_run != 'true'
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64 — span manylinux floor + customer glibcs.
+          # `quay.io/pypa/manylinux_2_28_x86_64` is the floor we
+          # promise; if the wheel fails here, our manylinux tag is
+          # a lie. `ubuntu:22.04` (glibc 2.35) is the environment
+          # from issue #355's reporter. `ubuntu:20.04` (glibc 2.31)
+          # covers older still-supported LTS.
+          - { runner: ubuntu-24.04, image: "quay.io/pypa/manylinux_2_28_x86_64", python: "3.11", wheel_target: x86_64-unknown-linux-gnu, wheel_artifact: wheels-ubuntu-24.04-x86_64-unknown-linux-gnu, glibc_label: "2.28-floor" }
+          - { runner: ubuntu-24.04, image: "ubuntu:22.04", python: "3.12", wheel_target: x86_64-unknown-linux-gnu, wheel_artifact: wheels-ubuntu-24.04-x86_64-unknown-linux-gnu, glibc_label: "2.35" }
+          - { runner: ubuntu-24.04, image: "ubuntu:20.04", python: "3.10", wheel_target: x86_64-unknown-linux-gnu, wheel_artifact: wheels-ubuntu-24.04-x86_64-unknown-linux-gnu, glibc_label: "2.31" }
+          # Linux aarch64 — floor + one customer env. Native arm64
+          # runners (PR #376) host the container.
+          - { runner: ubuntu-24.04-arm, image: "quay.io/pypa/manylinux_2_28_aarch64", python: "3.11", wheel_target: aarch64-unknown-linux-gnu, wheel_artifact: wheels-ubuntu-24.04-arm-aarch64-unknown-linux-gnu, glibc_label: "2.28-floor" }
+          - { runner: ubuntu-24.04-arm, image: "ubuntu:22.04", python: "3.12", wheel_target: aarch64-unknown-linux-gnu, wheel_artifact: wheels-ubuntu-24.04-arm-aarch64-unknown-linux-gnu, glibc_label: "2.35" }
+          # macOS arm64 — runs natively on the host runner; no
+          # container. Apple Silicon is the only macOS target we
+          # ship today (Intel macOS dropped in PR #371 — ort-sys
+          # has no x86_64-apple-darwin prebuilts).
+          - { runner: macos-14, image: "", python: "3.13", wheel_target: aarch64-apple-darwin, wheel_artifact: wheels-macos-14-aarch64-apple-darwin, glibc_label: "" }
+
+    steps:
+      - name: Download wheels artifact for this target
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.wheel_artifact }}
+          path: dist/
+
+      - name: Smoke-import wheel inside container (Linux)
+        if: matrix.image != ''
+        env:
+          IMAGE: ${{ matrix.image }}
+          PYTHON_VERSION: ${{ matrix.python }}
+          WHEEL_TARGET: ${{ matrix.wheel_target }}
+          GLIBC_LABEL: ${{ matrix.glibc_label }}
+        run: |
+          set -e
+          # The container script intentionally avoids `<<EOF` heredoc
+          # interpolation by passing values via env vars — keeps the
+          # shell quoting straightforward and makes failure modes
+          # easier to debug.
+          docker run --rm \
+            -v "$(pwd)/dist:/wheels:ro" \
+            -e PYTHON_VERSION="$PYTHON_VERSION" \
+            -e WHEEL_TARGET="$WHEEL_TARGET" \
+            -e GLIBC_LABEL="$GLIBC_LABEL" \
+            "$IMAGE" \
+            bash -ec '
+              set -e
+              echo "=== smoke-import: image=$0 python=$PYTHON_VERSION glibc=$GLIBC_LABEL target=$WHEEL_TARGET ===" "'"$IMAGE"'"
+
+              # Locate a Python interpreter matching the requested
+              # version. manylinux images ship interpreters under
+              # /opt/python/cp{XY}-cp{XY}/bin/; ubuntu/debian images
+              # need an apt-get install.
+              py_tag=cp$(echo "$PYTHON_VERSION" | tr -d .)
+              if [ -d /opt/python ]; then
+                python_bin="/opt/python/${py_tag}-${py_tag}/bin/python"
+                if [ ! -x "$python_bin" ]; then
+                  echo "ERROR: $python_bin missing in $0" "'"$IMAGE"'" >&2
+                  ls -la /opt/python >&2
+                  exit 1
+                fi
+              elif command -v apt-get >/dev/null 2>&1; then
+                export DEBIAN_FRONTEND=noninteractive
+                apt-get update -qq
+                # ubuntu:20.04s default repo only ships 3.8; 3.10 lives
+                # in deadsnakes. Add it on demand. ubuntu:22.04 has
+                # 3.10/3.11 in main and 3.12 via deadsnakes.
+                apt-get install -y -qq --no-install-recommends ca-certificates software-properties-common >/dev/null
+                add-apt-repository -y ppa:deadsnakes/ppa >/dev/null 2>&1 || true
+                apt-get update -qq
+                apt-get install -y -qq --no-install-recommends \
+                  "python$PYTHON_VERSION" \
+                  "python$PYTHON_VERSION-venv" \
+                  "python$PYTHON_VERSION-distutils" >/dev/null 2>&1 \
+                || apt-get install -y -qq --no-install-recommends \
+                  "python$PYTHON_VERSION" \
+                  "python$PYTHON_VERSION-venv" >/dev/null
+                python_bin="python$PYTHON_VERSION"
+              else
+                echo "ERROR: image has neither /opt/python nor apt-get" >&2
+                exit 1
+              fi
+              "$python_bin" --version
+
+              # Print glibc version so failures show what we are
+              # actually testing against.
+              ldd --version | head -1 || true
+
+              # Pick the wheel that matches python version + arch.
+              case "$WHEEL_TARGET" in
+                x86_64-unknown-linux-gnu)  arch_tag=manylinux_2_28_x86_64 ;;
+                aarch64-unknown-linux-gnu) arch_tag=manylinux_2_28_aarch64 ;;
+                *) echo "ERROR: unknown wheel target $WHEEL_TARGET" >&2; exit 1 ;;
+              esac
+              whl=$(ls /wheels/headroom_ai-*-${py_tag}-${py_tag}-${arch_tag}.whl 2>/dev/null | head -1)
+              if [ -z "$whl" ]; then
+                echo "ERROR: no wheel matching python=$PYTHON_VERSION arch=$arch_tag in /wheels/" >&2
+                ls -la /wheels/ >&2
+                exit 1
+              fi
+              echo "Installing: $whl"
+
+              "$python_bin" -m venv /tmp/venv
+              /tmp/venv/bin/pip install --quiet --upgrade pip
+              /tmp/venv/bin/pip install --quiet "$whl"
+
+              # The actual smoke check — mirrors the proxy
+              # `_check_rust_core` path that fails with exit-78 on
+              # broken wheels. If this `import` fails the whole
+              # release is held.
+              /tmp/venv/bin/python - <<PY
+              import sys
+              import headroom
+              from headroom._core import hello as _rust_hello
+              print(f"smoke-import OK: python={sys.version_info[:3]} hello={_rust_hello()}")
+              PY
+            '
+
+      - name: Smoke-import wheel on macOS host
+        if: matrix.image == ''
+        env:
+          PYTHON_VERSION: ${{ matrix.python }}
+        run: |
+          set -e
+          py_tag=cp$(echo "$PYTHON_VERSION" | tr -d .)
+          # macOS wheels are tagged macosx_*_arm64 (Apple Silicon only).
+          whl=$(ls dist/headroom_ai-*-${py_tag}-${py_tag}-macosx_*_arm64.whl 2>/dev/null | head -1)
+          if [ -z "$whl" ]; then
+            echo "ERROR: no macOS wheel matching python=$PYTHON_VERSION"
+            ls -la dist/
+            exit 1
+          fi
+          echo "Installing: $whl"
+
+          # Use the system python at the requested minor version. The
+          # macos-14 runner image preinstalls multiple Python versions.
+          "python$PYTHON_VERSION" -m venv /tmp/venv
+          /tmp/venv/bin/pip install --quiet --upgrade pip
+          /tmp/venv/bin/pip install --quiet "$whl"
+          /tmp/venv/bin/python - <<'PY'
+          import sys
+          import headroom
+          from headroom._core import hello as _rust_hello
+          print(f"smoke-import OK: python={sys.version_info[:3]} hello={_rust_hello()}")
+          PY
+
   publish-pypi:
-    needs: [collect-dist]
+    needs: [collect-dist, smoke-import-wheels]
     if: github.event.inputs.dry_run != 'true' && vars.PYPI_SKIP != 'true'
     environment: pypi  # NOTE: environment name must be a literal; update here if the GitHub environment name changes
     runs-on: ubuntu-latest
@@ -518,7 +694,12 @@ jobs:
           echo "::notice::One or more GitHub Package Registry publishes failed. Check GITHUB_TOKEN permissions and package scope/repository settings. Set GH_PACKAGES_SKIP=true to skip."
 
   publish-docker:
-    needs: [detect-version]
+    # Wait for the smoke-import gate. The docker images bundle the
+    # same wheels we publish to PyPI; a wheel that can't import
+    # cleanly on the manylinux floor will also fail the docker
+    # image's `pip install` step. Failing here ~3 minutes earlier
+    # than docker-build saves the matrix's wall-clock budget.
+    needs: [detect-version, smoke-import-wheels]
     if: github.event.inputs.dry_run != 'true'
     permissions:
       contents: read
@@ -530,7 +711,7 @@ jobs:
       enable_ref_tags: false
 
   create-release:
-    needs: [detect-version, build, build-wheels, collect-dist, publish-pypi, publish-npm, publish-github-packages, publish-docker]
+    needs: [detect-version, build, build-wheels, collect-dist, smoke-import-wheels, publish-pypi, publish-npm, publish-github-packages, publish-docker]
     if: >-
       ${{
         always() &&
@@ -538,7 +719,8 @@ jobs:
         needs.detect-version.result == 'success' &&
         needs.build.result == 'success' &&
         needs.build-wheels.result == 'success' &&
-        needs.collect-dist.result == 'success'
+        needs.collect-dist.result == 'success' &&
+        needs.smoke-import-wheels.result == 'success'
       }}
     runs-on: ubuntu-latest
     permissions:

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -46,14 +46,20 @@ def test_create_release_runs_after_successful_build_even_if_other_publishes_fail
     # and `collect-dist` (aggregator that merges wheel artifacts + npm
     # release-assets) between `build` and the publish jobs. create-release
     # must wait for all of them.
+    # PR #387 (X1) added `smoke-import-wheels` — the runtime gate that
+    # actually loads the wheel on a customer-representative environment
+    # before publish. create-release must wait for it AND require its
+    # success in the `if:` block (otherwise `always()` would let the
+    # release proceed even when the smoke gate failed).
     assert (
-        "needs: [detect-version, build, build-wheels, collect-dist, publish-pypi, publish-npm, publish-github-packages, publish-docker]"
+        "needs: [detect-version, build, build-wheels, collect-dist, smoke-import-wheels, publish-pypi, publish-npm, publish-github-packages, publish-docker]"
         in content
     )
     assert "always()" in content
     assert "needs.build.result == 'success'" in content
     assert "needs.build-wheels.result == 'success'" in content
     assert "needs.collect-dist.result == 'success'" in content
+    assert "needs.smoke-import-wheels.result == 'success'" in content
 
 
 def test_macos_native_wrapper_dependency_install_retries_pypi_downloads() -> None:
@@ -564,6 +570,115 @@ def test_release_workflow_audits_wheel_glibc_symbols() -> None:
     )
     assert "Audit wheel glibc symbols (Linux only)" in content, (
         "audit step name has been renamed; update both this test and the workflow"
+    )
+
+
+def test_release_workflow_has_smoke_import_wheel_gate() -> None:
+    """STRUCTURAL INVARIANT: release.yml runs the just-built wheels
+    through `import headroom._core` on a matrix of representative
+    customer environments BEFORE publishing to PyPI / pushing to
+    GHCR / cutting a GitHub Release.
+
+    This is the X1 gate from the post-#355 hardening plan. Issue #355
+    plus its three follow-on hotfixes (#384/#385/#386) all share a
+    pattern: the wheel is technically valid (clippy passes, tests
+    pass, auditwheel is happy) but fails to import on a customer's
+    box because of a runtime symbol mismatch. Static gates can't
+    catch that — only actually loading the .so does.
+
+    Required matrix coverage:
+    - manylinux floor we promise (`manylinux_2_28_x86_64` and
+      `manylinux_2_28_aarch64`). If these fail, our manylinux tag
+      is a lie.
+    - At least one customer-representative glibc per arch (Ubuntu
+      LTS, the issue #355 reporter's environment).
+    - macOS native (Apple Silicon).
+
+    Required gating: `publish-pypi`, `publish-docker`, AND
+    `create-release` must all `needs:` smoke-import-wheels. A
+    smoke failure has to BLOCK publish, not just produce a
+    notification.
+
+    A future "remove this slow CI step that always passes anyway"
+    refactor — exactly the impulse that landed us PR #382's sdist
+    gap and PR #386's link-order surprise — fails this test at
+    PR time.
+    """
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    # The job itself must exist.
+    assert "\n  smoke-import-wheels:" in content, (
+        "release.yml must define a `smoke-import-wheels` job. This is the "
+        "X1 gate that catches runtime symbol mismatches in the published "
+        "wheel before it hits PyPI. Issue #355 + #384/#385/#386 are the "
+        "canonical reason this gate exists."
+    )
+
+    # Required matrix entries — pin both the floor (manylinux_2_28)
+    # and at least one customer environment per arch.
+    required_matrix_substrings = [
+        # manylinux floor for x86_64 — pins what we promise customers.
+        'image: "quay.io/pypa/manylinux_2_28_x86_64"',
+        # manylinux floor for aarch64 — would have caught PR #386.
+        'image: "quay.io/pypa/manylinux_2_28_aarch64"',
+        # At least one Ubuntu LTS — issue #355's environment was
+        # ubuntu:22.04 + Python 3.12.
+        'image: "ubuntu:22.04"',
+        # macOS native (no container) — Apple Silicon wheel.
+        "runner: macos-14",
+    ]
+    for sub in required_matrix_substrings:
+        assert sub in content, (
+            f"smoke matrix missing required entry: {sub!r}. The matrix "
+            f"must cover the manylinux floor + at least one customer-"
+            f"representative environment per arch + macOS native."
+        )
+
+    # Gating: publish-pypi must wait for the smoke job.
+    publish_pypi_idx = content.index("\n  publish-pypi:")
+    next_job_idx = content.index("\n  publish-npm:", publish_pypi_idx)
+    publish_pypi_block = content[publish_pypi_idx:next_job_idx]
+    assert "smoke-import-wheels" in publish_pypi_block, (
+        "publish-pypi must `needs: [..., smoke-import-wheels]` — without "
+        "the dependency, a broken wheel can be published before the "
+        "smoke job has even finished. The whole point of X1 is that it "
+        "BLOCKS publish."
+    )
+
+    # Same for publish-docker.
+    publish_docker_idx = content.index("\n  publish-docker:")
+    next_idx = content.index("\n  create-release:", publish_docker_idx)
+    publish_docker_block = content[publish_docker_idx:next_idx]
+    assert "smoke-import-wheels" in publish_docker_block, (
+        "publish-docker must `needs: [..., smoke-import-wheels]` — the "
+        "docker image bundles the same wheels; a broken wheel will fail "
+        "the docker build's `pip install` 3 minutes later anyway. "
+        "Failing fast in smoke saves matrix budget."
+    )
+
+    # And create-release.
+    create_release_idx = content.index("\n  create-release:")
+    create_release_block = content[create_release_idx:]
+    assert "smoke-import-wheels" in create_release_block, (
+        "create-release must `needs: [..., smoke-import-wheels]` and gate on its success"
+    )
+    assert "needs.smoke-import-wheels.result == 'success'" in create_release_block, (
+        "create-release's `if:` must explicitly require "
+        "`needs.smoke-import-wheels.result == 'success'` — without "
+        "this, `always()` would let the release proceed even if the "
+        "smoke gate failed."
+    )
+
+    # The actual import command must hit `from headroom._core import hello`
+    # — this is the same call the proxy's `_check_rust_core` makes on
+    # startup (per `headroom/proxy/server.py` and the issue #355 backtrace).
+    # Anything else (e.g. just `import headroom`) fails to exercise the
+    # Rust _core.so binary.
+    assert "from headroom._core import hello" in content, (
+        "smoke-import command must call `from headroom._core import hello` "
+        "— that's what the proxy does at startup. A weaker check (e.g. "
+        "`import headroom`) wouldn't exercise the .so and wouldn't catch "
+        "the bugs the gate exists for."
     )
 
 


### PR DESCRIPTION
## Summary

The X1 hardening from the post-#355 plan: a release-gating job that **actually loads the wheel** on a matrix of representative customer environments before \`publish-pypi\` / \`publish-docker\` / \`create-release\`.

## Why this is necessary

Issue #355 plus the three hotfixes (#384/#385/#386) all share the same pattern: the wheel is technically valid (clippy passes, tests pass, auditwheel is happy, the static symbol audit in #384 is happy) but **fails to import on a customer's box** because of a runtime symbol mismatch. None of our pre-publish gates actually \`import headroom._core\` on a representative environment. They only build it.

This PR closes that gap.

## Matrix

6 jobs, ~3 min wall-clock parallel:

| runner | image | python | rationale |
|---|---|---|---|
| \`ubuntu-24.04\` | \`quay.io/pypa/manylinux_2_28_x86_64\` | 3.11 | x86_64 floor — pins what we promise |
| \`ubuntu-24.04\` | \`ubuntu:22.04\` | 3.12 | issue #355's environment |
| \`ubuntu-24.04\` | \`ubuntu:20.04\` | 3.10 | older still-supported LTS |
| \`ubuntu-24.04-arm\` | \`quay.io/pypa/manylinux_2_28_aarch64\` | 3.11 | aarch64 floor (would have caught #386) |
| \`ubuntu-24.04-arm\` | \`ubuntu:22.04\` | 3.12 | aarch64 customer env |
| \`macos-14\` | (host, no container) | 3.13 | Apple Silicon |

Each job downloads its arch's wheel artifact and runs the exact command the proxy's \`_check_rust_core\` runs at startup:

\`\`\`python
from headroom._core import hello as _rust_hello
\`\`\`

## Gating

\`publish-pypi\`, \`publish-docker\`, AND \`create-release\` all \`needs: smoke-import-wheels\` AND require its success in their \`if:\` blocks. A smoke failure BLOCKS publish — that's the whole point.

## Regression test

\`tests/test_release_workflows.py::test_release_workflow_has_smoke_import_wheel_gate\` pins:
- The job exists.
- The matrix covers manylinux floor + Ubuntu LTS per arch + macOS native.
- All three downstream jobs (\`publish-pypi\`, \`publish-docker\`, \`create-release\`) gate on the smoke job's success.
- The import command actually exercises \`_core\` — \`from headroom._core import hello\`, not just \`import headroom\`.

A future "drop this slow CI step that always passes" refactor fails at PR time.

## Validation

- \`make ci-precheck\` covers the regression test (passing locally).
- 20/20 workflow tests green (13 pre-existing + 7 added across #371/#376/#382/#384/#387).
- YAML structure verified via Python yaml parser: smoke-import-wheels job exists, 6 matrix rows, gating wires correct.

## Test plan
- [ ] Next release run: smoke-import-wheels job appears, runs in parallel after build-wheels, produces 6 green matrix entries.
- [ ] publish-pypi / publish-docker / create-release wait for the smoke gate.
- [ ] Inject a deliberate failure (e.g. revert the #386 link-arg fix on a feature branch) — confirm aarch64 smoke fails and BLOCKS publish.