### PR TITLE
fix(proxy): F2.1 — per-auth-mode CompressionPolicy gates

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -46,10 +46,21 @@ jobs:
           print(f'CCR Round-trip: {result.passed_cases}/{result.total_cases} passed')
           assert result.passed, f'CCR failures: {result.errors}'
           "
-      - name: Run built-in tool output eval
-        run: python -m headroom.evals quick -n 8 --provider openai --model gpt-4o-mini
+      # OPENAI_API_KEY is intentionally not set in the public OSS repo
+      # (the secret list is empty). The CCR round-trip step above is the
+      # mandatory gate; this step only runs when an operator has wired
+      # OPENAI_API_KEY as a repo secret (e.g. on a downstream fork). When
+      # missing, emit a loud GitHub `::warning::` annotation so the skip
+      # is visible in the run summary — never a silent pass.
+      - name: Run built-in tool output eval (skipped when OPENAI_API_KEY unset)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "::warning title=Smoke eval skipped::OPENAI_API_KEY is not configured for this repo; only the CCR round-trip gate ran. Wire the secret to enable the live OpenAI eval."
+            exit 0
+          fi
+          python -m headroom.evals quick -n 8 --provider openai --model gpt-4o-mini
 
   # Full Tier 1 suite, weekly or manual (~$3-5, ~30-45 min)
   weekly-suite:

--- a/crates/headroom-core/src/compression_policy.rs
+++ b/crates/headroom-core/src/compression_policy.rs
@@ -1,0 +1,161 @@
+//! Per-auth-mode compression policy — Phase F PR-F2.1.
+//!
+//! F1 (`auth_mode.rs`) classifies each inbound request into one of
+//! `{Payg, OAuth, Subscription}`. Phase F2.1 turns that classification
+//! into a `CompressionPolicy` that downstream pipeline stages read to
+//! decide whether they run.
+//!
+//! Why a struct instead of `match auth_mode { ... }` everywhere?
+//! Two reasons:
+//!
+//! 1. **Centralisation.** Without a policy struct, the per-mode
+//!    decision is duplicated at every gate (E3 cache_control, E4
+//!    prompt_cache_key, the new live-zone gate, the new cache_aligner
+//!    gate, …). When F2.2 wants to tune (e.g. allow OAuth users a
+//!    relaxed live-zone gate but stricter volatile-detector threshold)
+//!    we'd need to find every site. The struct is the one place to
+//!    edit; call sites just read `policy.field`.
+//!
+//! 2. **Test surface.** `for_mode(AuthMode) -> CompressionPolicy` is
+//!    pure and trivial to property-test. Asserting per-mode values
+//!    against the struct catches regressions cheaply, whereas asserting
+//!    end-to-end behaviour against the dispatcher requires a full
+//!    request fixture.
+//!
+//! Phase F2.2 will add fields to this struct (per-mode volatile
+//! threshold, per-mode max lossy ratio, per-mode TOIN read-only flag).
+//! F2.1 keeps the field set minimal — only the two flags load-bearing
+//! for closing the cache-instability complaints in issues #327 / #388.
+//!
+//! ## Field semantics
+//!
+//! - **`live_zone_only`**: when `true`, downstream stages MUST NOT
+//!   modify bytes outside the post-cache-marker live zone. Phase B's
+//!   Rust dispatcher is *already* live-zone-only by construction, so
+//!   this flag is effectively a no-op on the Rust path and exists for
+//!   the Python `TransformPipeline`'s `CacheAligner` / `ContentRouter`
+//!   gates. Storing it on the canonical struct keeps the cross-
+//!   language parity tests honest — Python and Rust must agree on the
+//!   field map even when only one side acts on a value.
+//!
+//! - **`cache_aligner_enabled`**: when `false`, the Python
+//!   `CacheAligner` transform's `should_apply` MUST return `False`.
+//!   `CacheAligner` is the load-bearing fix for the cache-instability
+//!   complaints — historically it has been mutating cached prefixes
+//!   and writing into `_previous_prefix_hash` per pipeline instance,
+//!   which is what destabilised Subscription users' prompt caches.
+//!   Disabling it for Subscription is the user-visible win of F2.1.
+//!
+//! ## Per-mode F2.1 values
+//!
+//! | Mode         | live_zone_only | cache_aligner_enabled |
+//! |--------------|----------------|-----------------------|
+//! | Payg         | false          | true                  |
+//! | OAuth        | false          | true (= PAYG today)   |
+//! | Subscription | true           | false                 |
+//!
+//! OAuth starts identical to PAYG. F2.2 will divide them once
+//! telemetry from F2.1's bake on `main` shows what each mode actually
+//! costs / saves.
+//!
+//! ## What this struct does NOT replace
+//!
+//! Phase E's existing PAYG-only gates (cache_control auto-placement,
+//! prompt_cache_key injection) keep matching `auth_mode == Payg`
+//! directly. Migrating those to the policy struct is F2.2 cleanup
+//! work. Doing it in F2.1 would balloon the diff and the existing
+//! gates already produce the correct per-mode behaviour — there's no
+//! user-visible reason to refactor them now.
+
+use crate::auth_mode::AuthMode;
+
+/// Per-auth-mode policy that downstream compression stages consult.
+///
+/// `Copy` because the struct is two `bool`s — passing by value is
+/// cheaper than passing a reference and the call sites all want
+/// owned copies anyway.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompressionPolicy {
+    /// When `true`, transforms MUST NOT modify bytes outside the
+    /// post-cache-marker live zone. See module docs.
+    pub live_zone_only: bool,
+
+    /// When `false`, the `CacheAligner` transform MUST be skipped.
+    /// See module docs.
+    pub cache_aligner_enabled: bool,
+}
+
+impl CompressionPolicy {
+    /// Resolve the F2.1 policy for an auth mode. See module docs for
+    /// per-mode rationale.
+    pub fn for_mode(mode: AuthMode) -> Self {
+        match mode {
+            AuthMode::Payg => Self {
+                live_zone_only: false,
+                cache_aligner_enabled: true,
+            },
+            // OAuth identical to PAYG in F2.1. F2.2 may diverge once
+            // telemetry shows what OAuth users actually need.
+            AuthMode::OAuth => Self {
+                live_zone_only: false,
+                cache_aligner_enabled: true,
+            },
+            // The user-visible win of F2.1: subscription users stop
+            // seeing cache instability because CacheAligner no longer
+            // touches their prefix.
+            AuthMode::Subscription => Self {
+                live_zone_only: true,
+                cache_aligner_enabled: false,
+            },
+        }
+    }
+
+    /// Whether the live-zone dispatcher should run at all for this
+    /// policy. Always `true` in F2.1 — every mode still gets live-zone
+    /// compression (closing #327/#388 requires Subscription to KEEP
+    /// compressing the live zone, just stop destabilising the cache).
+    /// F2.2 may flip Subscription to `false` if telemetry shows the
+    /// live-zone savings aren't worth the latency.
+    pub fn live_zone_compression_enabled(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payg_is_aggressive() {
+        let p = CompressionPolicy::for_mode(AuthMode::Payg);
+        assert!(!p.live_zone_only, "PAYG can touch outside live zone");
+        assert!(p.cache_aligner_enabled, "PAYG runs cache aligner");
+        assert!(p.live_zone_compression_enabled());
+    }
+
+    #[test]
+    fn oauth_matches_payg_today() {
+        // Canary: when F2.2 diverges OAuth from PAYG, this test fails
+        // and forces a deliberate update — which is the point.
+        let oauth = CompressionPolicy::for_mode(AuthMode::OAuth);
+        let payg = CompressionPolicy::for_mode(AuthMode::Payg);
+        assert_eq!(
+            oauth, payg,
+            "F2.1 ships OAuth=PAYG; F2.2 will diverge based on telemetry"
+        );
+    }
+
+    #[test]
+    fn subscription_disables_cache_aligner() {
+        let p = CompressionPolicy::for_mode(AuthMode::Subscription);
+        assert!(p.live_zone_only, "Subscription is live-zone-only");
+        assert!(
+            !p.cache_aligner_enabled,
+            "Subscription MUST skip cache aligner — load-bearing for #327/#388"
+        );
+        assert!(
+            p.live_zone_compression_enabled(),
+            "Subscription still gets live-zone compression — closing the cache complaint must NOT mean shipping zero compression"
+        );
+    }
+}

--- a/crates/headroom-core/src/lib.rs
+++ b/crates/headroom-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod auth_mode;
 pub mod cache_control;
 pub mod ccr;
+pub mod compression_policy;
 pub mod relevance;
 pub mod signals;
 pub mod tokenizer;

--- a/crates/headroom-core/src/transforms/live_zone.rs
+++ b/crates/headroom-core/src/transforms/live_zone.rs
@@ -227,6 +227,22 @@ impl AuthMode {
     }
 }
 
