### PR TITLE
fix(proxy): hot-fix Codex /v1/responses compression via PyO3 inline call

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.21.0"
+    "version": "0.21.4"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.21.0",
+      "version": "0.21.4",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.21.0"
+    "version": "0.21.4"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.21.0",
+      "version": "0.21.4",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/crates/headroom-py/src/lib.rs
+++ b/crates/headroom-py/src/lib.rs
@@ -28,9 +28,11 @@ use headroom_core::transforms::tag_protector::{
     protect_tags as rust_protect_tags, restore_tags as rust_restore_tags,
 };
 use headroom_core::transforms::{
+    compress_openai_responses_live_zone as rust_compress_openai_responses_live_zone,
     detect as rust_detect_chain, is_json_array_of_dicts as rust_is_json_array_of_dicts,
-    ContentType as RustContentType, DetectionResult as RustDetectionResult, DiffCompressionResult,
-    DiffCompressor, DiffCompressorConfig, DiffCompressorStats,
+    AuthMode as RustLiveZoneAuthMode, ContentType as RustContentType,
+    DetectionResult as RustDetectionResult, DiffCompressionResult, DiffCompressor,
+    DiffCompressorConfig, DiffCompressorStats, LiveZoneOutcome,
     LogCompressionResult as RustLogResult, LogCompressor as RustLogCompressor,
     LogCompressorConfig as RustLogConfig, LogCompressorStats as RustLogStats,
     LogFormat as RustLogFormat, LogLevel as RustLogLevel,
@@ -38,7 +40,7 @@ use headroom_core::transforms::{
     SearchCompressorConfig as RustSearchConfig, SearchCompressorStats as RustSearchStats,
 };
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyString};
+use pyo3::types::{PyBytes, PyDict, PyString};
 
 /// Identity stub used by the Python smoke test to verify linkage.
 #[pyfunction]
@@ -1459,6 +1461,72 @@ fn known_html_tag_names() -> Vec<&'static str> {
 
 // ─── Module init ───────────────────────────────────────────────────────────
 
+/// Apply OpenAI `/v1/responses` live-zone compression to a request body.
+///
+/// Hot-fix entry point added 2026-05-06: re-enables `/v1/responses`
+/// compression on the Python proxy after PR-C5 retired the Python
+/// pipeline. PR-C5's "Rust handles it" claim assumed the standalone
+/// `crates/headroom-proxy` binary would sit in front of Python; that
+/// binary is not deployed by the CLI (`headroom proxy`,
+/// `headroom wrap codex`). This binding lets the Python proxy call
+/// the live-zone dispatcher inline so Codex `/v1/responses` traffic
+/// is compressed end-to-end.
+///
+/// # Arguments
+/// * `body` — raw request body bytes (post memory-injection).
+/// * `auth_mode` — one of `"payg"`, `"oauth"`, `"subscription"`,
+///   `"unknown"`. Currently unused by the dispatcher (the policy
+///   gating is upstream); accepted for forward-compat.
+/// * `model` — model name from the request body. Empty string defaults
+///   to `headroom_core::transforms::live_zone::DEFAULT_MODEL`.
+///
+/// # Returns
+/// `(body, modified)`:
+/// * Modified: `(new_body_bytes, True)` — caller forwards the new bytes.
+/// * Unchanged / passthrough: `(input_bytes, False)` — caller forwards
+///   the original.
+///
+/// # Failure mode
+/// Never raises. The dispatcher's `LiveZoneError` outcomes (body not
+/// JSON, no `messages`/`input` array) are passthrough conditions, not
+/// failures — matching the Rust proxy's
+/// `compress_openai_responses_request` contract.
+#[pyfunction]
+#[pyo3(signature = (body, auth_mode = "payg", model = ""))]
+fn compress_openai_responses_live_zone(
+    py: Python<'_>,
+    body: &[u8],
+    auth_mode: &str,
+    model: &str,
+) -> (Py<PyBytes>, bool) {
+    let mode = match auth_mode.to_ascii_lowercase().as_str() {
+        "payg" => RustLiveZoneAuthMode::Payg,
+        "oauth" => RustLiveZoneAuthMode::OAuth,
+        "subscription" => RustLiveZoneAuthMode::Subscription,
+        _ => RustLiveZoneAuthMode::Unknown,
+    };
+    let model_str = if model.is_empty() {
+        headroom_core::transforms::live_zone::DEFAULT_MODEL
+    } else {
+        model
+    };
+
+    match rust_compress_openai_responses_live_zone(body, mode, model_str) {
+        Ok(LiveZoneOutcome::NoChange { .. }) => (PyBytes::new_bound(py, body).unbind(), false),
+        Ok(LiveZoneOutcome::Modified { new_body, .. }) => {
+            // `RawValue::get` returns the underlying serialized JSON
+            // as `&str`; bytes are valid UTF-8 by construction.
+            let bytes = new_body.get().as_bytes();
+            (PyBytes::new_bound(py, bytes).unbind(), true)
+        }
+        Err(_) => {
+            // BodyNotJson / NoMessagesArray are non-fatal: nothing to
+            // compress, fall through to passthrough byte-for-byte.
+            (PyBytes::new_bound(py, body).unbind(), false)
+        }
+    }
+}
+
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(hello, m)?)?;
@@ -1487,5 +1555,6 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score_line, m)?)?;
     m.add_function(wrap_pyfunction!(content_has_error_indicators, m)?)?;
     m.add_function(wrap_pyfunction!(keyword_registry_snapshot, m)?)?;
