### PR TITLE
fix(crusher): bridge SmartCrusher row-drop hash to Python compression_store (#389)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.20.16"
+    "version": "0.20.28"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.20.16",
+      "version": "0.20.28",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.20.16"
+    "version": "0.20.28"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.20.16",
+      "version": "0.20.28",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/headroom/cache/compression_store.py
+++ b/headroom/cache/compression_store.py
@@ -199,7 +199,7 @@ class CompressionStore:
             compression_strategy: Strategy used for compression.
             ttl: Custom TTL in seconds (uses default if not specified).
             explicit_hash: Use this exact hex hash as the storage key
-                instead of computing MD5(original)[:24]. Required when
+                instead of computing SHA-256(original)[:24]. Required when
                 the marker that points at this entry was emitted by a
                 producer with its own hash function (e.g. SmartCrusher's
                 Rust row-drop path uses SHA-256[:12]). If not a hex
@@ -210,28 +210,35 @@ class CompressionStore:
         Returns:
             Hash key for retrieving this content.
         """
-        # Generate hash from original content. Default: MD5[:24] of the
+        # Generate hash from original content. Default: SHA-256[:24] of the
         # original. When the caller provides `explicit_hash`, use it
         # verbatim — required when the hash that ends up in the prompt
         # marker is produced by another component (e.g. the Rust
         # SmartCrusher row-drop path emits SHA-256[:12], which the
         # Python store has to mirror so /v1/retrieve resolves it).
-        # CRITICAL FIX #5: Use 24 chars (96 bits) instead of 16 (64 bits) for better
-        # collision resistance. Birthday paradox: 50% collision at sqrt(2^n) entries.
-        # - 64 bits: ~4 billion entries for 50% collision
-        # - 96 bits: ~280 trillion entries for 50% collision
+        # 24 chars (96 bits) was chosen for collision resistance under the
+        # birthday bound: 50% collision probability at ~280 trillion entries
+        # (2^48), versus ~4 billion (2^32) for the previous 16-char default.
         if explicit_hash is not None:
             # Validate as hex. Bail loudly per `feedback_no_silent_fallbacks`
-            # — silently falling back to MD5 when the caller asked for a
-            # specific key would defeat the marker/store consistency we're
-            # trying to preserve.
+            # — silently falling back to the default hash when the caller
+            # asked for a specific key would defeat the marker/store
+            # consistency we're trying to preserve.
             if not explicit_hash or not all(c in "0123456789abcdefABCDEF" for c in explicit_hash):
                 raise ValueError(
                     f"explicit_hash must be a non-empty hex string, got {explicit_hash!r}"
                 )
             hash_key = explicit_hash.lower()
         else:
-            hash_key = hashlib.md5(original.encode()).hexdigest()[:24]  # nosec B324
+            # SHA-256 truncated to 24 hex chars (96 bits) — same collision
+            # space as the MD5[:24] this replaced. Switched from MD5 in
+            # PR #395 to silence CodeQL's `py/weak-sensitive-data-hashing`
+            # rule (the `usedforsecurity=False` parameter and the `lgtm`
+            # comment marker both failed to suppress it). The cache is
+            # in-memory, so changing the hash function on upgrade has no
+            # persistence-side effect — the same content always hashes
+            # deterministically under whichever function is in use.
+            hash_key = hashlib.sha256(original.encode()).hexdigest()[:24]
 
         entry = CompressionEntry(
             hash=hash_key,

--- a/headroom/cache/compression_store.py
+++ b/headroom/cache/compression_store.py
@@ -181,6 +181,7 @@ class CompressionStore:
         tool_signature_hash: str | None = None,
         compression_strategy: str | None = None,
         ttl: int | None = None,
+        explicit_hash: str | None = None,
     ) -> str:
         """Store compressed content and return hash for retrieval.
 
@@ -197,16 +198,40 @@ class CompressionStore:
             tool_signature_hash: Hash from ToolSignature for TOIN correlation.
             compression_strategy: Strategy used for compression.
             ttl: Custom TTL in seconds (uses default if not specified).
+            explicit_hash: Use this exact hex hash as the storage key
+                instead of computing MD5(original)[:24]. Required when
+                the marker that points at this entry was emitted by a
+                producer with its own hash function (e.g. SmartCrusher's
+                Rust row-drop path uses SHA-256[:12]). If not a hex
+                string, raises ``ValueError``. The marker hash and the
+                store key MUST match — otherwise ``/v1/retrieve/{hash}``
+                returns 404 even though the data is present.
 
         Returns:
             Hash key for retrieving this content.
         """
-        # Generate hash from original content
+        # Generate hash from original content. Default: MD5[:24] of the
+        # original. When the caller provides `explicit_hash`, use it
+        # verbatim — required when the hash that ends up in the prompt
+        # marker is produced by another component (e.g. the Rust
+        # SmartCrusher row-drop path emits SHA-256[:12], which the
+        # Python store has to mirror so /v1/retrieve resolves it).
         # CRITICAL FIX #5: Use 24 chars (96 bits) instead of 16 (64 bits) for better
         # collision resistance. Birthday paradox: 50% collision at sqrt(2^n) entries.
         # - 64 bits: ~4 billion entries for 50% collision
         # - 96 bits: ~280 trillion entries for 50% collision
-        hash_key = hashlib.md5(original.encode()).hexdigest()[:24]  # nosec B324
+        if explicit_hash is not None:
+            # Validate as hex. Bail loudly per `feedback_no_silent_fallbacks`
+            # — silently falling back to MD5 when the caller asked for a
+            # specific key would defeat the marker/store consistency we're
+            # trying to preserve.
+            if not explicit_hash or not all(c in "0123456789abcdefABCDEF" for c in explicit_hash):
+                raise ValueError(
+                    f"explicit_hash must be a non-empty hex string, got {explicit_hash!r}"
+                )
+            hash_key = explicit_hash.lower()
+        else:
+            hash_key = hashlib.md5(original.encode()).hexdigest()[:24]  # nosec B324
 
         entry = CompressionEntry(
             hash=hash_key,

--- a/headroom/transforms/smart_crusher.py
+++ b/headroom/transforms/smart_crusher.py
@@ -294,6 +294,15 @@ class SmartCrusher(Transform):
                 query_context=query,
                 tool_name=None,
             )
+        # Bridge any CCR markers emitted by the Rust crusher into the
+        # Python compression_store so /v1/retrieve resolves them.
+        # See `_mirror_ccr_to_python_store` for full rationale.
+        self._mirror_ccr_to_python_store(
+            rendered=r.compressed,
+            strategy=r.strategy,
+            query_context=query,
+            tool_name=None,
+        )
         return CrushResult(
             compressed=r.compressed,
             original=r.original,
@@ -318,6 +327,36 @@ class SmartCrusher(Transform):
         the hash directly rather than parsing it out of a prompt marker.
         """
         result: dict[str, Any] = self._rust.crush_array_json(items_json, query, bias)
+        # Row-drop case: Rust returns the structured `ccr_hash` and has
+        # already stashed the canonical in its own store. Mirror that
+        # entry into the Python compression_store keyed by the same
+        # 12-char SHA-256 hash so /v1/retrieve resolves it.
+        ccr_hash = result.get("ccr_hash")
+        if ccr_hash:
+            self._mirror_single_hash_to_python_store(
+                ccr_hash,
+                strategy=str(result.get("strategy_info") or "smart_crusher_row_drop"),
+                query_context=query,
+                tool_name=None,
+            )
+        # Opaque-blob substitutions inside the kept items also produce
+        # markers. Walk the rendered shape to bridge those too.
+        kept_json = result.get("items")
+        if isinstance(kept_json, str) and "<<ccr:" in kept_json:
+            self._mirror_ccr_markers_in_text(
+                kept_json,
+                strategy=str(result.get("strategy_info") or "smart_crusher"),
+                query_context=query,
+                tool_name=None,
+            )
+        compacted = result.get("compacted")
+        if isinstance(compacted, str) and "<<ccr:" in compacted:
+            self._mirror_ccr_markers_in_text(
+                compacted,
+                strategy=str(result.get("strategy_info") or "smart_crusher"),
+                query_context=query,
+                tool_name=None,
+            )
         return result
 
     def compact_document_json(self, doc_json: str) -> str:
@@ -332,6 +371,15 @@ class SmartCrusher(Transform):
         without per-array lossy crushing.
         """
         result: str = self._rust.compact_document_json(doc_json)
+        # Mirror any opaque-blob markers the walker emitted into the
+        # Python store so /v1/retrieve resolves them.
+        if "<<ccr:" in result:
+            self._mirror_ccr_markers_in_text(
+                result,
+                strategy="smart_crusher_compact_document",
+                query_context="",
+                tool_name=None,
+            )
         return result
 
     def ccr_get(self, hash_key: str) -> str | None:
@@ -379,6 +427,15 @@ class SmartCrusher(Transform):
                 query_context=query_context,
                 tool_name=tool_name,
             )
+        # Bridge any CCR markers (row-drop sentinels or opaque-blob
+        # substitutions) emitted by the Rust crusher into the Python
+        # compression_store so /v1/retrieve resolves them.
+        self._mirror_ccr_to_python_store(
+            rendered=crushed,
+            strategy=info or "smart_crusher",
+            query_context=query_context,
+            tool_name=tool_name,
+        )
         return crushed, was_modified, info
 
     def _record_to_toin(
@@ -459,6 +516,196 @@ class SmartCrusher(Transform):
             self._toin_load_failed = True
         except Exception as e:  # pragma: no cover - best effort
             logger.debug("SmartCrusher TOIN recording failed (non-fatal): %s", e)
+
+    # ─── CCR Rust → Python store bridge ───────────────────────────────────
+    #
+    # Issue #389: SmartCrusher's row-drop and opaque-blob paths emit
+    # `<<ccr:HASH ...>>` markers and stash the original payload in the
+    # Rust process-local CCR store. /v1/retrieve queries the Python
+    # `compression_store` via `get_compression_store()` — which is a
+    # different store. Without an explicit bridge, every retrieve call
+    # for a marker emitted by the Rust crusher returns 404.
+    #
+    # The bridge is straight Rust→Python mirror: extract every
+    # `<<ccr:HASH>>` hash from the rendered output, fetch the canonical
+    # bytes via `self._rust.ccr_get(hash)`, and call
+    # `compression_store.store(..., explicit_hash=hash)` so the Python
+    # store is keyed by the exact hash that's in the prompt marker.
+    #
+    # Best-effort by design: a missing compression_store import (e.g.
+    # in a stripped CLI build) or a transient store error must NOT
+    # break compression itself. Compression has already succeeded; the
+    # bridge just makes /v1/retrieve work. Errors log at debug.
+
+    def _mirror_ccr_to_python_store(
+        self,
+        rendered: str,
+        strategy: str,
+        query_context: str,
+        tool_name: str | None,
+    ) -> None:
+        """Walk `rendered` for any `<<ccr:HASH ...>>` markers and mirror
+        each into the Python `compression_store`.
+
+        `rendered` may be a JSON string (the standard SmartCrusher
+        output format) or arbitrary text. We try the structured walk
+        first; if that fails we fall back to a non-regex token scan.
+        """
+        # Cheap pre-filter — most outputs have no marker at all.
+        if "<<ccr:" not in rendered:
+            return
+        self._mirror_ccr_markers_in_text(
+            rendered,
+            strategy=strategy,
+            query_context=query_context,
+            tool_name=tool_name,
+        )
+
+    def _mirror_ccr_markers_in_text(
+        self,
+        rendered: str,
+        strategy: str,
+        query_context: str,
+        tool_name: str | None,
+    ) -> None:
+        """Find every distinct `<<ccr:HASH...>>` hash in `rendered` and
+        mirror Rust→Python store for each.
+
+        Tries JSON-tree walk first (structured, handles nested shapes);
+        falls back to a token scan if `rendered` isn't valid JSON.
+        Both paths avoid regex per
+        ``feedback_no_silent_fallbacks``-adjacent rule that prefers
+        structured parsing.
+        """
+        hashes: set[str] = set()
+        try:
+            parsed = json.loads(rendered)
+            self._collect_ccr_hashes(parsed, hashes)
+        except (json.JSONDecodeError, ValueError):
+            # Output isn't valid JSON (rare — `smart_crush_content`
+            # always re-serializes via `python_safe_json_dumps`). Fall
+            # through to a string-token scan so we still bridge.
+            self._collect_ccr_hashes_from_string(rendered, hashes)
+        if not hashes:
+            return
+        for h in hashes:
+            self._mirror_single_hash_to_python_store(
+                h,
+                strategy=strategy,
+                query_context=query_context,
+                tool_name=tool_name,
+            )
+
+    @staticmethod
+    def _collect_ccr_hashes(value: Any, sink: set[str]) -> None:
+        """Recursively walk a parsed-JSON value, appending every CCR
+        hash found inside string leaves to `sink`. Never raises."""
+        if isinstance(value, str):
+            SmartCrusher._collect_ccr_hashes_from_string(value, sink)
+            return
+        if isinstance(value, dict):
+            for v in value.values():
+                SmartCrusher._collect_ccr_hashes(v, sink)
+            return
+        if isinstance(value, list):
+            for v in value:
+                SmartCrusher._collect_ccr_hashes(v, sink)
+            return
+        # ints/bools/None/floats — no markers possible
+
+    @staticmethod
+    def _collect_ccr_hashes_from_string(s: str, sink: set[str]) -> None:
+        """Extract every `<<ccr:HASH...>>` hash from a string by
+        substring scan (no regex). The marker grammar is fixed:
+
+            <<ccr:HASH<sep>...>>
+
+        where ``HASH`` is `[0-9a-f]+` and ``<sep>`` is one of the
+        delimiters the Rust emitters use today: a single space (the
+        row-drop summary, ``<<ccr:abc 100_rows_offloaded>>``) or a
+        comma (the opaque-blob marker, ``<<ccr:abc,base64,4.5KB>>``).
+        We accept either delimiter and tolerate `>>` as the terminator
+        (the case where the marker is just `<<ccr:abc>>` with no
+        suffix, used by the bare CCR helpers).
+        """
+        idx = 0
+        prefix = "<<ccr:"
+        n = len(s)
+        while True:
+            start = s.find(prefix, idx)
+            if start == -1:
+                return
+            cursor = start + len(prefix)
+            end = cursor
+            while end < n and s[end] in "0123456789abcdefABCDEF":
+                end += 1
+            if end == cursor:
+                # No hex chars after `<<ccr:` — not a real marker.
+                idx = cursor
+                continue
+            hash_str = s[cursor:end].lower()
+            sink.add(hash_str)
+            idx = end
+
+    def _mirror_single_hash_to_python_store(
+        self,
+        ccr_hash: str,
+        strategy: str,
+        query_context: str,
+        tool_name: str | None,
+    ) -> None:
+        """Mirror a single Rust-stored CCR entry into the Python
+        compression_store, keyed by `ccr_hash`. Best-effort.
+        """
+        canonical = self._rust.ccr_get(ccr_hash)
+        if canonical is None:
+            # Rust store doesn't have it — either the marker came from
+            # somewhere else (defensive: another transform's marker
+            # leaked into our input), or the entry expired between
+            # emission and mirror. Either way, nothing to mirror.
+            logger.debug(
+                "CCR mirror: hash %s not in Rust store (skipped)",
+                ccr_hash,
+            )
+            return
+        try:
+            from ..cache.compression_store import get_compression_store
+        except ImportError:
+            # Stripped build without the compression_store module.
+            # Mirror is a no-op; Rust side still serves the data.
+            logger.debug("CCR mirror: compression_store module unavailable")
+            return
+        try:
+            store = get_compression_store()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("CCR mirror: cannot get compression_store (%s)", e)
+            return
+        # The TTL on the Python store defaults to 5 minutes — same as
+        # the Rust store's `DEFAULT_TTL` (see crates/headroom-core/src/
+        # ccr/mod.rs). No need to override.
+        try:
+            store.store(
+                original=canonical,
+                # The "compressed" payload for the row-drop case isn't
+                # readily available here (the rendered output may be
+                # only one of many crushed sub-arrays). Use the marker
+                # itself as a placeholder — `/v1/retrieve` returns
+                # `original_content` and `compressed` isn't surfaced.
+                compressed=f"<<ccr:{ccr_hash}>>",
+                tool_name=tool_name,
+                query_context=query_context if query_context else None,
+                compression_strategy=strategy,
+                explicit_hash=ccr_hash,
+            )
+        except ValueError:
+            # explicit_hash validation failed — the marker had a
+            # malformed hash (shouldn't happen in practice).
+            logger.warning(
+                "CCR mirror: invalid hash %r from rendered marker",
+                ccr_hash,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("CCR mirror: store.store() raised (%s)", e)
 
     def _extract_context_from_messages(self, messages: list[dict[str, Any]]) -> str:
         """Build a query string from the last 5 user messages + recent

--- a/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.20.16",
+  "version": "0.20.28",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/plugins/headroom-agent-hooks/.github/plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.20.16",
+  "version": "0.20.28",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/tests/test_ccr_row_drop_store_bridge.py
+++ b/tests/test_ccr_row_drop_store_bridge.py
@@ -1,0 +1,482 @@
+"""Issue #389: SmartCrusher row-drop CCR hash → Python compression_store bridge.
+
+The row-drop and opaque-blob paths in the Rust SmartCrusher emit
+``<<ccr:HASH ...>>`` markers and stash the original payload in the
+Rust process-local CCR store. The Python proxy's ``/v1/retrieve``
+endpoint queries the Python ``compression_store`` (not the Rust one),
+so without a bridge every retrieve call for a Rust-emitted marker
+returns 404.
+
+These tests pin the bridge:
+
+1. Unit: lossy crush of a 200-item array populates the Python
+   compression_store keyed by the same hash that's in the marker, with
+   the canonical original retrievable via ``store.retrieve(hash)``.
+
+2. Integration: ``/v1/compress`` followed by ``/v1/retrieve/{hash}``
+   on the same hash returns 200 with the original content. This is
+   the failing case from the issue's reproducer.
+
+3. Edge: opaque-blob markers (the ``<<ccr:HASH,KIND,SIZE>>`` shape)
+   also bridge — the document walker emits these for long strings.
+
+If these regress, ``/v1/retrieve`` silently 404s for every
+SmartCrusher-emitted marker even though the data is held in the Rust
+store. The LLM follows the marker, gets nothing, and the proxy's CCR
+contract is broken at the bridge.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _build_extension() -> None:
+    try:
+        from headroom._core import SmartCrusher  # noqa: F401
+    except ImportError:
+        pytest.skip(
+            "headroom._core not built — run `bash scripts/build_rust_extension.sh`",
+            allow_module_level=True,
+        )
+
+
+_build_extension()
+
+
+# Skip if fastapi not available — needed for integration tests but not unit.
+try:
+    import fastapi  # noqa: F401
+
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+
+# ─── Unit tests: shim populates Python store ─────────────────────────────
+
+
+def test_lossy_crush_populates_python_compression_store() -> None:
+    """The cornerstone unit test: trigger a row-drop via the Python
+    SmartCrusher shim, then verify the Python compression_store has
+    an entry keyed by the marker's hash with the canonical original.
+    """
+    from headroom.cache.compression_store import (
+        get_compression_store,
+        reset_compression_store,
+    )
+    from headroom.config import CCRConfig
+    from headroom.config import SmartCrusherConfig as PyConfig
+    from headroom.transforms.smart_crusher import SmartCrusher
+
+    reset_compression_store()
+    try:
+        crusher = SmartCrusher(PyConfig(), ccr_config=CCRConfig(), with_compaction=False)
+
+        # 60 items is well above adaptive_k → lossy path fires.
+        original = [{"id": i, "status": "ok", "tag": "alpha"} for i in range(60)]
+        original_json = json.dumps(original)
+
+        result = crusher.crush_array_json(original_json)
+
+        # Sanity: lossy path actually fired.
+        assert result["ccr_hash"] is not None, (
+            f"expected lossy drop, got strategy={result['strategy_info']!r}"
+        )
+        ccr_hash = result["ccr_hash"]
+        # The marker text embeds the same hash.
+        assert ccr_hash in result["dropped_summary"], (
+            f"marker {result['dropped_summary']!r} should embed hash {ccr_hash}"
+        )
+
+        # The bridge: Python compression_store now holds an entry keyed
+        # by the Rust-emitted hash.
+        store = get_compression_store()
+        entry = store.retrieve(ccr_hash)
+        assert entry is not None, (
+            f"compression_store has no entry for hash {ccr_hash!r}; "
+            f"the bridge dropped the row-drop hash on the floor"
+        )
+
+        # The entry's original content is the canonical-JSON
+        # serialization of the original array — same bytes the Rust
+        # store has under the same hash.
+        rust_canonical = crusher.ccr_get(ccr_hash)
+        assert rust_canonical is not None, "Rust store lost the entry"
+        assert entry.original_content == rust_canonical, (
+            "Python store's canonical bytes diverged from Rust store"
+        )
+
+        # Round-trip: parse the canonical and compare to input.
+        retrieved = json.loads(entry.original_content)
+        assert retrieved == original
+    finally:
+        reset_compression_store()
+
+
+def test_smart_crush_content_populates_python_store() -> None:
+    """Same bridge but driven through the runtime path the proxy
+    actually uses: `_smart_crush_content` (not `crush_array_json`).
+    This is what `apply()` invokes per-message."""
+    from headroom.cache.compression_store import (
+        get_compression_store,
+        reset_compression_store,
+    )
+    from headroom.config import CCRConfig
+    from headroom.config import SmartCrusherConfig as PyConfig
+    from headroom.transforms.smart_crusher import SmartCrusher
+
+    reset_compression_store()
+    try:
+        crusher = SmartCrusher(PyConfig(), ccr_config=CCRConfig(), with_compaction=False)
+
+        # Mix of "ok" + occasional "error" → variance the lossy path
+        # can latch onto. A purely-uniform array gets a `skip:unique_
+        # entities_no_signal` strategy and never row-drops.
+        original = [
+            {
+                "id": i,
+                "level": "error" if i % 30 == 0 else "info",
+                "msg": f"line {i}",
+            }
+            for i in range(80)
+        ]
+        content = json.dumps(original)
+
+        crushed, was_modified, info = crusher._smart_crush_content(content)
+        assert was_modified, f"expected lossy modification, got info={info!r}"
+        assert "<<ccr:" in crushed, (
+            f"expected CCR marker in output (info={info!r}): {crushed[:200]!r}"
+        )
+
+        # Pull the hash from the rendered output via JSON parse.
+        # The output is a JSON array with a `_ccr_dropped` sentinel.
+        parsed = json.loads(crushed)
+        assert isinstance(parsed, list), f"expected JSON array, got {type(parsed).__name__}"
+        sentinel = parsed[-1]
+        assert isinstance(sentinel, dict) and "_ccr_dropped" in sentinel, (
+            f"expected _ccr_dropped sentinel as last element, got {sentinel!r}"
+        )
+        marker_text = sentinel["_ccr_dropped"]
+        assert marker_text.startswith("<<ccr:") and "rows_offloaded>>" in marker_text
+
+        # Extract hash by structural slice (no regex).
+        ccr_hash = marker_text[len("<<ccr:") :].split(" ", 1)[0]
+        assert all(c in "0123456789abcdef" for c in ccr_hash), f"hash should be hex: {ccr_hash!r}"
+
+        # The Python store now has the entry under this hash.
+        store = get_compression_store()
+        entry = store.retrieve(ccr_hash)
+        assert entry is not None, (
+            f"_smart_crush_content didn't bridge hash {ccr_hash!r} to "
+            f"Python store; /v1/retrieve would 404"
+        )
+
+        # Original is recoverable byte-for-byte from the bridged entry.
+        retrieved = json.loads(entry.original_content)
+        assert retrieved == original
+    finally:
+        reset_compression_store()
+
+
+def test_passthrough_does_not_populate_store() -> None:
+    """Below adaptive_k → no row drop → no Python store write.
+    Pins that we don't accidentally store on every crush call."""
+    from headroom.cache.compression_store import (
+        get_compression_store,
+        reset_compression_store,
+    )
+    from headroom.config import CCRConfig
+    from headroom.config import SmartCrusherConfig as PyConfig
+    from headroom.transforms.smart_crusher import SmartCrusher
+
+    reset_compression_store()
+    try:
+        crusher = SmartCrusher(PyConfig(), ccr_config=CCRConfig(), with_compaction=False)
+
+        # 3 items: well below the threshold; no compression happens.
+        small = json.dumps([{"id": i} for i in range(3)])
+        crusher._smart_crush_content(small)
+
+        store = get_compression_store()
+        stats = store.get_stats()
+        assert stats["entry_count"] == 0, (
+            f"passthrough crush should not write to compression_store, "
+            f"got {stats['entry_count']} entries"
+        )
+    finally:
+        reset_compression_store()
+
+
+def test_marker_disabled_skips_python_store() -> None:
+    """`ccr_config.enabled=False` flips off marker emission AND store
+    writes on the Rust side. The bridge should have nothing to do."""
+    from headroom.cache.compression_store import (
+        get_compression_store,
+        reset_compression_store,
+    )
+    from headroom.config import CCRConfig
+    from headroom.config import SmartCrusherConfig as PyConfig
+    from headroom.transforms.smart_crusher import SmartCrusher
+
+    reset_compression_store()
+    try:
+        # Markers disabled → Rust skips both marker emission and store write.
+        crusher = SmartCrusher(
+            PyConfig(),
+            ccr_config=CCRConfig(enabled=False),
+            with_compaction=False,
+        )
+
+        original = [{"id": i, "status": "ok"} for i in range(60)]
+        crushed, was_modified, _info = crusher._smart_crush_content(json.dumps(original))
+
+        # Compression still happens (rows still drop), but no marker.
+        assert was_modified
+        assert "<<ccr:" not in crushed, (
+            f"expected no marker when ccr_config.enabled=False, got: {crushed[:200]!r}"
+        )
+
+        # And the Python store stays empty — bridge had nothing to mirror.
+        store = get_compression_store()
+        assert store.get_stats()["entry_count"] == 0
+    finally:
+        reset_compression_store()
+
+
+def test_distinct_payloads_get_distinct_python_store_entries() -> None:
+    """Two unrelated payloads → two row drops → two entries under
+    distinct hashes in the Python store; both retrievable independently."""
+    from headroom.cache.compression_store import (
+        get_compression_store,
+        reset_compression_store,
+    )
+    from headroom.config import CCRConfig
+    from headroom.config import SmartCrusherConfig as PyConfig
+    from headroom.transforms.smart_crusher import SmartCrusher
+
+    reset_compression_store()
+    try:
+        crusher = SmartCrusher(PyConfig(), ccr_config=CCRConfig(), with_compaction=False)
+
+        a = [{"id": i, "tag": "alpha"} for i in range(50)]
+        b = [{"id": i, "tag": "beta"} for i in range(50)]
+
+        ra = crusher.crush_array_json(json.dumps(a))
+        rb = crusher.crush_array_json(json.dumps(b))
+
+        ha, hb = ra["ccr_hash"], rb["ccr_hash"]
+        assert ha and hb and ha != hb
+
+        store = get_compression_store()
+        ea = store.retrieve(ha)
+        eb = store.retrieve(hb)
+        assert ea is not None and eb is not None
+        assert json.loads(ea.original_content) == a
+        assert json.loads(eb.original_content) == b
+    finally:
+        reset_compression_store()
+
+
+# ─── compression_store: explicit_hash parameter ───────────────────────────
+
+
+def test_compression_store_explicit_hash_round_trips() -> None:
+    """The new `explicit_hash` parameter on `store.store()` keys the
+    entry by the caller-supplied hash instead of MD5(original)[:24]."""
+    from headroom.cache.compression_store import (
+        get_compression_store,
+        reset_compression_store,
+    )
+
+    reset_compression_store()
+    try:
+        store = get_compression_store()
+        # SmartCrusher emits 12-char SHA-256 hashes — much shorter than
+        # the default MD5[:24].
+        explicit = "abc123def456"
+        returned = store.store(
+            original='[{"id":1}]',
+            compressed="<<placeholder>>",
+            explicit_hash=explicit,
+        )
+        assert returned == explicit
+        entry = store.retrieve(explicit)
+        assert entry is not None
+        assert entry.original_content == '[{"id":1}]'
+    finally:
+        reset_compression_store()
+
+
+def test_compression_store_explicit_hash_rejects_non_hex() -> None:
+    """Non-hex `explicit_hash` raises ValueError. No silent fallback
+    to MD5 — that would re-introduce the marker/store mismatch."""
+    from headroom.cache.compression_store import (
+        get_compression_store,
+        reset_compression_store,
+    )
+
+    reset_compression_store()
+    try:
+        store = get_compression_store()
+        with pytest.raises(ValueError, match="hex string"):
+            store.store(
+                original="x",
+                compressed="y",
+                explicit_hash="NOT_HEX!@#",
+            )
+        with pytest.raises(ValueError, match="hex string"):
+            store.store(
+                original="x",
+                compressed="y",
+                explicit_hash="",
+            )
+    finally:
+        reset_compression_store()
+
+
+# ─── Integration test: /v1/compress → /v1/retrieve via FastAPI ──────────
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi not installed")
+def test_v1_compress_then_v1_retrieve_resolves_marker_hash() -> None:
+    """End-to-end issue #389 reproducer:
+    1. POST a 200-item tool message to /v1/compress.
+    2. Parse the `<<ccr:HASH N_rows_offloaded>>` marker out of the
+       compressed messages.
+    3. GET /v1/retrieve/{hash} — must return 200 with the original.
+
+    Before the fix this returns 404 because the Rust crusher's marker
+    points at a hash the Python compression_store never received.
+    """
+    from fastapi.testclient import TestClient
+
+    from headroom.cache.compression_store import reset_compression_store
+    from headroom.proxy.server import ProxyConfig, create_app
+
+    reset_compression_store()
+    config = ProxyConfig(
+        optimize=True,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+    )
+    app = create_app(config)
+
+    # Build a payload similar to the issue's reproducer — 200 items
+    # with enough variation to trigger the lossy path. The Rust
+    # crusher's adaptive_k will keep ~15 and drop the rest.
+    items = [
+        {
+            "id": i,
+            "score": 0.99 if i % 30 == 0 else 0.6,
+            "msg": f"Result {i:03d}{' error' if i % 30 == 0 else ' ok'}",
+            "blob": "x" * 80,
+        }
+        for i in range(200)
+    ]
+    req = {
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "Get items"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "get", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": json.dumps(items)},
+        ],
+    }
+
+    try:
+        with TestClient(app) as client:
+            resp = client.post("/v1/compress", json=req)
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+
+            # The compressed messages should embed at least one CCR marker.
+            messages_blob = json.dumps(body["messages"])
+            assert "<<ccr:" in messages_blob, (
+                f"no CCR marker after /v1/compress on a 200-item array; "
+                f"compression didn't fire as expected: "
+                f"transforms={body.get('transforms_applied')}"
+            )
+
+            # Pull the hash with a substring scan (no regex).
+            start = messages_blob.find("<<ccr:") + len("<<ccr:")
+            end = start
+            while end < len(messages_blob) and messages_blob[end] in ("0123456789abcdef"):
+                end += 1
+            ccr_hash = messages_blob[start:end]
+            assert ccr_hash, "couldn't extract hash from marker"
+
+            # The retrieve stats endpoint should now show ≥ 1 entry.
+            stats_resp = client.get("/v1/retrieve/stats")
+            assert stats_resp.status_code == 200
+            stats = stats_resp.json()
+            assert stats["store"]["entry_count"] >= 1, (
+                f"compression_store empty after /v1/compress; stats={stats!r}"
+            )
+
+            # The actual /v1/retrieve call from the issue:
+            retrieve_resp = client.post("/v1/retrieve", json={"hash": ccr_hash})
+            assert retrieve_resp.status_code == 200, (
+                f"/v1/retrieve for marker hash {ccr_hash!r} returned "
+                f"{retrieve_resp.status_code} ({retrieve_resp.text}). "
+                f"The Rust→Python store bridge dropped the entry."
+            )
+            retrieve_body = retrieve_resp.json()
+            assert retrieve_body["hash"] == ccr_hash
+            # The retrieved content should parse back to a JSON array
+            # of the original items.
+            retrieved_items = json.loads(retrieve_body["original_content"])
+            assert isinstance(retrieved_items, list)
+            # The original was 200 items. The Rust hash is over the
+            # canonical-JSON form of the parsed input — should round-trip.
+            assert len(retrieved_items) == 200, (
+                f"expected 200 items in retrieved content, got {len(retrieved_items)}"
+            )
+            # Spot-check the first item.
+            assert retrieved_items[0]["id"] == 0
+
+            # And the GET shape (used by some clients) returns the same.
+            get_resp = client.get(f"/v1/retrieve/{ccr_hash}")
+            assert get_resp.status_code == 200
+            get_body = get_resp.json()
+            assert get_body["hash"] == ccr_hash
+    finally:
+        reset_compression_store()
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi not installed")
+def test_v1_retrieve_unknown_hash_still_404() -> None:
+    """Sanity: unknown hashes still return 404 (the bridge doesn't
+    accidentally make the store too permissive)."""
+    from fastapi.testclient import TestClient
+
+    from headroom.cache.compression_store import reset_compression_store
+    from headroom.proxy.server import ProxyConfig, create_app
+
+    reset_compression_store()
+    config = ProxyConfig(
+        optimize=False,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+    )
+    app = create_app(config)
+
+    try:
+        with TestClient(app) as client:
+            resp = client.post("/v1/retrieve", json={"hash": "deadbeef0000"})
+            assert resp.status_code == 404
+    finally:
+        reset_compression_store()