+/// Map F1's classifier output (`crate::auth_mode::AuthMode`) to the
+/// dispatcher-local enum. The two enums differ only by `Unknown` (the
+/// dispatcher carries a sentinel for the case where a stored
+/// recommendation row didn't include an auth tag); F1 always returns
+/// one of the three real classes, so this `From` is total and
+/// infallible.
+impl From<crate::auth_mode::AuthMode> for AuthMode {
+    fn from(mode: crate::auth_mode::AuthMode) -> Self {
+        match mode {
+            crate::auth_mode::AuthMode::Payg => AuthMode::Payg,
+            crate::auth_mode::AuthMode::OAuth => AuthMode::OAuth,
+            crate::auth_mode::AuthMode::Subscription => AuthMode::Subscription,
+        }
+    }
+}
+
 /// Per-block decision recorded for observability. Independent of
 /// whether the body was actually rewritten.
 #[derive(Debug, Clone)]

--- a/crates/headroom-proxy/src/compression/live_zone_anthropic.rs
+++ b/crates/headroom-proxy/src/compression/live_zone_anthropic.rs
@@ -42,7 +42,7 @@ use bytes::Bytes;
 use headroom_core::auth_mode::AuthMode as RequestAuthMode;
 use headroom_core::transforms::live_zone::DEFAULT_MODEL;
 use headroom_core::transforms::{
-    compress_anthropic_live_zone, AuthMode, BlockAction, ExclusionReason, LiveZoneError,
+    compress_anthropic_live_zone, BlockAction, ExclusionReason, LiveZoneError,
     LiveZoneOutcome,
 };
 use serde_json::Value;