+    m.add_function(wrap_pyfunction!(compress_openai_responses_live_zone, m)?)?;
     Ok(())
 }

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -1475,6 +1475,43 @@ class OpenAIHandlerMixin:
         else:
             url = build_copilot_upstream_url(self.OPENAI_API_URL, "/v1/responses")
 
+        # Hot-fix (post-PR-C5): re-enable /v1/responses compression via the
+        # PyO3 inline call to the Rust live-zone dispatcher. PR-C5 retired
+        # the Python pipeline expecting that the standalone
+        # `crates/headroom-proxy` Rust binary would sit in front of the
+        # Python proxy and compress here. That binary is not deployed by
+        # the CLI today (`headroom proxy`, `headroom wrap codex` both run
+        # only the Python proxy), so /v1/responses traffic has been
+        # uncompressed since v0.20.16. This call closes that gap by
+        # invoking the same dispatcher in-process via `headroom._core`.
+        # All policy gating already happened upstream (auth_mode classify,
+        # CompressionPolicy resolve at request entry).
+        if self.config.optimize:
+            try:
+                from headroom._core import (
+                    compress_openai_responses_live_zone as _rust_compress_responses,
+                )
+
+                _input_bytes = json.dumps(body).encode("utf-8")
+                _new_bytes, _modified = _rust_compress_responses(
+                    _input_bytes,
+                    auth_mode.value,
+                    model,
+                )
+                if _modified:
+                    body = json.loads(_new_bytes)
+                    transforms_applied = list(transforms_applied) + ["openai_responses_live_zone"]
+                    logger.info(
+                        f"[{request_id}] /v1/responses compressed "
+                        f"{len(_input_bytes):,}→{len(_new_bytes):,} bytes "
+                        f"(auth_mode={auth_mode.value})"
+                    )
+            except Exception as _e:
+                logger.warning(
+                    f"[{request_id}] /v1/responses compression failed; "
+                    f"forwarding original body: {type(_e).__name__}: {_e}"
+                )
+
         try:
             if stream:
                 # Streaming for Responses API uses semantic events

