### PR TITLE
fix(crusher): shim __libc_single_threaded for glibc < 2.32 + extend audit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.20.16"
+    "version": "0.20.28"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.20.16",
+      "version": "0.20.28",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.20.16"
+    "version": "0.20.28"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.20.16",
+      "version": "0.20.28",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/crates/headroom-py/build.rs
+++ b/crates/headroom-py/build.rs
@@ -1,17 +1,24 @@
-// Compile a tiny C shim that provides local definitions of the C23
-// strtol family (`__isoc23_strtol`, `__isoc23_strtoll`, etc.).
+// Compile a tiny C shim that provides local definitions of glibc
+// symbols introduced after the manylinux_2_28 floor that our static
+// deps reference:
 //
-// glibc < 2.38 doesn't ship these symbols. Static dependencies in
-// `_core.so` (notably the prebuilt ONNX Runtime artifacts compiled
-// with gcc 14.x) reference them, so without this shim the wheel
-// fails to import on Ubuntu 22.04, Conda envs with libc 2.35, etc.
+//   - C23 strtol family (`__isoc23_strtol`, `__isoc23_strtoll`, ...)
+//     introduced in glibc 2.38 — see `glibc_compat.c` Section A.
+//   - `__libc_single_threaded` introduced in glibc 2.32 — see
+//     `glibc_compat.c` Section B (caught by X1 smoke gate on PR
+//     #396 X2 dry-run; latent since the ORT artifact bump).
 //
-// See `glibc_compat.c` for the full background, including the two
-// implementation traps (no `alias` attribute, no `<stdlib.h>`).
-// The shim is Linux/glibc-only — macOS, Windows, and musl don't
-// ship glibc and don't reference `__isoc23_*`.
+// Static dependencies in `_core.so` (notably the prebuilt ONNX
+// Runtime artifacts compiled with gcc 14.x) reference all of these,
+// so without this shim the wheel fails to import on user machines
+// whose system glibc is below the build host's. The shim is
+// Linux/glibc-only — macOS, Windows, and musl don't ship glibc and
+// don't reference any of these symbols.
 //