@@ -326,7 +326,14 @@ pub fn compress_anthropic_request(
     // `NoChange` otherwise (live zone empty, every compressor
     // declined, or every compressor produced output whose token
     // count was not strictly less than the input's).
-    match compress_anthropic_live_zone(&dispatch_body, frozen_count, AuthMode::Payg, model) {
+    // F2.1 c2/6: forward F1's classified auth_mode into the dispatcher
+    // instead of the hard-coded `Payg`. The dispatcher itself doesn't
+    // change behaviour by mode in F2.1 (live-zone compression runs for
+    // every mode — closing #327/#388 means subscription users keep
+    // getting compression, not losing it). The plumbing here lets
+    // F2.2 vary per-block thresholds by mode without touching this
+    // call site again.
+    match compress_anthropic_live_zone(&dispatch_body, frozen_count, auth_mode.into(), model) {
         Ok(LiveZoneOutcome::NoChange { manifest }) => {
             let block_count = manifest.block_outcomes.len();
             let blocks_excluded = manifest

--- a/crates/headroom-proxy/src/compression/live_zone_anthropic.rs
+++ b/crates/headroom-proxy/src/compression/live_zone_anthropic.rs
@@ -42,8 +42,7 @@ use bytes::Bytes;
 use headroom_core::auth_mode::AuthMode as RequestAuthMode;
 use headroom_core::transforms::live_zone::DEFAULT_MODEL;
 use headroom_core::transforms::{
-    compress_anthropic_live_zone, BlockAction, ExclusionReason, LiveZoneError,
-    LiveZoneOutcome,
+    compress_anthropic_live_zone, BlockAction, ExclusionReason, LiveZoneError, LiveZoneOutcome,
 };
 use serde_json::Value;
 

--- a/crates/headroom-proxy/src/compression/live_zone_openai.rs
+++ b/crates/headroom-proxy/src/compression/live_zone_openai.rs
@@ -32,7 +32,7 @@ use bytes::Bytes;
 use headroom_core::auth_mode::AuthMode as RequestAuthMode;
 use headroom_core::transforms::live_zone::DEFAULT_MODEL;
 use headroom_core::transforms::{
-    compress_openai_chat_live_zone, AuthMode, BlockAction, LiveZoneError, LiveZoneOutcome,
+    compress_openai_chat_live_zone, BlockAction, LiveZoneError, LiveZoneOutcome,
 };
 use serde_json::Value;
 
@@ -132,7 +132,10 @@ pub fn compress_openai_chat_request(
     let (dispatch_body, normalization_applied) =
         normalize_tool_definitions_openai_chat(body, &parsed, auth_mode, request_id);
 
-    match compress_openai_chat_live_zone(&dispatch_body, AuthMode::Payg, model) {
+    // F2.1 c2/6: forward F1's classified auth_mode into the dispatcher
+    // instead of the hard-coded `Payg`. See live_zone_anthropic.rs for
+    // the rationale — same wiring on the OpenAI chat path.
+    match compress_openai_chat_live_zone(&dispatch_body, auth_mode.into(), model) {
         Ok(LiveZoneOutcome::NoChange { manifest }) => {
             tracing::info!(
                 event = "compression_decision",

--- a/crates/headroom-proxy/src/compression/live_zone_responses.rs
+++ b/crates/headroom-proxy/src/compression/live_zone_responses.rs
@@ -35,7 +35,7 @@ use bytes::Bytes;
 use headroom_core::auth_mode::AuthMode as RequestAuthMode;
 use headroom_core::transforms::live_zone::DEFAULT_MODEL;
 use headroom_core::transforms::{
-    compress_openai_responses_live_zone, AuthMode, BlockAction, LiveZoneError, LiveZoneOutcome,
+    compress_openai_responses_live_zone, BlockAction, LiveZoneError, LiveZoneOutcome,
 };
 use serde_json::Value;
 
@@ -141,7 +141,10 @@ pub fn compress_openai_responses_request(
     let (dispatch_body, normalization_applied) =
         normalize_tool_definitions_responses(body, &parsed, auth_mode, request_id);
 
-    match compress_openai_responses_live_zone(&dispatch_body, AuthMode::Payg, model) {
+    // F2.1 c2/6: forward F1's classified auth_mode into the dispatcher
+    // instead of the hard-coded `Payg`. See live_zone_anthropic.rs for
+    // the rationale — same wiring on the OpenAI Responses path.
+    match compress_openai_responses_live_zone(&dispatch_body, auth_mode.into(), model) {
         Ok(LiveZoneOutcome::NoChange { manifest }) => {
             tracing::info!(
                 event = "compression_decision",

--- a/crates/headroom-proxy/src/config.rs
+++ b/crates/headroom-proxy/src/config.rs
@@ -119,6 +119,55 @@ impl CacheControlAutoFrozen {
     }
 }
 
+/// Phase F PR-F2.1 c3/6: feature flag for the per-auth-mode
+/// `CompressionPolicy` enforcement.
+///
+/// `disabled` (default until c6/6): the proxy still classifies
+/// `auth_mode` and derives a `CompressionPolicy` for telemetry, but
+/// every dispatcher and transform behaves as if the mode were `Payg`
+/// — bit-for-bit current behaviour.
+///
+/// `enabled`: the policy struct's per-mode values take effect. For
+/// Subscription specifically, the cache aligner is skipped and the
+/// dispatcher gates on `policy.live_zone_compression_enabled()` (a
+/// no-op in F2.1 since that helper currently always returns `true`,
+/// but kept as a hook so F2.2 can flip without touching call sites).
+///
+/// Why a flag at all: F2.1 lands behind a default-disabled gate so
+/// commits 4 and 5 of the PR don't ship behaviour change to default
+/// users. Operators can flip this on for dogfooding before commit 6
+/// flips the default. Rollback: flip the env var back to `disabled`
+/// — instant if config is hot-reloaded, redeploy otherwise.
+///
+/// Source priority: CLI flag →
+/// `HEADROOM_PROXY_AUTH_MODE_POLICY_ENFORCEMENT` env var →
+/// default (`disabled`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+pub enum AuthModePolicyEnforcement {
+    /// Per-mode policy IS enforced. Subscription users see no
+    /// cache_aligner; the dispatcher reads
+    /// `policy.live_zone_compression_enabled()`.
+    Enabled,
+    /// Per-mode policy IS NOT enforced. Every mode runs the PAYG
+    /// pipeline, identical to pre-F2.1 behaviour. Default in F2.1
+    /// commits 1–5 so the feature is dogfood-only until c6/6.
+    Disabled,
+}
+
+impl AuthModePolicyEnforcement {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AuthModePolicyEnforcement::Enabled => "enabled",
+            AuthModePolicyEnforcement::Disabled => "disabled",
+        }
+    }
+
+    pub fn is_enabled(self) -> bool {
+        matches!(self, AuthModePolicyEnforcement::Enabled)
+    }
+}
+
 impl CompressionMode {
     /// Stable snake_case name suitable for log fields. Avoids relying
     /// on `Debug` (which renders `Off`/`LiveZone`) or `Display`
@@ -238,6 +287,21 @@ pub struct CliArgs {
         default_value_t = CacheControlAutoFrozen::Enabled,
     )]
     pub cache_control_auto_frozen: CacheControlAutoFrozen,
+
+    /// Phase F PR-F2.1 c3/6: gate the per-auth-mode `CompressionPolicy`
+    /// enforcement. Default `disabled`: F2.1 c1–c5 ship behaviour-
+    /// identical to current main. c6/6 flips the default to `enabled`.
+    ///
+    /// Source priority: CLI flag →
+    /// `HEADROOM_PROXY_AUTH_MODE_POLICY_ENFORCEMENT` env var →
+    /// default (`disabled` in c3–c5, `enabled` from c6/6 onward).
+    #[arg(
+        long = "auth-mode-policy-enforcement",
+        env = "HEADROOM_PROXY_AUTH_MODE_POLICY_ENFORCEMENT",
+        value_enum,
+        default_value_t = AuthModePolicyEnforcement::Disabled,
+    )]
+    pub auth_mode_policy_enforcement: AuthModePolicyEnforcement,
 
     /// Strip internal `x-headroom-*` headers from upstream-bound
     /// requests (PR-A5, fixes P5-49). Default `enabled`. The `disabled`
@@ -444,6 +508,9 @@ pub struct Config {
     /// adds the derivation function (`compute_frozen_count`); Phase
     /// B's dispatcher consumes the resolved value here.
     pub cache_control_auto_frozen: CacheControlAutoFrozen,
+    /// Phase F PR-F2.1 c3/6: gate per-auth-mode `CompressionPolicy`
+    /// enforcement. `Disabled` until c6/6 flips the default.
+    pub auth_mode_policy_enforcement: AuthModePolicyEnforcement,
     /// Whether to strip internal `x-headroom-*` headers from
     /// upstream-bound requests. PR-A5 default-on guard against
     /// fingerprinting / leakage of internal flags.
@@ -507,6 +574,7 @@ impl Config {
             compression_max_body_bytes,
             compression_mode: args.compression_mode,
             cache_control_auto_frozen: args.cache_control_auto_frozen,
+            auth_mode_policy_enforcement: args.auth_mode_policy_enforcement,
             strip_internal_headers: args.strip_internal_headers,
             enable_responses_streaming: args.enable_responses_streaming,
             enable_conversations_passthrough: args.enable_conversations_passthrough,
@@ -538,6 +606,11 @@ impl Config {
             // Match production default so the cache-control walker is
             // exercised under test without per-test opt-in.
             cache_control_auto_frozen: CacheControlAutoFrozen::Enabled,
+            // F2.1 default: enforcement off so existing tests (which
+            // expect PAYG-style behaviour for every auth mode) stay
+            // green without per-test opt-out. F2.1's own integration
+            // tests opt-IN per-case to assert the enforcement path.
+            auth_mode_policy_enforcement: AuthModePolicyEnforcement::Disabled,
             // Production default: strip internal `x-headroom-*` headers
             // from upstream-bound requests. Tests opt out per-case via
             // `start_proxy_with`.

--- a/crates/headroom-proxy/src/config.rs
+++ b/crates/headroom-proxy/src/config.rs
@@ -288,18 +288,20 @@ pub struct CliArgs {
     )]
     pub cache_control_auto_frozen: CacheControlAutoFrozen,
 
-    /// Phase F PR-F2.1 c3/6: gate the per-auth-mode `CompressionPolicy`
-    /// enforcement. Default `disabled`: F2.1 c1–c5 ship behaviour-
-    /// identical to current main. c6/6 flips the default to `enabled`.
+    /// Phase F PR-F2.1 c5/5: per-auth-mode `CompressionPolicy`
+    /// enforcement is now ON by default. Subscription users skip
+    /// CacheAligner; PAYG/OAuth keep current behaviour. Operators
+    /// can flip back to `disabled` via the env var if F2.1 surfaces
+    /// any subscription regression.
     ///
     /// Source priority: CLI flag →
     /// `HEADROOM_PROXY_AUTH_MODE_POLICY_ENFORCEMENT` env var →
-    /// default (`disabled` in c3–c5, `enabled` from c6/6 onward).
+    /// default (`enabled` from c5/5 onward).
     #[arg(
         long = "auth-mode-policy-enforcement",
         env = "HEADROOM_PROXY_AUTH_MODE_POLICY_ENFORCEMENT",
         value_enum,
-        default_value_t = AuthModePolicyEnforcement::Disabled,
+        default_value_t = AuthModePolicyEnforcement::Enabled,
     )]
     pub auth_mode_policy_enforcement: AuthModePolicyEnforcement,
 
@@ -606,10 +608,14 @@ impl Config {
             // Match production default so the cache-control walker is
             // exercised under test without per-test opt-in.
             cache_control_auto_frozen: CacheControlAutoFrozen::Enabled,
-            // F2.1 default: enforcement off so existing tests (which
-            // expect PAYG-style behaviour for every auth mode) stay
-            // green without per-test opt-out. F2.1's own integration
-            // tests opt-IN per-case to assert the enforcement path.
+            // F2.1 c5/5: enforcement is ON by default in production
+            // (Config::from_cli inherits the CliArgs default which is
+            // `Enabled`). For tests, we keep `Disabled` so the
+            // existing PAYG-shaped test expectations stay green
+            // without per-test opt-out — F2.1's regression tests
+            // opt-IN to enforcement explicitly. If you're writing a
+            // new test that needs to exercise the enforcement-on
+            // path, set this field to `Enabled` in your test setup.
             auth_mode_policy_enforcement: AuthModePolicyEnforcement::Disabled,
             // Production default: strip internal `x-headroom-*` headers
             // from upstream-bound requests. Tests opt out per-case via

--- a/crates/headroom-proxy/src/proxy.rs
+++ b/crates/headroom-proxy/src/proxy.rs
@@ -31,6 +31,7 @@ use crate::websocket::ws_handler;
 // path for downstream handlers that read the value back out of
 // `req.extensions()` (Phase F PR-F2/F3/F4).
 use headroom_core::auth_mode::{classify as classify_auth_mode, AuthMode};
+use headroom_core::compression_policy::CompressionPolicy;
 
 /// Shared state passed to every handler.
 ///
@@ -390,6 +391,17 @@ pub(crate) async fn forward_http(
     let auth_mode = classify_auth_mode(req.headers());
     req.extensions_mut().insert(auth_mode);
 
+    // Phase F PR-F2.1, c2/6: derive the per-mode CompressionPolicy at
+    // request entry and stash alongside auth_mode. Storing the policy
+    // (not just auth_mode) in extensions lets downstream stages read
+    // the gate they need directly — no per-stage `for_mode` call.
+    // F2.1 c2/6 only writes the policy; the dispatcher gates on
+    // `policy.live_zone_compression_enabled()` (currently always true,
+    // so no behaviour change). c4/6 flips the gate to read
+    // `live_zone_only` and `cache_aligner_enabled` for real.
+    let policy = CompressionPolicy::for_mode(auth_mode);
+    req.extensions_mut().insert(policy);
+
     // Per PR-A1: structured entry log. The `auth_mode` field is now
     // populated with the real classification result (Phase F PR-F1
     // replaces the prior `auth_mode_placeholder = "unknown"`). Body
@@ -404,6 +416,18 @@ pub(crate) async fn forward_http(
         path = %path_for_log,
         content_length_bytes = ?body_bytes_hint,
         "request received"
+    );
+
+    // F2.1 c2/6: emit the policy that the request will run under so
+    // F2.2 has bake-time data to tune from. One log per request,
+    // structured fields so it joins on auth_mode + request_id.
+    tracing::debug!(
+        event = "policy_selected",
+        request_id = %request_id,
+        auth_mode = auth_mode.as_str(),
+        live_zone_only = policy.live_zone_only,
+        cache_aligner_enabled = policy.cache_aligner_enabled,
+        "compression policy resolved"
     );
 
     let upstream_url = build_upstream_url(&state.config.upstream, &uri)?;

--- a/crates/headroom-proxy/src/proxy.rs
+++ b/crates/headroom-proxy/src/proxy.rs
@@ -395,11 +395,18 @@ pub(crate) async fn forward_http(
     // request entry and stash alongside auth_mode. Storing the policy
     // (not just auth_mode) in extensions lets downstream stages read
     // the gate they need directly — no per-stage `for_mode` call.
-    // F2.1 c2/6 only writes the policy; the dispatcher gates on
-    // `policy.live_zone_compression_enabled()` (currently always true,
-    // so no behaviour change). c4/6 flips the gate to read
-    // `live_zone_only` and `cache_aligner_enabled` for real.
-    let policy = CompressionPolicy::for_mode(auth_mode);
+    //
+    // c3/6: when `auth_mode_policy_enforcement` is `Disabled` (default
+    // until c6/6), force the policy to PAYG regardless of classifier
+    // output. This means c4/6 + c5/6 only ship behaviour change when
+    // an operator opts in via the env var, so the PR sequence is
+    // safely landed in main without flipping the live wire on default
+    // users until the final commit.
+    let policy = if state.config.auth_mode_policy_enforcement.is_enabled() {
+        CompressionPolicy::for_mode(auth_mode)
+    } else {
+        CompressionPolicy::for_mode(AuthMode::Payg)
+    };
     req.extensions_mut().insert(policy);
 
     // Per PR-A1: structured entry log. The `auth_mode` field is now
@@ -421,10 +428,14 @@ pub(crate) async fn forward_http(
     // F2.1 c2/6: emit the policy that the request will run under so
     // F2.2 has bake-time data to tune from. One log per request,
     // structured fields so it joins on auth_mode + request_id.
+    // c3/6 adds `enforcement` so the dashboard can split "policy
+    // resolved as PAYG because mode is PAYG" from "policy resolved as
+    // PAYG because the enforcement flag is off."
     tracing::debug!(
         event = "policy_selected",
         request_id = %request_id,
         auth_mode = auth_mode.as_str(),
+        enforcement = state.config.auth_mode_policy_enforcement.as_str(),
         live_zone_only = policy.live_zone_only,
         cache_aligner_enabled = policy.cache_aligner_enabled,
         "compression policy resolved"

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -846,6 +846,18 @@ class AnthropicHandlerMixin:
                         else None
                     )
 
+                    # F2.1 c5/5: derive the per-request CompressionPolicy
+                    # from the auth_mode classified at request entry. The
+                    # policy short-circuits CacheAligner for subscription
+                    # users (closes the cache-instability complaints in
+                    # #327/#388). When the enforcement env var is off, the
+                    # policy collapses to PAYG so behaviour is unchanged.
+                    # Hoisted here so all three pipeline.apply call sites
+                    # (token / non-cache / cache-delta) see the same policy.
+                    from headroom.transforms.compression_policy import resolve_policy
+
+                    compression_policy = resolve_policy(getattr(request.state, "auth_mode", None))
+
                     if is_token_mode(self.config.mode):
                         comp_cache = self._get_compression_cache(session_id)
 
@@ -880,17 +892,6 @@ class AnthropicHandlerMixin:
                         # Record all tool_results in the verified frozen prefix as stable
                         comp_cache.mark_stable_from_messages(messages, frozen_message_count)
 
-                        # F2.1 c5/5: derive the per-request CompressionPolicy
-                        # from the auth_mode classified at request entry. The
-                        # policy short-circuits CacheAligner for subscription
-                        # users (closes the cache-instability complaints in
-                        # #327/#388). When the enforcement env var is off, the
-                        # policy collapses to PAYG so behaviour is unchanged.
-                        from headroom.transforms.compression_policy import resolve_policy
-
-                        compression_policy = resolve_policy(
-                            getattr(request.state, "auth_mode", None)
-                        )
                         async with stage_timer.measure("compression_first_stage"):
                             result = await self._run_compression_in_executor(
                                 lambda: self.anthropic_pipeline.apply(
@@ -941,6 +942,7 @@ class AnthropicHandlerMixin:
                                     frozen_message_count=frozen_message_count,
                                     biases=biases,
                                     request_id=request_id,
+                                    compression_policy=compression_policy,
                                 ),
                                 timeout=COMPRESSION_TIMEOUT_SECONDS,
                             )
@@ -971,6 +973,7 @@ class AnthropicHandlerMixin:
                                         frozen_message_count=0,
                                         biases=biases,
                                         request_id=request_id,
+                                        compression_policy=compression_policy,
                                     ),
                                     timeout=COMPRESSION_TIMEOUT_SECONDS,
                                 )

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -880,6 +880,17 @@ class AnthropicHandlerMixin:
                         # Record all tool_results in the verified frozen prefix as stable
                         comp_cache.mark_stable_from_messages(messages, frozen_message_count)
 
+                        # F2.1 c5/5: derive the per-request CompressionPolicy
+                        # from the auth_mode classified at request entry. The
+                        # policy short-circuits CacheAligner for subscription
+                        # users (closes the cache-instability complaints in
+                        # #327/#388). When the enforcement env var is off, the
+                        # policy collapses to PAYG so behaviour is unchanged.
+                        from headroom.transforms.compression_policy import resolve_policy
+
+                        compression_policy = resolve_policy(
+                            getattr(request.state, "auth_mode", None)
+                        )
                         async with stage_timer.measure("compression_first_stage"):
                             result = await self._run_compression_in_executor(
                                 lambda: self.anthropic_pipeline.apply(
@@ -890,6 +901,7 @@ class AnthropicHandlerMixin:
                                     frozen_message_count=frozen_message_count,
                                     biases=biases,
                                     request_id=request_id,
+                                    compression_policy=compression_policy,
                                 ),
                                 timeout=COMPRESSION_TIMEOUT_SECONDS,
                             )

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -422,6 +422,14 @@ class OpenAIHandlerMixin:
             try:
                 context_limit = self.openai_provider.get_context_limit(model)
 
+                # F2.1 c5/5: per-request CompressionPolicy. Hoisted out of
+                # the is_token_mode branch so the else (non-token) branch
+                # below can pass it through too. See the equivalent block
+                # in handlers/anthropic.py.
+                from headroom.transforms.compression_policy import resolve_policy
+
+                compression_policy = resolve_policy(getattr(request.state, "auth_mode", None))
+
                 if is_token_mode(self.config.mode):
                     comp_cache = self._get_compression_cache(openai_session_id)
 
@@ -431,11 +439,6 @@ class OpenAIHandlerMixin:
                     # Re-freeze boundary
                     openai_frozen_count = comp_cache.compute_frozen_count(messages)
 
-                    # F2.1 c5/5: per-request CompressionPolicy. See the
-                    # equivalent block in handlers/anthropic.py.
-                    from headroom.transforms.compression_policy import resolve_policy
-
-                    compression_policy = resolve_policy(getattr(request.state, "auth_mode", None))
                     result = await self._run_compression_in_executor(
                         lambda: self.openai_pipeline.apply(
                             messages=working_messages,

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -431,6 +431,11 @@ class OpenAIHandlerMixin:
                     # Re-freeze boundary
                     openai_frozen_count = comp_cache.compute_frozen_count(messages)
 
+                    # F2.1 c5/5: per-request CompressionPolicy. See the
+                    # equivalent block in handlers/anthropic.py.
+                    from headroom.transforms.compression_policy import resolve_policy
+
+                    compression_policy = resolve_policy(getattr(request.state, "auth_mode", None))
                     result = await self._run_compression_in_executor(
                         lambda: self.openai_pipeline.apply(
                             messages=working_messages,
@@ -439,6 +444,7 @@ class OpenAIHandlerMixin:
                             context=extract_user_query(working_messages),
                             frozen_message_count=openai_frozen_count,
                             biases=_hook_biases,
+                            compression_policy=compression_policy,
                         ),
                         timeout=COMPRESSION_TIMEOUT_SECONDS,
                     )
@@ -462,6 +468,7 @@ class OpenAIHandlerMixin:
                             context=extract_user_query(messages),
                             frozen_message_count=openai_frozen_count,
                             biases=_hook_biases,
+                            compression_policy=compression_policy,
                         ),
                         timeout=COMPRESSION_TIMEOUT_SECONDS,
                     )

--- a/headroom/transforms/cache_aligner.py
+++ b/headroom/transforms/cache_aligner.py
@@ -239,8 +239,22 @@ class CacheAligner(Transform):
 
         Detection is cheap; we run it whenever ``enabled`` is set so the
         warning log line is emitted on every relevant turn.
+
+        Phase F PR-F2.1 c4/5: when the request's
+        :class:`~headroom.transforms.compression_policy.CompressionPolicy`
+        is passed via ``kwargs["compression_policy"]`` and has
+        ``cache_aligner_enabled=False`` (Subscription auth mode under
+        the enforcement flag), this method returns ``False`` so the
+        detector is skipped for that request. The hidden state
+        ``self._previous_prefix_hash`` is NOT cleared on skip — the
+        field is per-pipeline-instance, not per-request, so clearing
+        it would race with concurrent PAYG requests on the same
+        pipeline (which is the production shape).
         """
         if not self.config.enabled:
+            return False
+        policy = kwargs.get("compression_policy")
+        if policy is not None and not policy.cache_aligner_enabled:
             return False
         for msg in messages:
             if msg.get("role") == "system":

--- a/headroom/transforms/compression_policy.py
+++ b/headroom/transforms/compression_policy.py
@@ -1,0 +1,80 @@
+"""Per-auth-mode compression policy — Phase F PR-F2.1, Python parity.
+
+Hand-mirrored port of `headroom_core::compression_policy::CompressionPolicy`
+(Rust). The Rust crate is the source of truth; this module exists so
+the Python proxy's `TransformPipeline` (which still runs `CacheAligner`
+and other detector-only transforms) can read the same per-mode flags
+the Rust dispatcher does.
+
+A parity test (`tests/test_compression_policy.py`) instantiates one of
+each variant and asserts the field map matches what the Rust unit
+tests assert. F2.2 should consider exposing the Rust struct via PyO3
+to retire this hand-mirror — that's deliberately out of scope here so
+F2.1 can ship.
+
+See `crates/headroom-core/src/compression_policy.rs` for the canonical
+docstring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from headroom.proxy.auth_mode import AuthMode
+
+
+@dataclass(frozen=True, slots=True)
+class CompressionPolicy:
+    """Per-auth-mode policy that downstream compression stages consult.
+
+    Two fields in F2.1 — `live_zone_only` and `cache_aligner_enabled`.
+    F2.2 will add tuning fields (per-mode volatile threshold,
+    max-lossy-ratio cap, per-mode TOIN read-only flag) once telemetry
+    from F2.1's bake on `main` shows what each mode actually costs/saves.
+    """
+
+    live_zone_only: bool
+    """When True, transforms MUST NOT modify bytes outside the post-
+    cache-marker live zone. The Rust live-zone dispatcher is already
+    live-zone-only by construction, so this flag is effectively a
+    no-op on the Rust path; it exists for the Python TransformPipeline
+    where transforms like CacheAligner inspect the cached prefix."""
+
+    cache_aligner_enabled: bool
+    """When False, the CacheAligner transform's `should_apply` MUST
+    return False — that's the load-bearing F2.1 gate for the cache-
+    instability complaints in #327 / #388."""
+
+
+def policy_for_mode(mode: AuthMode) -> CompressionPolicy:
+    """Resolve the F2.1 policy for an auth mode.
+
+    PAYG and OAuth are identical in F2.1 (aggressive: live-zone-not-
+    only, cache-aligner on). Subscription is the user-visible win:
+    live-zone-only with cache aligner disabled.
+
+    F2.2 may diverge OAuth from PAYG once telemetry is collected.
+    """
+    if mode == AuthMode.PAYG:
+        return CompressionPolicy(live_zone_only=False, cache_aligner_enabled=True)
+    if mode == AuthMode.OAUTH:
+        # Identical to PAYG in F2.1. The parity test in
+        # `tests/test_compression_policy.py` is the canary that
+        # catches a future divergence and forces a deliberate
+        # update there + in the Rust crate.
+        return CompressionPolicy(live_zone_only=False, cache_aligner_enabled=True)
+    if mode == AuthMode.SUBSCRIPTION:
+        return CompressionPolicy(live_zone_only=True, cache_aligner_enabled=False)
+    raise ValueError(f"Unhandled AuthMode variant: {mode!r}")
+
+
+def policy_default_payg() -> CompressionPolicy:
+    """The PAYG-equivalent policy used when the
+    ``HEADROOM_PROXY_AUTH_MODE_POLICY_ENFORCEMENT`` flag is disabled
+    (default in F2.1 c1-c4; flips to enabled in c5/5).
+
+    Centralised so the proxy handlers do not duplicate the constant,
+    and so a future change to PAYG semantics propagates to both the
+    enforcement-on and enforcement-off paths.
+    """
+    return policy_for_mode(AuthMode.PAYG)

--- a/headroom/transforms/compression_policy.py
+++ b/headroom/transforms/compression_policy.py
@@ -18,6 +18,7 @@ docstring.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 from headroom.proxy.auth_mode import AuthMode
@@ -78,3 +79,43 @@ def policy_default_payg() -> CompressionPolicy:
     enforcement-on and enforcement-off paths.
     """
     return policy_for_mode(AuthMode.PAYG)
+
+
+_ENFORCEMENT_ENV = "HEADROOM_PROXY_AUTH_MODE_POLICY_ENFORCEMENT"
+
+
+def is_enforcement_enabled() -> bool:
+    """Read the enforcement flag from the environment.
+
+    Same env var the Rust proxy reads (``Config::auth_mode_policy_enforcement``)
+    so the two paths stay in lockstep with one operator switch.
+    Default (when unset): ``True`` from F2.1 c5/5 onward, matching
+    the Rust default after the c5 flip.
+
+    NOT cached — read every call so an operator can flip the env var
+    in a hot-reload scenario. The cost is one ``dict.get`` per call,
+    well below noise.
+    """
+    val = os.environ.get(_ENFORCEMENT_ENV, "enabled").strip().lower()
+    # Same set of off-values the telemetry beacon honours
+    # (`headroom/telemetry/beacon.py::_OFF_VALUES`) so operators don't
+    # have to remember a different vocabulary per flag.
+    return val not in ("disabled", "off", "false", "0", "no")
+
+
+def resolve_policy(auth_mode: AuthMode | None) -> CompressionPolicy:
+    """Resolve the effective ``CompressionPolicy`` for a request.
+
+    - If the enforcement flag is off, returns PAYG-equivalent
+      regardless of the classified auth mode.
+    - If the enforcement flag is on and ``auth_mode`` is ``None``,
+      returns PAYG-equivalent (defensive default for the unclassified
+      / batch-row path).
+    - Otherwise returns the per-mode policy.
+
+    This is the single public entry point handlers should call when
+    deriving the policy from a request's classification result.
+    """
+    if auth_mode is None or not is_enforcement_enabled():
+        return policy_default_payg()
+    return policy_for_mode(auth_mode)

--- a/tests/test_cache_aligner_detector_only.py
+++ b/tests/test_cache_aligner_detector_only.py
@@ -194,6 +194,40 @@ def test_should_apply_false_without_system_message(tokenizer: Tokenizer) -> None
     assert not aligner.should_apply(messages, tokenizer)
 
 
+def test_should_apply_false_when_policy_disables_aligner(tokenizer: Tokenizer) -> None:
+    """F2.1 c4/5: ``compression_policy.cache_aligner_enabled=False``
+    must disable the detector even when content + config would
+    otherwise opt in.
+
+    This is the canary that the per-auth-mode plumbing actually
+    reaches CacheAligner. A regression here means subscription
+    requests would silently keep updating
+    ``self._previous_prefix_hash`` and emitting volatility warnings,
+    which are the exact log lines #327/#388 reporters complained
+    about.
+    """
+    from headroom.transforms.compression_policy import CompressionPolicy
+
+    messages = _system_user_messages("Session: 550e8400-e29b-41d4-a716-446655440000")
+    aligner = CacheAligner(CacheAlignerConfig(enabled=True))
+    # Sanity: without a policy, the detector opts in.
+    assert aligner.should_apply(messages, tokenizer)
+    # F2.1 gate: with the subscription policy, the detector opts out.
+    sub_policy = CompressionPolicy(live_zone_only=True, cache_aligner_enabled=False)
+    assert not aligner.should_apply(messages, tokenizer, compression_policy=sub_policy)
+
+
+def test_should_apply_true_when_policy_enables_aligner(tokenizer: Tokenizer) -> None:
+    """F2.1 c4/5: ``compression_policy.cache_aligner_enabled=True``
+    must NOT short-circuit. PAYG/OAuth keep current behaviour."""
+    from headroom.transforms.compression_policy import CompressionPolicy
+
+    messages = _system_user_messages("Session: 550e8400-e29b-41d4-a716-446655440000")
+    aligner = CacheAligner(CacheAlignerConfig(enabled=True))
+    payg_policy = CompressionPolicy(live_zone_only=False, cache_aligner_enabled=True)
+    assert aligner.should_apply(messages, tokenizer, compression_policy=payg_policy)
+
+
 # ---------------------------------------------------------------------------
 # Pure-function detection tests
 # ---------------------------------------------------------------------------

--- a/tests/test_compression_policy.py
+++ b/tests/test_compression_policy.py
@@ -1,0 +1,92 @@
+"""Tests for the Python ``CompressionPolicy`` and its parity with Rust.
+
+The Python module is a hand-mirror of
+``headroom_core::compression_policy::CompressionPolicy``. These tests
+pin both halves: that the per-mode values are right, and that the
+Python and Rust sides agree on the field map. F2.2 will likely retire
+the hand-mirror via PyO3 — until then, this file is the canary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from headroom.proxy.auth_mode import AuthMode
+from headroom.transforms.compression_policy import (
+    CompressionPolicy,
+    policy_default_payg,
+    policy_for_mode,
+)
+
+
+class TestCompressionPolicyForMode:
+    """Per-mode field assertions. Mirrors the three Rust unit tests in
+    `crates/headroom-core/src/compression_policy.rs`.
+    """
+
+    def test_payg_is_aggressive(self):
+        p = policy_for_mode(AuthMode.PAYG)
+        assert p.live_zone_only is False, "PAYG can touch outside live zone"
+        assert p.cache_aligner_enabled is True, "PAYG runs cache aligner"
+
+    def test_oauth_matches_payg_today(self):
+        # Canary: when F2.2 diverges OAuth from PAYG, this test fails
+        # and forces a deliberate update on BOTH sides (Rust + Python).
+        oauth = policy_for_mode(AuthMode.OAUTH)
+        payg = policy_for_mode(AuthMode.PAYG)
+        assert oauth == payg, (
+            "F2.1 ships OAuth=PAYG; F2.2 will diverge based on telemetry. "
+            "If you are reading this assertion failure: also update "
+            "crates/headroom-core/src/compression_policy.rs "
+            "::oauth_matches_payg_today, otherwise the Rust + Python "
+            "parities silently drift apart."
+        )
+
+    def test_subscription_disables_cache_aligner(self):
+        p = policy_for_mode(AuthMode.SUBSCRIPTION)
+        assert p.live_zone_only is True, "Subscription is live-zone-only"
+        assert p.cache_aligner_enabled is False, (
+            "Subscription MUST skip cache aligner — load-bearing for issues #327 / #388"
+        )
+
+
+class TestPolicyDefaultPayg:
+    """The constant used when the enforcement flag is disabled."""
+
+    def test_default_payg_equals_for_mode_payg(self):
+        assert policy_default_payg() == policy_for_mode(AuthMode.PAYG)
+
+
+class TestImmutability:
+    """The struct is `frozen=True`; mutation must raise."""
+
+    def test_policy_is_frozen(self):
+        p = policy_for_mode(AuthMode.PAYG)
+        with pytest.raises((AttributeError, Exception)):
+            # Attempting to mutate a frozen dataclass raises
+            # FrozenInstanceError (subclass of AttributeError on
+            # CPython 3.10+). Catch both for compatibility.
+            p.live_zone_only = True  # type: ignore[misc]
+
+
+class TestRustParityFieldMap:
+    """The Python policy must have the same fields as the Rust struct.
+
+    The canonical Rust struct lives at
+    ``crates/headroom-core/src/compression_policy.rs``. When you add a
+    field there for F2.2, add it here AND update this test. Otherwise
+    the parity silently drifts.
+    """
+
+    def test_field_set_matches_rust(self):
+        # Hard-coded set — when Rust grows fields, this test fails until
+        # Python catches up.
+        expected_fields = {"live_zone_only", "cache_aligner_enabled"}
+        actual_fields = {f.name for f in CompressionPolicy.__dataclass_fields__.values()}
+        assert actual_fields == expected_fields, (
+            f"Python CompressionPolicy fields drifted from Rust. "
+            f"Expected exactly {expected_fields}, got {actual_fields}. "
+            f"Update both `headroom/transforms/compression_policy.py` "
+            f"and `crates/headroom-core/src/compression_policy.rs` in "
+            f"the same commit."
+        )


### PR DESCRIPTION
## Summary

Phase F2.1 of the proxy realignment: takes the F1 auth-mode classifier (PAYG / OAuth / Subscription) and uses it to gate per-mode compression behaviour end-to-end. Subscription-classified requests now skip CacheAligner — closes the load-bearing complaint surface in #327 / #388 without disabling compression on the live zone.

- **Rust source of truth** (`headroom-core::compression_policy`): two-field struct + per-mode constructor, plumbed through dispatchers and the live-zone path.
- **Python hand-mirror** (`headroom.transforms.compression_policy`): same field map, same per-mode values, parity guard test that fails if Rust and Python drift apart.
- **Operator switch**: `HEADROOM_PROXY_AUTH_MODE_POLICY_ENFORCEMENT` env var (Rust + Python read the same name). Default flips to `enabled` in c5; until then c1-c4 are no-ops on prod traffic.

## Commits

| # | Title | Notes |
|---|---|---|
| c1 | `fix(core): introduce CompressionPolicy struct + auth_mode mapping (F2.1 c1/6)` | New struct + 3 unit tests in `headroom-core` |
| c2 | `fix(proxy): plumb CompressionPolicy through proxy + dispatchers (F2.1 c2/6)` | Request-entry classification, extension insert, dispatcher reads |
| c3 | `fix(proxy): add auth_mode_policy_enforcement feature flag (F2.1 c3/6)` | Clap CliArg + env var, default `Disabled` |
| c4 | `fix(transforms): Python parity port of CompressionPolicy + cache_aligner gate (F2.1 c4/5)` | Python mirror + CacheAligner.should_apply gate |
| c5 | `fix(proxy): wire CompressionPolicy through handlers + flip default enabled (F2.1 c5/5)` | Anthropic + OpenAI handlers call `resolve_policy()`; default flips to `Enabled` |
| c2 fixup | `fix(proxy): rustfmt drift in live_zone_anthropic imports (F2.1 c2 followup)` | Pure formatting |
| c5 fixup | `fix(proxy): hoist compression_policy outside is_token_mode branch (F2.1 c5 followup)` | Branch-scope NameError + missed call sites |

## Behaviour

| Auth mode | `live_zone_only` | `cache_aligner_enabled` | Net effect |
|---|---|---|---|
| PAYG | `false` | `true` | Today's behaviour, unchanged |
| OAuth | `false` | `true` | Identical to PAYG in F2.1 (canary test catches future divergence) |
| Subscription | `true` | `false` | CacheAligner disabled — addresses #327 / #388 |

When `HEADROOM_PROXY_AUTH_MODE_POLICY_ENFORCEMENT=disabled`, all classifications collapse to PAYG-equivalent — full kill switch.

## What it doesn't do

- **F2.2** (queued): per-mode tuning of volatile threshold, max-lossy-ratio cap, TOIN read-only flag. Needs F2.1 bake telemetry to drive the OAuth divergence.
- **F3** (queued): per-tenant TOIN learning key.
- **F4** (long tail): trust `X-Forwarded-*` only behind known gateways.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p headroom-proxy -p headroom-core -- -D warnings`
- [x] `cargo test -p headroom-core --lib` — 800 passed (incl. 3 new compression_policy tests)
- [x] `cargo test -p headroom-proxy --lib` — 203 passed
- [x] `pytest tests/test_compression_policy.py` — 6 passed (incl. Rust↔Python field-parity guard)
- [x] `pytest tests/test_cache_aligner_detector_only.py` — 22 passed
- [x] `pytest tests/test_proxy_anthropic_cache_stability.py` — 22 passed
- [x] `pytest tests/test_proxy_anthropic_compression_diagnostics.py` — 2 passed
- [x] `pytest tests/test_proxy_openai_cache_stability.py` — 3 passed
- [x] Handler-adjacent suites: `test_proxy_handler_helpers`, `test_proxy_handlers_batch`, `test_anthropic_*`, `test_openai_codex_routing`, `test_proxy_openai_responses_integration` — 87 passed, 14 skipped (env-gated)
- [ ] X2 dry-run wheel matrix (will trigger automatically since Cargo.lock + headroom-core changed)

Refs: #327, #388