### PR TITLE
fix: harden release gating and clarify pipx Python compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ on:
       - ".github/workflows/docker.yml"
       - "crates/headroom-py/**"
       - "pyproject.toml"
+      - "scripts/verify-versions.py"
+      - "scripts/version-sync.py"
       - "Cargo.toml"
       - "Cargo.lock"
   workflow_dispatch:
@@ -121,6 +123,10 @@ jobs:
       - name: Sync version to package files
         run: |
           python scripts/version-sync.py --version ${{ needs.detect-version.outputs.npm_version }}
+
+      - name: Verify package versions are synchronized
+        run: |
+          python scripts/verify-versions.py
 
       - name: Run changelog generation
         run: |
@@ -249,6 +255,10 @@ jobs:
         run: |
           python scripts/version-sync.py --version ${{ needs.detect-version.outputs.npm_version }}
 
+      - name: Verify package versions are synchronized
+        run: |
+          python scripts/verify-versions.py
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -284,6 +294,32 @@ jobs:
         with:
           command: sdist
           args: --out dist
+
+      - name: Verify sdist includes top-level LICENSE
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import tarfile
+
+          sdists = sorted(Path("dist").glob("*.tar.gz"))
+          if len(sdists) != 1:
+              raise SystemExit(f"expected exactly one sdist in dist/, found {len(sdists)}")
+
+          with tarfile.open(sdists[0], "r:gz") as archive:
+              names = archive.getnames()
+
+          roots = {name.split("/", 1)[0] for name in names if "/" in name}
+          if len(roots) != 1:
+              raise SystemExit(f"expected one sdist root directory, found {sorted(roots)}")
+
+          root = roots.pop()
+          license_path = f"{root}/LICENSE"
+          if license_path not in names:
+              raise SystemExit(f"{sdists[0].name} is missing {license_path}")
+
+          print(f"sdist LICENSE OK: {license_path}")
+          PY
 
       # Audit each Linux wheel's dynamic symbol references against its
       # declared manylinux glibc floor. Catches the bug class from
@@ -580,12 +616,6 @@ jobs:
       - name: Publish ${{ env.PYPI_PACKAGE }} to PyPI
         id: pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1
-        continue-on-error: true
-
-      - name: PyPI publish notice
-        if: steps.pypi-publish.outcome == 'failure'
-        run: |
-          echo "::notice::PyPI publish skipped — OIDC trusted publisher not configured for this repo. See: https://pypi.org/trusted-publishers/ — Set PYPI_SKIP=true in repo Variables to suppress this notice."
 
   publish-npm:
     needs: [detect-version, build]
@@ -777,7 +807,8 @@ jobs:
         needs.build.result == 'success' &&
         needs.build-wheels.result == 'success' &&
         needs.collect-dist.result == 'success' &&