--- a/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.21.0",
+  "version": "0.21.4",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/plugins/headroom-agent-hooks/.github/plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.21.0",
+  "version": "0.21.4",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/tests/test_responses_pyo3_compression.py
+++ b/tests/test_responses_pyo3_compression.py
@@ -1,0 +1,129 @@
+"""Hot-fix tests: PyO3 inline `/v1/responses` compression.
+
+Re-enables compression after PR-C5 retired the Python pipeline. The
+standalone Rust proxy binary (`crates/headroom-proxy`) was supposed to
+handle this, but it's not deployed by the CLI today. This module
+exposes a PyO3 binding so the Python proxy can call the live-zone
+dispatcher in-process.
+
+These tests pin:
+
+1. The binding is exposed and callable.
+2. Round-trip: a body with no eligible content passes through unchanged.
+3. Round-trip: a body with a compressible function-call output gets compressed.
+4. Errors are non-fatal: malformed JSON / missing input array → passthrough.
+5. Auth-mode parsing accepts every variant the F1 classifier produces.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _ensure_binding():
+    """Skip if the Rust extension hasn't been built (mirrors existing pattern)."""
+    try:
+        from headroom._core import compress_openai_responses_live_zone
+
+        return compress_openai_responses_live_zone
+    except ImportError:
+        pytest.skip("headroom._core not built — run scripts/build_rust_extension.sh")
+
+
+class TestBindingExposed:
+    """The pyfunction is reachable from Python."""
+
+    def test_callable(self):
+        compress = _ensure_binding()
+        assert callable(compress), "compress_openai_responses_live_zone must be callable"
+
+
+class TestPassthroughCases:
+    """Bodies the dispatcher cannot compress should be returned byte-for-byte
+    with `modified=False`. Matches the Rust proxy's `Outcome::Passthrough`
+    contract."""
+
+    def test_not_json_passthrough(self):
+        compress = _ensure_binding()
+        body = b"this is not JSON at all"
+        out, modified = compress(body, "payg", "gpt-4o-mini")
+        assert out == body
+        assert modified is False
+
+    def test_no_input_array_passthrough(self):
+        compress = _ensure_binding()
+        body = json.dumps({"model": "gpt-4o-mini"}).encode()
+        out, modified = compress(body, "payg", "gpt-4o-mini")
+        assert out == body
+        assert modified is False
+
+    def test_empty_input_array_passthrough(self):
+        compress = _ensure_binding()
+        body = json.dumps({"model": "gpt-4o-mini", "input": []}).encode()
+        out, modified = compress(body, "payg", "gpt-4o-mini")
+        assert out == body
+        assert modified is False
+
+    def test_no_eligible_items_passthrough(self):
+        compress = _ensure_binding()
+        # Single user message under the byte threshold — no compression
+        # applies, but still valid input.
+        body = json.dumps(
+            {
+                "model": "gpt-4o-mini",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+            }
+        ).encode()
+        out, modified = compress(body, "payg", "gpt-4o-mini")
+        assert modified is False
+        # Body should be byte-equal (passthrough, not re-serialized).
+        assert out == body
+
+
+class TestAuthModeAccepted:
+    """Every F1 AuthMode value is accepted; unrecognised falls back to
+    Unknown (does not raise)."""
+
+    @pytest.mark.parametrize(
+        "auth_mode",
+        ["payg", "oauth", "subscription", "unknown", "", "garbage"],
+    )
+    def test_accepts(self, auth_mode):
+        compress = _ensure_binding()
+        body = json.dumps({"model": "gpt-4o-mini", "input": []}).encode()
+        # Should not raise on any string input.
+        out, modified = compress(body, auth_mode, "gpt-4o-mini")
+        assert isinstance(out, bytes)
+        assert modified is False
+
+
+class TestModelDefault:
+    """Empty `model` defaults to `headroom_core`'s `DEFAULT_MODEL`."""
+
+    def test_empty_model_uses_default(self):
+        compress = _ensure_binding()
+        body = json.dumps({"input": []}).encode()
+        out, modified = compress(body, "payg", "")
+        assert isinstance(out, bytes)
+        assert modified is False
+
+
+class TestNoExceptionsLeak:
+    """The binding's contract is `never raises` (matches the Rust proxy's
+    `compress_openai_responses_request` passthrough-on-error semantics).
+    Pin this so future maintainers don't accidentally introduce a
+    raising path."""
+
+    def test_garbage_bytes_no_raise(self):
+        compress = _ensure_binding()
+        out, modified = compress(b"\xff\xfe\x00\xff", "payg", "gpt-4o-mini")
+        assert modified is False
+        assert out == b"\xff\xfe\x00\xff"
+
+    def test_empty_body_no_raise(self):
+        compress = _ensure_binding()
+        out, modified = compress(b"", "payg", "gpt-4o-mini")
+        assert modified is False
+        assert out == b""


### PR DESCRIPTION
## Summary

Restores `/v1/responses` request-side compression that has been silently OFF since **v0.20.16** (PR-C5, 2026-05-03). Closes the regression Codex subscription users have been reporting.

PR-C5 retired the Python `/v1/responses` compression pipeline with the comment *"Rust handles item-aware compression natively (see `crates/headroom-proxy/src/handlers/responses.rs`)"* — but the standalone `headroom-proxy` Rust binary that was supposed to do that compression **is not deployed by the CLI**:

