### PR TITLE
fix(ci): stage smoke-import script as host file (broke main)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,6 +387,32 @@ jobs:
           name: ${{ matrix.wheel_artifact }}
           path: dist/
 
+      - name: Stage smoke-import script
+        # The smoke script lives in a host file rather than an inline
+        # heredoc/`-c` invocation. Rationale:
+        #
+        # 1. The Linux job wraps the smoke check in `bash -ec '<long>'`
+        #    where the outer single quote preserves whitespace AND
+        #    forbids any internal single quote (closing it terminates
+        #    the script). A `<<PY ... PY` heredoc inside the inner bash
+        #    inherits the YAML indentation, so the closing `PY` is at
+        #    column 14, never matched (caught post-#387 merge: bash
+        #    "here-document at line 65 delimited by end-of-file").
+        # 2. Switching to `python -c "<f-string>"` solves the heredoc
+        #    indent problem but reintroduces the single-quote nesting
+        #    issue (Python f-strings need quote chars).
+        # 3. A host-side file dodges both: bash heredoc body lives at
+        #    YAML `run: |` level (uniform strip), the docker container
+        #    sees it as a read-only mount, and macOS host runs the
+        #    same script — no quoting drift between paths.
+        run: |
+          cat > "${RUNNER_TEMP}/smoke_import.py" <<'PY'
+          import sys
+          import headroom
+          from headroom._core import hello as _rust_hello
+          print(f"smoke-import OK: python={sys.version_info[:3]} hello={_rust_hello()}")
+          PY
+
       - name: Smoke-import wheel inside container (Linux)
         if: matrix.image != ''
         env:
@@ -402,6 +428,7 @@ jobs:
           # easier to debug.
           docker run --rm \
             -v "$(pwd)/dist:/wheels:ro" \
+            -v "${RUNNER_TEMP}/smoke_import.py:/smoke_import.py:ro" \
             -e PYTHON_VERSION="$PYTHON_VERSION" \
             -e WHEEL_TARGET="$WHEEL_TARGET" \
             -e GLIBC_LABEL="$GLIBC_LABEL" \
@@ -469,14 +496,11 @@ jobs:
 
               # The actual smoke check — mirrors the proxy
               # `_check_rust_core` path that fails with exit-78 on
-              # broken wheels. If this `import` fails the whole
-              # release is held.
-              /tmp/venv/bin/python - <<PY
-              import sys
-              import headroom
-              from headroom._core import hello as _rust_hello
-              print(f"smoke-import OK: python={sys.version_info[:3]} hello={_rust_hello()}")
-              PY
+              # broken wheels. The script is mounted from the host via
+              # `-v ${RUNNER_TEMP}/smoke_import.py:/smoke_import.py:ro`;
+              # see the "Stage smoke-import script" step above for why
+              # an inline heredoc here would not work.
+              /tmp/venv/bin/python /smoke_import.py
             '
 
       - name: Smoke-import wheel on macOS host
@@ -500,12 +524,9 @@ jobs:
           "python$PYTHON_VERSION" -m venv /tmp/venv
           /tmp/venv/bin/pip install --quiet --upgrade pip
           /tmp/venv/bin/pip install --quiet "$whl"
-          /tmp/venv/bin/python - <<'PY'
-          import sys
-          import headroom
-          from headroom._core import hello as _rust_hello
-          print(f"smoke-import OK: python={sys.version_info[:3]} hello={_rust_hello()}")
-          PY
+          # Same staged smoke script as the Linux container path uses,
+          # invoked directly on the macOS host (no docker mount needed).
+          /tmp/venv/bin/python "${RUNNER_TEMP}/smoke_import.py"
 
   publish-pypi:
     needs: [collect-dist, smoke-import-wheels]


### PR DESCRIPTION
## Summary
- Hotfix for the post-#387 main breakage. The X1 smoke-import job's `<<PY` heredoc was nested inside `bash -ec '...'` (single-quoted), so the heredoc body and the closing `PY` retained their YAML indentation (column 14). Inner bash never matched a column-0 `PY` and read past EOF — the smoke check then crashed with `IndentationError`.
- Failing run: https://github.com/chopratejas/headroom/actions/runs/25361396712/job/74362427755 (manylinux_2_28_x86_64 / Python 3.11)
- Fix: stage the smoke script to `${RUNNER_TEMP}/smoke_import.py` in a new "Stage smoke-import script" step (heredoc at YAML `run: |` level — uniform indent strip works fine), then mount/run from both Linux container and macOS host.
- Why not `python -c "..."`: dodges the heredoc indent issue but reintroduces single-quote nesting on the f-string.

## Test plan
- [x] `actionlint .github/workflows/*.yml` clean locally
- [x] `pytest tests/test_release_workflows.py` 20/20 pass (structural pins still satisfied)
- [x] Local hand-execution of the staged-file heredoc + Python script runs end-to-end on the host
- [ ] Post-merge release run on main passes the smoke-import matrix on all 6 platforms (manylinux floor x86_64+aarch64, ubuntu 22.04 x86_64, ubuntu 20.04 x86_64, ubuntu 22.04 aarch64, macos-14)

## Followup
This is the second X1 follow-up after PR #387's shellcheck fix. The original X1 design's gap: no PR-time release dry-run that would have caught the heredoc on PR #387 itself. **X2 (PR-time dry-run) is the structural fix and is the next branch up.**