-        needs.smoke-import-wheels.result == 'success'
+        needs.smoke-import-wheels.result == 'success' &&
+        (vars.PYPI_SKIP == 'true' || needs.publish-pypi.result == 'success')
       }}
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **PyPI install clarity and release gating.** Documented `pipx --python python3.13`
+  for environments where unsupported Python wheel tags cause older-version
+  resolution, made PyPI publish failures block GitHub Releases unless
+  `PYPI_SKIP=true`, and added an sdist `LICENSE` invariant.
+
 - **`Learned: error recovery` section in MEMORY.md no longer bloats with
   stale, one-shot, or contradictory entries.** The matchers paired up
   unrelated tool calls (e.g. `state.rs` and `lib.rs` in the same dir

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ headroom wrap aider       # Aider
 headroom wrap copilot     # GitHub Copilot CLI
 ```
 
+Using `pipx`? Current release wheels are built for Python 3.10 through 3.13, so
+choose a supported interpreter explicitly:
+
+```bash
+pipx install --python python3.13 "headroom-ai[all]"
+```
+
 **Drop it into your own code — Python or TypeScript:**
 
 ```python

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -6,6 +6,8 @@ description: Install Headroom via pip, npm, or Docker. Includes all Python extra
 ## Python
 
 Headroom requires **Python 3.10+** and is published as `headroom-ai` on PyPI.
+Current release wheels are built for Python **3.10 through 3.13**. If your
+installer is using a newer Python, force a supported interpreter.
 
 ### Core package
 
@@ -38,6 +40,30 @@ You can combine extras:
 
 ```bash
 pip install "headroom-ai[proxy,langchain,ml]"
+```
+
+### pipx
+
+`pipx` creates one virtual environment per app. If that environment uses an
+unsupported Python version, `pipx` may resolve an older compatible Headroom
+release instead of the newest one.
+
+Use Python 3.13 explicitly:
+
+```bash
+pipx install --python python3.13 "headroom-ai[all]"
+```
+
+For a pinned release:
+
+```bash
+pipx install --python python3.13 "headroom-ai[all]==0.21.4"
+```
+
+Check which Python an existing `pipx` environment uses:
+
+```bash
+pipx list
 ```
 
 ### Verify the install

--- a/docs/content/docs/releases.mdx
+++ b/docs/content/docs/releases.mdx
@@ -144,6 +144,20 @@ To skip a publish target, set the corresponding GitHub Actions variable:
 
 Set these in: **GitHub repo → Settings → Variables → Actions Variables → New repository variable**.
 
+PyPI publishing is a hard gate for GitHub Releases unless `PYPI_SKIP=true`.
+If the PyPI upload fails, the workflow stops before creating or updating the
+GitHub Release, so release notes cannot advertise a version that was not
+published to PyPI.
+
+Before release artifacts are built, the workflow runs:
+
+```bash
+python scripts/verify-versions.py
+```
+
+That gate fails on cross-package version drift. The sdist build is also checked
+for a top-level `LICENSE` file before any publish job can consume it.
+
 ## Workflow Triggers
 
 The workflow runs on push to `main`, but ignores pushes that only touch docs, CI config, or scripts:

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -165,6 +165,37 @@ config.rolling_window.enabled = False
 
 ## Installation Issues
 
+### pipx installs an older Headroom version
+
+**Symptom**: PyPI shows a newer `headroom-ai` release, but `pipx install` or
+`pipx upgrade` keeps an older version. A pinned install can also fail with
+`No matching distribution found`.
+
+**Cause**: `pipx` resolves packages inside its app virtual environment. If that
+environment uses a Python version that Headroom does not publish wheels for yet,
+pip may skip newer releases and choose the newest compatible build it can use.
+
+Check the interpreter:
+
+```bash
+pipx list
+```
+
+Install with a supported Python explicitly:
+
+```bash
+pipx install --python python3.13 "headroom-ai[all]"
+```
+
+For a pinned release:
+
+```bash
+pipx install --python python3.13 "headroom-ai[all]==0.21.4"
+```
+
+If you already have Headroom installed under `pipx`, uninstall it first or
+reinstall it with the supported interpreter.
+
 ### pip install fails with C++ compilation error
 
 **Symptom**: `RuntimeError: Unsupported compiler -- at least C++11 support is needed!`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,8 +263,9 @@ default = true
 # Where the Python package lives. With `python-source = "."` and the
 # package directory `headroom/` at repo root, maturin includes every file
 # under `headroom/` in the wheel — that picks up the dashboard HTML
-# templates, the bundled YAML configs, etc., without needing an explicit
-# `include` list.
+# templates and bundled YAML configs. `LICENSE` is listed explicitly because
+# maturin sdists do not get the package-directory treatment wheels do.
+include = [{ path = "LICENSE", format = "sdist" }]
 python-source = "."
 module-name = "headroom._core"
 # The cdylib source lives under `crates/headroom-py`. Maturin invokes

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -38,7 +38,7 @@ def test_release_workflow_publishes_python_distributions_to_github_release() -> 
     assert 'gh release upload "$TAG" release-assets/*.tgz --clobber' in content
 
 
-def test_create_release_runs_after_successful_build_even_if_other_publishes_fail() -> None:
+def test_create_release_requires_successful_build_and_pypi_publish() -> None:
     content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
     # Single-wheel maturin refactor (PR #360) added `build-wheels` (the
@@ -60,6 +60,7 @@ def test_create_release_runs_after_successful_build_even_if_other_publishes_fail
     assert "needs.build-wheels.result == 'success'" in content
     assert "needs.collect-dist.result == 'success'" in content
     assert "needs.smoke-import-wheels.result == 'success'" in content
+    assert "(vars.PYPI_SKIP == 'true' || needs.publish-pypi.result == 'success')" in content
 
 
 def test_macos_native_wrapper_dependency_install_retries_pypi_downloads() -> None:
@@ -491,6 +492,46 @@ def test_sdist_build_conditional_keyed_on_target_not_os() -> None:
         f"sdist build conditional must NOT depend on `matrix.os` — that's "
         f"how PR #376 silently disabled the sdist build. Got: {if_line!r}"
     )