--- a/tests/test_compression_store.py
+++ b/tests/test_compression_store.py
@@ -1249,11 +1249,26 @@ class TestHashCollisionDetection:
         # Should not have collision warning
         assert "Hash collision detected" not in caplog.text
 
-    def test_hash_uses_md5_truncated(self, store: CompressionStore):
-        """Hash is MD5 truncated to 24 characters (fast, non-crypto)."""
+    def test_hash_uses_sha256_truncated(self, store: CompressionStore):
+        """Hash is SHA-256 truncated to 24 characters.
+
+        Switched from MD5[:24] in PR #395 to silence CodeQL's
+        py/weak-sensitive-data-hashing rule. SHA-256[:24] gives the
+        same 96-bit collision space (~280 trillion entries for 50%
+        collision under birthday bound) and is FIPS-clean. The cache
+        is in-memory, so changing the hash function on upgrade has no
+        persistence-side effect.
+        """
         content = "test content"
-        expected_hash = hashlib.md5(content.encode()).hexdigest()[:24]  # nosec B324
+        expected_hash = hashlib.sha256(content.encode()).hexdigest()[:24]
 
         hash_key = store.store(original=content, compressed="[]")
 
-        assert hash_key == expected_hash
+        assert hash_key == expected_hash, (
+            "compression_store key must be SHA-256(original)[:24]. "
+            "If this test fails because the hash function was changed, "
+            "verify that no caller (incl. /v1/retrieve consumers) "
+            "depends on the specific MD5/SHA-256 value — the cache is "
+            "in-memory so upgrade-time mismatch is fine, but external "
+            "systems that hash-and-lookup independently need to match."
+        )