-// Issue: #355 (https://github.com/chopratejas/headroom/issues/355)
+// Issues:
+//   - #355 (https://github.com/chopratejas/headroom/issues/355)
+//     for the `__isoc23_*` family
+//   - PR #396 dry-run for the `__libc_single_threaded` symbol
 
 fn main() {
     println!("cargo:rerun-if-changed=glibc_compat.c");
@@ -19,7 +26,7 @@ fn main() {
 
     // The shim is glibc-specific. Skip on every other target: macOS
     // uses Darwin libc, Windows has MSVCRT, musl handles strtoll
-    // identically and never emits __isoc23_*.
+    // identically and never emits __isoc23_* / __libc_single_threaded.
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
     if target_os != "linux" || target_env != "gnu" {
@@ -57,6 +64,13 @@ fn main() {
         "__isoc23_strtoll",
         "__isoc23_strtoul",
         "__isoc23_strtoull",
+        // glibc 2.32+ — see glibc_compat.c Section B. Force-undefined
+        // here for the same reason as the __isoc23_* family: archives
+        // that DEFINE the symbol must be scanned before archives that
+        // REFERENCE it, otherwise our shim's archive is dropped and
+        // the .so ships with a UND `__libc_single_threaded` that
+        // breaks import on glibc < 2.32.
+        "__libc_single_threaded",
     ] {
         println!("cargo:rustc-link-arg=-Wl,-u,{sym}");
     }

--- a/crates/headroom-py/glibc_compat.c
+++ b/crates/headroom-py/glibc_compat.c
@@ -1,8 +1,15 @@
 /*
- * glibc < 2.38 compatibility shim for the C23 strtol* family.
+ * glibc post-2.28 compatibility shim — provides local definitions of
+ * symbols introduced after the manylinux_2_28 floor that some of our
+ * statically-linked dependencies reference.
  *
- * Why this file exists
- * --------------------
+ * Currently shimmed:
+ *   - C23 strtol* family (`__isoc23_*`, glibc 2.38+) — see Section A
+ *   - `__libc_single_threaded` (glibc 2.32+) — see Section B
+ *
+ * ============================================================
+ * Section A: C23 strtol* family — glibc 2.38+
+ * ============================================================
  *
  * glibc 2.38 (Aug 2023) added `__isoc23_strtol`, `__isoc23_strtoll`,
  * `__isoc23_strtoul`, and `__isoc23_strtoull` as canonical C23
@@ -112,3 +119,52 @@ unsigned long __isoc23_strtoul(const char *nptr, char **endptr, int base) {
 unsigned long long __isoc23_strtoull(const char *nptr, char **endptr, int base) {
     return strtoull(nptr, endptr, base);
 }
+
+/*
+ * ============================================================
+ * Section B: __libc_single_threaded — glibc 2.32+
+ * ============================================================
+ *
+ * glibc 2.32 (Aug 2020) added the `__libc_single_threaded` global
+ * variable: a single-byte char that's set to 1 when the process has
+ * exactly one thread, 0 otherwise. Newer libstdc++ (gcc 11+) reads
+ * it inside `__cxa_thread_atexit_impl` and similar functions to
+ * elide locking on the fast path.
+ *
+ * The same ORT prebuilt static archives that triggered the
+ * `__isoc23_*` problem above are compiled with gcc-14.2.1 against
+ * glibc-2.38+ headers, so they bake in references to
+ * `__libc_single_threaded`. Manylinux_2_28 hosts have it; user
+ * machines with glibc < 2.32 (e.g. Ubuntu 20.04 + system glibc
+ * 2.31) do not, and `import headroom._core` fails with:
+ *
+ *     ImportError: undefined symbol: __libc_single_threaded
+ *
+ * Caught by the X1 smoke-import gate on the manylinux_2_28
+ * floor entry of PR #396 (X2's first dry-run run). Latent since
+ * the ORT artifact bump that started using gcc 14; we never
+ * tested wheel imports on the floor before X1.
+ *
+ * The fix
+ * -------
+ *
+ * Provide a local definition of the symbol with value 0
+ * (multi-threaded). Same dynamic-linker semantics as Section A:
+ * on glibc 2.32+, libc.so.6 has the strong symbol and ours is
+ * shadowed (harmless); on glibc < 2.32, ours is the only
+ * definition and resolves to 0, which is the safe value
+ * (libstdc++ then takes the locked, multi-threaded slow path —
+ * a tiny perf cost in exchange for an importable wheel).
+ *
+ * Setting it to 0 (rather than 1) is deliberate. If we lied and
+ * said 1, libstdc++ would skip the lock acquisition on the
+ * thread-atexit fast path. If the user actually has multiple
+ * threads (which a Rust wheel making blocking calls almost
+ * certainly does), that would race. 0 is always-correct.
+ *
+ * Reference:
+ * - https://sourceware.org/glibc/wiki/Release/2.32
+ * - glibc commit fc859c30
+ *   (`Single-threaded stdio optimization`)
+ */
+char __libc_single_threaded = 0;

--- a/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.20.16",
+  "version": "0.20.28",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/plugins/headroom-agent-hooks/.github/plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.20.16",
+  "version": "0.20.28",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/scripts/audit_wheel_glibc_symbols.py
+++ b/scripts/audit_wheel_glibc_symbols.py
@@ -47,15 +47,30 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-# Symbol families introduced after specific glibc versions, beyond what
-# `auditwheel` already checks. Add here as new bug classes surface.
+# Symbols introduced after specific glibc versions, beyond what
+# `auditwheel` already checks (auditwheel relies on the GLIBC_x.y
+# version tag baked into versioned symbols; the entries below are
+# either tagless or family-tagged, neither of which auditwheel
+# catches). Add here as new bug classes surface.
 #
 # Each entry is `(symbol_name_prefix, min_glibc_version_introduced, justification_url)`.
+# `startswith(prefix)` is used to match — for a single symbol use the
+# full name as the prefix (no other symbol starts with it).
 POST_FLOOR_SYMBOLS = [
+    # C23 strtol family. Issue #355.
     (
         "__isoc23_",
         (2, 38),
         "https://sourceware.org/glibc/wiki/Release/2.38",
+    ),
+    # Single-threaded fast-path flag read by libstdc++ (gcc 11+).
+    # Caught by the X1 smoke gate on PR #396 (X2 dry-run) on the
+    # manylinux_2_28 floor entry — the audit had let the wheel
+    # through because it didn't know about this symbol.
+    (
+        "__libc_single_threaded",
+        (2, 32),
+        "https://sourceware.org/glibc/wiki/Release/2.32",
     ),
 ]
 


### PR DESCRIPTION
## Summary

PR #396 (X2)'s dry-run caught a wheel-import failure on the manylinux_2_28 floor matrix entry (both x86_64 and aarch64). Same class as #355:

\`\`\`
ImportError: ... undefined symbol: __libc_single_threaded
\`\`\`

\`__libc_single_threaded\` is a single-byte char added in **glibc 2.32**. Newer libstdc++ (gcc 11+) reads it inside \`__cxa_thread_atexit_impl\` to elide locking on the single-threaded fast path. ORT prebuilt static archives (compiled with gcc-14.2.1 against glibc-2.38+ headers) bake in the reference. Users with glibc < 2.32 (Ubuntu 20.04, RHEL 8.4-, etc.) hit ImportError on \`import headroom._core\`.

**Latent since the ORT artifact bump that started using gcc 14.** We never tested wheel imports on the manylinux floor before X1 (PR #387) added the smoke matrix; X2 (PR #396) was the first run that actually exercised the floor. So **X1 is the gate that catches it at release time and X2 is the gate that catches it at PR time — exactly as designed.**

## What changed

1. **\`crates/headroom-py/glibc_compat.c\`** — adds Section B alongside the existing C23 strtol family shim:
   \`\`\`c
   char __libc_single_threaded = 0;
   \`\`\`
   Same dynamic-linker semantics as Section A: on glibc 2.32+ libc.so.6's strong symbol wins, ours is shadowed harmlessly; on glibc < 2.32 ours is the only definition and resolves to 0. **Setting to 0 (multi-threaded) is the safe value** — libstdc++ takes the locked slow path, slower but correct. Setting to 1 would race in any multithreaded Rust wheel.

2. **\`crates/headroom-py/build.rs\`** — extends \`cargo:rustc-link-arg=-Wl,-u,...\` list to include the new symbol. Same reason as the \`__isoc23_*\` entries: forces the linker to pull our shim's archive members regardless of relative archive scan order (the bug that bit PR #386 on aarch64).

3. **\`scripts/audit_wheel_glibc_symbols.py\`** — extends \`POST_FLOOR_SYMBOLS\` so the static gate catches this symbol on future wheels. **Verified locally**: the audit now correctly rejects the failing PR #396 wheel:
   \`\`\`
   FAIL: headroom_ai-0.20.28-cp311-cp311-manylinux_2_28_x86_64.whl references symbols above its glibc floor:
     headroom/_core.cpython-311-x86_64-linux-gnu.so:
       __libc_single_threaded (no version tag, introduced in glibc 2.32 > floor 2.28 — see https://sourceware.org/glibc/wiki/Release/2.32)
   \`\`\`

## Test plan

- [x] Local audit script catches the failing PR #396 wheel
- [x] \`make ci-precheck\` (pre-push hook) green: Rust rebuild, lints, commitlint
- [ ] CI smoke-import matrix passes on this PR (especially manylinux_2_28 x86_64 + aarch64 entries)

## Followup

- After merge, **rebase PR #396 (X2)** so it picks up this fix, then the X2 dry-run on its own PR should be all-green
- Consider pulling the audit script forward to run as a **PR-time gate** before the smoke matrix fires (faster fail, cheaper signal). Currently it runs post-build per matrix entry; could be a build-time \`needs:\` ordering tweak in a follow-up.

## Issue reference

- Same class as #355 (\`__isoc23_*\` family); this is the symbol the original audit's prefix-only rule missed.