+
+
+def test_release_workflow_verifies_versions_before_build_outputs() -> None:
+    """Release sync must be followed by an explicit cross-package version gate."""
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert "scripts/verify-versions.py" in content
+    assert "scripts/version-sync.py" in content
+    assert content.count("python scripts/verify-versions.py") >= 2
+
+    first_sync = content.index("python scripts/version-sync.py --version")
+    first_verify = content.index("python scripts/verify-versions.py", first_sync)
+    changelog = content.index("name: Run changelog generation", first_verify)
+    assert first_sync < first_verify < changelog
+
+    second_sync = content.index("python scripts/version-sync.py --version", first_verify)
+    second_verify = content.index("python scripts/verify-versions.py", second_sync)
+    build_wheels = content.index("name: Build wheels", second_verify)
+    assert second_sync < second_verify < build_wheels
+
+
+def test_sdist_license_is_packaged_and_verified_before_upload() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    release_yml = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert 'include = [{ path = "LICENSE", format = "sdist" }]' in pyproject
+    assert "name: Verify sdist includes top-level LICENSE" in release_yml
+    assert 'license_path = f"{root}/LICENSE"' in release_yml
+
+
+def test_pypi_publish_failure_blocks_github_release() -> None:
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    pypi_job_start = content.index("publish-pypi:")
+    npm_job_start = content.index("publish-npm:", pypi_job_start)
+    pypi_job = content[pypi_job_start:npm_job_start]
+
+    assert "uses: pypa/gh-action-pypi-publish@release/v1" in pypi_job
+    assert "continue-on-error: true" not in pypi_job
+    assert "(vars.PYPI_SKIP == 'true' || needs.publish-pypi.result == 'success')" in content
 
 
 def test_glibc_compat_shim_present_in_headroom_py() -> None:


### PR DESCRIPTION
## Summary
This change makes install behavior clearer for users hitting `pipx` interpreter compatibility issues, and hardens release behavior so GitHub Releases cannot proceed when PyPI publish fails (unless `PYPI_SKIP=true`).

## Why
When `pipx` uses an unsupported Python interpreter (for example, Python `3.14` while release wheels are published for `3.10` through `3.13`), installs can resolve older compatible versions or fail for pinned newer versions.

Separately, the release workflow could still create or update a GitHub Release when PyPI publish failed.

## User Impact (Before vs Now)
### Before
- `pipx install "headroom-ai[all]"` could install an older version under unsupported interpreter tags.
- `pipx install "headroom-ai[all]==<newer-version>"` could fail with no clear compatibility guidance.
- GitHub release artifacts could be published even if PyPI publish failed.

### Now
- Docs explicitly guide users to supported `pipx` interpreter selection:
  - `pipx install --python python3.13 "headroom-ai[all]"`
- Release pipeline blocks GitHub release creation unless PyPI publish succeeds (or explicit skip via `PYPI_SKIP=true`).
- Sdist packaging and version consistency are verified before publish.

## What Changed
- Release workflow hardening in `.github/workflows/release.yml`:
  - Removed `continue-on-error` from `publish-pypi`.
  - Added `create-release` gate requiring PyPI success when `PYPI_SKIP != true`.
  - Added `python scripts/verify-versions.py` after each `version-sync.py` stage.
  - Added sdist check to assert top-level `LICENSE` exists.
  - Expanded PR trigger paths to include version script changes.
- Packaging update in `pyproject.toml`:
  - Explicit sdist include for `LICENSE`.
- Documentation updates:
  - `README.md`
  - `docs/content/docs/installation.mdx`
  - `docs/content/docs/troubleshooting.mdx`
  - `docs/content/docs/releases.mdx`
- Regression coverage in `tests/test_release_workflows.py`:
  - Version-sync gate checks.
  - Sdist `LICENSE` invariant checks.
  - PyPI-failure release-block checks.
- Changelog entry in `CHANGELOG.md` (`Unreleased > Fixed`).

## How to Test
```bash
python3 scripts/verify-versions.py
.venv/bin/python -m pytest tests/test_release_workflows.py -q -k "create_release_requires_successful_build_and_pypi_publish or verifies_versions or sdist_license or pypi_publish_failure"
.venv/bin/python -m ruff check tests/test_release_workflows.py
.venv/bin/python -m ruff format --check tests/test_release_workflows.py
```