### PR DESCRIPTION
## Summary

- Bridge SmartCrusher's Rust-side CCR store entries into the Python `compression_store` so `/v1/retrieve` resolves the hashes embedded in `<<ccr:HASH ...>>` markers.
- Add an `explicit_hash` kwarg to `CompressionStore.store()` so the Python store can be keyed by the exact hash the Rust crusher emitted (SHA-256[:12], not MD5[:24]).
- New tests pin the bridge end-to-end via the issue's reproducer (200-item array → `/v1/compress` → `/v1/retrieve/{hash}` → 200 with original content).

## Root cause

`crates/headroom-core/src/transforms/smart_crusher/crusher.rs:676-691` stashes the canonical payload in the **Rust** `ccr_store` and emits a marker pointing at that hash. `/v1/retrieve` (`headroom/proxy/server.py:2069`) queries the **Python** `compression_store` (`headroom/cache/compression_store.py`), which never received the entry — so any LLM that followed the marker got `404`. The Python wrapper at `headroom/transforms/smart_crusher.py` returned the rendered output as-is and never called `compression_store.store()`.

## What changed

- `headroom/cache/compression_store.py` — `store()` now accepts `explicit_hash: str | None`. When set, it's used as the storage key (validated as non-empty hex; raises `ValueError` otherwise — no silent fallback). Default behavior unchanged.
- `headroom/transforms/smart_crusher.py` — added a private bridge that walks the rendered output for `<<ccr:HASH>>` markers (structured JSON walk + non-regex substring scan), fetches the canonical via `self._rust.ccr_get(hash)`, and mirrors into the Python `compression_store` keyed by `explicit_hash=hash`. Wired into `crush()`, `crush_array_json()`, `compact_document_json()`, and `_smart_crush_content()`.
- Best-effort by design: a missing `compression_store` import or transient store error logs at debug and never blocks compression.

## Test plan

- [x] `pytest tests/test_ccr_row_drop_store_bridge.py -v` — 9 new tests pass:
  - row-drop populates Python store keyed by marker hash with canonical original
  - `_smart_crush_content` (runtime proxy path) also populates the store
  - passthrough crushes do not write
  - `ccr_config.enabled=False` correctly skips both marker emission and store write
  - distinct payloads → distinct hashes, both independently retrievable
  - `explicit_hash` round-trips; non-hex hashes raise `ValueError`
  - end-to-end `/v1/compress` → `/v1/retrieve/{hash}` returns 200 with original (the issue's reproducer)
  - unknown hashes still return 404
- [x] `make ci-precheck` (pre-push hook) green — Rust workspace tests, smart_crusher Python suite, and commitlint all pass.
- [x] Full `pytest tests/ -x -q --ignore=tests/test_release_workflows.py` — 4595 passed, 407 skipped, 0 failures.

Addresses #389