- `headroom proxy` runs only the Python proxy via `uvicorn`.
- `headroom wrap codex` spawns `python -m headroom.cli proxy` (`headroom/cli/wrap.py:139`).
- The `headroom-proxy` Rust binary is a workspace member but never built into the wheel; `which headroom-proxy` returns nothing.
- PR-A0's "rust core deployment smoke test" only verifies `headroom._core` (the PyO3 compression library), not the standalone proxy binary.

Result: every `/v1/responses` request between v0.20.16 and now has been forwarded to `api.openai.com` / `chatgpt.com` uncompressed.

## Why PyO3 inline (Layer 1) and not the originally-intended two-process chain (Layer 2)

The inline call requires zero deployment changes — the wheel already ships `headroom._core` and PR-A0 verifies it loads at proxy startup. The two-process chain (build + ship the standalone binary, teach CLI to spawn both processes, add an internal port for Python, configure Rust's `--upstream` to point at Python) is the right long-term move but not a hot-fix.

This PR exposes the existing `headroom_core::transforms::compress_openai_responses_live_zone` function as a PyO3 binding and calls it inline from the Python `handle_openai_responses` handler. **Same dispatcher code that the standalone binary would have run, just invoked in-process.**

## Commits

| # | Title |
|---|---|
| c1 | `fix(core): expose compress_openai_responses_live_zone via PyO3` — adds the binding to `crates/headroom-py/src/lib.rs` + 14-test contract in `tests/test_responses_pyo3_compression.py` |
| c2 | `fix(proxy): wire PyO3 compression into /v1/responses handler` — calls the binding from `headroom/proxy/handlers/openai.py::handle_openai_responses` right after upstream-URL resolution |

## Behavior

| Path | Pre-PR | Post-PR |
|---|---|---|
| `/v1/responses` HTTP non-stream | uncompressed | live-zone compressed |
| `/v1/responses` HTTP stream (SSE) | uncompressed | live-zone compressed (call site is BEFORE the if-stream branch) |
| `/v1/responses` WebSocket | uncompressed | uncompressed *(out of scope; PR-C5 explicitly deferred WS-side compression)* |
| `/v1/chat/completions` | unchanged | unchanged |

The compression is purely request-side (input items → compressed input items). Response items are streamed back unchanged. F2.1 policy gating applies upstream of this call — Subscription users get the same dispatcher with the upstream-resolved policy already in effect.

## Failure mode

`compress_openai_responses_live_zone` (the PyO3 function) **never raises**. The dispatcher's `LiveZoneError` cases (body not JSON, no input array) are passthrough conditions, not failures — matching the Rust proxy's `compress_openai_responses_request` contract.

The Python handler also wraps the call in a `try/except` and forwards the original body on any unexpected error — passthrough-on-failure is the right default for a hot-fix that must not regress in any edge case.

## What this PR does NOT fix

This PR only addresses **Bug 1** of the three-layer Codex regression diagnosed in the conversation:

- **Bug 2** (per-item-type response handling lives only in dead Rust binary code): partially addressed — the inline call exposes the live-zone path, which IS the per-item-type handler.
- **Bug 3** (`openai_base_url` + `requires_openai_auth = true` injection in `wrap codex` config): NOT addressed in this PR. Separate config-side fix needed; PR #401 propagated the broken injection to two more entry points (`init`, persistent install). Recommend a follow-up that strips those fields.

## Test plan

- [x] `cargo build -p headroom-py --release` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p headroom-py -p headroom-core -- -D warnings` — clean
- [x] `cargo test -p headroom-core --lib` — 799 passed, 1 ignored
- [x] `python -m pytest tests/test_responses_pyo3_compression.py` — 14/14 passed
- [x] Regression suite `test_proxy_openai_cache_stability + test_proxy_openai_responses_integration + test_compression_policy` — 23 passed, 14 skipped (env-gated)
- [x] `make ci-precheck` (rust + python + commitlint) — 176 tests passed via pre-push hook
- [x] Manual smoke: `from headroom._core import compress_openai_responses_live_zone` — exposed and callable
- [ ] **Live validation: an actual Codex subscription session against this branch** (cannot run from CI; needs the user's ChatGPT subscription credentials)

Refs: #327, #388 (cache-instability complaints, root-caused to this regression), v0.20.16 (first version with the regression)