### PR TITLE
fix(codex): bug 3 — strip requires_openai_auth, restore consistent openai_base_url injection

### DIFF
--- a/e2e/init/run.py
+++ b/e2e/init/run.py
@@ -139,9 +139,13 @@ def _verify_codex_local(ctx: CaseContext) -> None:
         raise AssertionError("Codex config should point at the requested proxy port (9012)")
     if 'env_key = "OPENAI_API_KEY"' in config:
         raise AssertionError("Codex local init should preserve OAuth and never inject env_key")
-    for expected in ("requires_openai_auth = true", "supports_websockets = true"):
-        if expected not in config:
-            raise AssertionError(f"Codex local init missing {expected!r}")
+    # Bug 3 (#406): requires_openai_auth must be absent from headroom provider blocks.
+    if "requires_openai_auth" in config:
+        raise AssertionError(
+            "Codex local init must NOT inject requires_openai_auth into the headroom provider block"
+        )
+    if "supports_websockets = true" not in config:
+        raise AssertionError("Codex local init missing 'supports_websockets = true'")
     if config.count("[features]") != 1:
         raise AssertionError("Codex config should keep a single [features] table")
     if "codex_hooks = true" not in config:
@@ -177,9 +181,13 @@ def _verify_codex_global(ctx: CaseContext) -> None:
         raise AssertionError("Codex user config should point at port 8787 by default")
     if 'env_key = "OPENAI_API_KEY"' in config:
         raise AssertionError("Codex global init should preserve OAuth and never inject env_key")
-    for expected in ("requires_openai_auth = true", "supports_websockets = true"):
-        if expected not in config:
-            raise AssertionError(f"Codex global init missing {expected!r}")
+    # Bug 3 (#406): requires_openai_auth must be absent from headroom provider blocks.
+    if "requires_openai_auth" in config:
+        raise AssertionError(
+            "Codex global init must NOT inject requires_openai_auth into the headroom provider block"
+        )
+    if "supports_websockets = true" not in config:
+        raise AssertionError("Codex global init missing 'supports_websockets = true'")
     if "codex_hooks = true" not in config:
         raise AssertionError("Codex user config should enable codex_hooks")
     hooks = json.loads((ctx.home / ".codex" / "hooks.json").read_text(encoding="utf-8"))

--- a/e2e/wrap/run.py
+++ b/e2e/wrap/run.py
@@ -563,8 +563,12 @@ def verify_codex_wrap(
         'env_key = "OPENAI_API_KEY"' not in config,
         "Codex wrap should preserve OAuth and never inject env_key",
     )
-    for expected in ("requires_openai_auth = true", "supports_websockets = true"):
-        assert_true(expected in config, f"Codex wrap missing {expected!r}")
+    # Bug 3 (#406): requires_openai_auth must be absent from headroom provider blocks.
+    assert_true(
+        "requires_openai_auth" not in config,
+        "Codex wrap must NOT inject requires_openai_auth into the headroom provider block",
+    )
+    assert_true("supports_websockets = true" in config, "Codex wrap missing 'supports_websockets = true'")
 
     entries = read_jsonl(log_dir / "codex.jsonl")
     assert_true(len(entries) > 0, "Codex shim should have been invoked")

--- a/e2e/wrap/run.py
+++ b/e2e/wrap/run.py
@@ -568,7 +568,9 @@ def verify_codex_wrap(
         "requires_openai_auth" not in config,
         "Codex wrap must NOT inject requires_openai_auth into the headroom provider block",
     )
-    assert_true("supports_websockets = true" in config, "Codex wrap missing 'supports_websockets = true'")
+    assert_true(
+        "supports_websockets = true" in config, "Codex wrap missing 'supports_websockets = true'"
+    )
 
     entries = read_jsonl(log_dir / "codex.jsonl")
     assert_true(len(entries) > 0, "Codex shim should have been invoked")

--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -207,11 +207,49 @@ def _replace_marker_block(content: str, marker_start: str, marker_end: str, bloc
     return (content.rstrip() + "\n\n" + block.strip() + "\n").lstrip()
 
 
+def _strip_codex_init_block(content: str) -> str:
+    """Remove all Headroom init-managed blocks and orphan keys from a Codex config.toml string."""
+    import re
+
+    # Remove any provider marker → end marker span, possibly repeated.
+    while _CODEX_PROVIDER_MARKER_START in content and _CODEX_PROVIDER_MARKER_END in content:
+        start = content.index(_CODEX_PROVIDER_MARKER_START)
+        end_idx = content.index(_CODEX_PROVIDER_MARKER_END, start)
+        if end_idx < start:
+            break
+        end = end_idx + len(_CODEX_PROVIDER_MARKER_END)
+        content = content[:start].rstrip("\n") + "\n" + content[end:].lstrip("\n")
+
+    # Remove stale unpaired markers.
+    content = content.replace(_CODEX_PROVIDER_MARKER_START + "\n", "")
+    content = content.replace(_CODEX_PROVIDER_MARKER_END + "\n", "")
+
+    # Strip any orphan top-level keys that a crashed or partial write may have
+    # left outside the marker block.
+    content = re.sub(r'(?m)^[ \t]*model_provider[ \t]*=[ \t]*"headroom"[ \t]*\r?\n', "", content)
+    content = re.sub(
+        r'(?m)^[ \t]*openai_base_url[ \t]*=[ \t]*"http://127\.0\.0\.1:\d+/v1"[ \t]*\r?\n',
+        "",
+        content,
+    )
+
+    # Strip any orphaned [model_providers.headroom] table that is recognisably ours.
+    orphan_headroom_table = re.compile(
+        r"(?ms)^\[model_providers\.headroom\][^\[]*?"
+        r'base_url[ \t]*=[ \t]*"http://127\.0\.0\.1:\d+/v1"[^\[]*?'
+        r"(?=^\[|\Z)"
+    )
+    content = orphan_headroom_table.sub("", content)
+
+    return content.lstrip("\n").rstrip() + "\n" if content.strip() else ""
+
+
 def _ensure_codex_provider(path: Path, port: int) -> None:
     logger.debug("ensure codex provider block: %s (port=%s)", path, port)
     block = (
         f"{_CODEX_PROVIDER_MARKER_START}\n"
-        'model_provider = "headroom"\n\n'
+        'model_provider = "headroom"\n'
+        f'openai_base_url = "http://127.0.0.1:{port}/v1"\n\n'
         "[model_providers.headroom]\n"
         'name = "Headroom init proxy"\n'
         f'base_url = "http://127.0.0.1:{port}/v1"\n'

--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -28,7 +28,6 @@ from headroom.install.runtime import (
 )
 from headroom.install.state import load_manifest, save_manifest
 from headroom.install.supervisors import start_supervisor
-from headroom.providers.codex.install import build_provider_section as build_codex_provider_section
 
 from .main import main
 
@@ -213,12 +212,12 @@ def _ensure_codex_provider(path: Path, port: int) -> None:
     block = (
         f"{_CODEX_PROVIDER_MARKER_START}\n"
         'model_provider = "headroom"\n\n'
-        + build_codex_provider_section(
-            port=port,
-            name="Headroom init proxy",
-            include_markers=False,
-        )
-        + f"{_CODEX_PROVIDER_MARKER_END}"
+        "[model_providers.headroom]\n"
+        'name = "Headroom init proxy"\n'
+        f'base_url = "http://127.0.0.1:{port}/v1"\n'
+        'env_key = "OPENAI_API_KEY"\n'
+        "supports_websockets = true\n"
+        f"{_CODEX_PROVIDER_MARKER_END}"
     )
     content = path.read_text(encoding="utf-8") if path.exists() else ""
     content = _replace_marker_block(

--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -253,7 +253,6 @@ def _ensure_codex_provider(path: Path, port: int) -> None:
         "[model_providers.headroom]\n"
         'name = "Headroom init proxy"\n'
         f'base_url = "http://127.0.0.1:{port}/v1"\n'
-        'env_key = "OPENAI_API_KEY"\n'
         "supports_websockets = true\n"
         f"{_CODEX_PROVIDER_MARKER_END}"
     )

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -542,10 +542,16 @@ def _prepare_wrap_rtk(verbose: bool = False, *, label: str | None = None) -> Pat
 def _inject_codex_provider_config(port: int) -> None:
     """Inject a Headroom model provider into Codex's config.toml.
 
-    Codex ignores OPENAI_BASE_URL for WebSocket transport unless a custom
-    provider declares ``supports_websockets = true``.  This writes a
-    ``[model_providers.headroom]`` section that routes both HTTP and WS
-    through the proxy, and sets ``model_provider = "headroom"``.
+    Two keys are written in the top-level block:
+
+    * ``model_provider = "headroom"`` — selects the custom provider for
+      API-key mode traffic.
+    * ``openai_base_url = "http://127.0.0.1:{port}/v1"`` — overrides the
+      built-in ``openai`` provider's base URL.  This is the critical key for
+      **subscription (ChatGPT plan) users**: Codex detects subscription auth
+      and routes through the built-in ``openai`` provider regardless of
+      ``model_provider``, so without this override it bypasses the proxy and
+      hits ``https://chatgpt.com/backend-api/codex`` directly.
 
     Safe to call multiple times — the injected block is fully replaced on
     each call, so re-running with a different ``port`` updates the config.
@@ -563,7 +569,10 @@ def _inject_codex_provider_config(port: int) -> None:
     # stripping them is unambiguous and never consumes user content that
     # happens to sit between the two.
     top_level_block = (
-        f'{_CODEX_TOP_LEVEL_MARKER}\nmodel_provider = "headroom"\n{_CODEX_END_MARKER}\n'
+        f"{_CODEX_TOP_LEVEL_MARKER}\n"
+        f'model_provider = "headroom"\n'
+        f'openai_base_url = "http://127.0.0.1:{port}/v1"\n'
+        f"{_CODEX_END_MARKER}\n"
     )
     provider_section = (
         f"{_CODEX_TOP_LEVEL_MARKER}\n"

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -579,7 +579,6 @@ def _inject_codex_provider_config(port: int) -> None:
         "[model_providers.headroom]\n"
         'name = "OpenAI via Headroom proxy"\n'
         f'base_url = "http://127.0.0.1:{port}/v1"\n'
-        f'env_key = "OPENAI_API_KEY"\n'
         f"supports_websockets = true\n"
         f"{_CODEX_END_MARKER}\n"
     )

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -542,20 +542,10 @@ def _prepare_wrap_rtk(verbose: bool = False, *, label: str | None = None) -> Pat
 def _inject_codex_provider_config(port: int) -> None:
     """Inject a Headroom model provider into Codex's config.toml.
 
-    Two keys are written in the top-level block:
-
-    * ``model_provider = "headroom"`` — selects the custom provider for
-      API-key mode traffic.
-    * ``openai_base_url = "http://127.0.0.1:{port}/v1"`` — overrides the
-      built-in ``openai`` provider's base URL.  This is the critical key for
-      **subscription (ChatGPT plan) users**: Codex detects subscription auth
-      and routes through the built-in ``openai`` provider regardless of
-      ``model_provider``, so without this override it bypasses the proxy and
-      hits ``https://chatgpt.com/backend-api/codex`` directly.
-
-    A ``[model_providers.headroom]`` section is also written with
-    ``supports_websockets = true`` so that WebSocket transport (used by
-    default) also flows through the proxy for API-key users.
+    Codex ignores OPENAI_BASE_URL for WebSocket transport unless a custom
+    provider declares ``supports_websockets = true``.  This writes a
+    ``[model_providers.headroom]`` section that routes both HTTP and WS
+    through the proxy, and sets ``model_provider = "headroom"``.
 
     Safe to call multiple times — the injected block is fully replaced on
     each call, so re-running with a different ``port`` updates the config.
@@ -573,17 +563,14 @@ def _inject_codex_provider_config(port: int) -> None:
     # stripping them is unambiguous and never consumes user content that
     # happens to sit between the two.
     top_level_block = (
-        f"{_CODEX_TOP_LEVEL_MARKER}\n"
-        f'model_provider = "headroom"\n'
-        f'openai_base_url = "http://127.0.0.1:{port}/v1"\n'
-        f"{_CODEX_END_MARKER}\n"
+        f'{_CODEX_TOP_LEVEL_MARKER}\nmodel_provider = "headroom"\n{_CODEX_END_MARKER}\n'
     )
     provider_section = (
         f"{_CODEX_TOP_LEVEL_MARKER}\n"
         "[model_providers.headroom]\n"
         'name = "OpenAI via Headroom proxy"\n'
         f'base_url = "http://127.0.0.1:{port}/v1"\n'
-        f"requires_openai_auth = true\n"
+        f'env_key = "OPENAI_API_KEY"\n'
         f"supports_websockets = true\n"
         f"{_CODEX_END_MARKER}\n"
     )
@@ -613,10 +600,7 @@ def _inject_codex_provider_config(port: int) -> None:
             content = top_level_block + "\n" + provider_section
 
         config_file.write_text(content)
-        click.echo(
-            f"  Codex config: injected Headroom provider (WS + HTTP, API-key + subscription)"
-            f" into {config_file}"
-        )
+        click.echo(f"  Codex config: injected Headroom provider (WS + HTTP) into {config_file}")
     except Exception as e:
         click.echo(f"  Warning: could not update Codex config: {e}")
 

--- a/headroom/providers/codex/install.py
+++ b/headroom/providers/codex/install.py
@@ -32,6 +32,31 @@ _ORPHAN_HEADROOM_TABLE = re.compile(
 )
 
 
+def build_provider_section(
+    *,
+    port: int,
+    name: str,
+    marker_start: str = _CODEX_MARKER_START,
+    marker_end: str = _CODEX_MARKER_END,
+    include_markers: bool = True,
+) -> str:
+    """Build a managed Codex provider block (without requires_openai_auth).
+
+    Bug 3 (#406): requires_openai_auth must NOT appear on custom provider
+    blocks — it forces codex to demand OpenAI OAuth login for local-proxy
+    traffic.  The built-in openai provider carries this flag; headroom does not.
+    """
+    body = (
+        "[model_providers.headroom]\n"
+        f'name = "{name}"\n'
+        f'base_url = "{proxy_base_url(port)}"\n'
+        "supports_websockets = true\n"
+    )
+    if not include_markers:
+        return body
+    return f"{marker_start}\n{body}{marker_end}\n"
+
+
 def build_install_env(*, port: int, backend: str) -> dict[str, str]:
     """Build the persistent install environment for Codex."""
     del backend
@@ -49,11 +74,12 @@ def apply_provider_scope(manifest: DeploymentManifest) -> ManagedMutation | None
         f"{_CODEX_MARKER_START}\n"
         'model_provider = "headroom"\n'
         f'openai_base_url = "{proxy_base_url(manifest.port)}"\n\n'
-        "[model_providers.headroom]\n"
-        'name = "Headroom persistent proxy"\n'
-        f'base_url = "{proxy_base_url(manifest.port)}"\n'
-        "supports_websockets = true\n"
-        f"{_CODEX_MARKER_END}\n"
+        + build_provider_section(
+            port=manifest.port,
+            name="Headroom persistent proxy",
+            include_markers=False,
+        )
+        + f"{_CODEX_MARKER_END}\n"
     )
     if path.exists():
         existing = path.read_text()

--- a/headroom/providers/codex/install.py
+++ b/headroom/providers/codex/install.py
@@ -17,6 +17,20 @@ _CODEX_PATTERN = re.compile(
     re.DOTALL,
 )
 
+# Orphan-key patterns: strip any top-level keys that a crashed or partial write
+# may have left outside the marker block.
+_ORPHAN_MODEL_PROVIDER = re.compile(
+    r'(?m)^[ \t]*model_provider[ \t]*=[ \t]*"headroom"[ \t]*\r?\n'
+)
+_ORPHAN_OPENAI_BASE_URL = re.compile(
+    r'(?m)^[ \t]*openai_base_url[ \t]*=[ \t]*"http://127\.0\.0\.1:\d+/v1"[ \t]*\r?\n'
+)
+_ORPHAN_HEADROOM_TABLE = re.compile(
+    r"(?ms)^\[model_providers\.headroom\][^\[]*?"
+    r'base_url[ \t]*=[ \t]*"http://127\.0\.0\.1:\d+/v1"[^\[]*?'
+    r"(?=^\[|\Z)"
+)
+
 
 def build_install_env(*, port: int, backend: str) -> dict[str, str]:
     """Build the persistent install environment for Codex."""
@@ -33,7 +47,8 @@ def apply_provider_scope(manifest: DeploymentManifest) -> ManagedMutation | None
     path.parent.mkdir(parents=True, exist_ok=True)
     section = (
         f"{_CODEX_MARKER_START}\n"
-        'model_provider = "headroom"\n\n'
+        'model_provider = "headroom"\n'
+        f'openai_base_url = "{proxy_base_url(manifest.port)}"\n\n'
         "[model_providers.headroom]\n"
         'name = "Headroom persistent proxy"\n'
         f'base_url = "{proxy_base_url(manifest.port)}"\n'
@@ -62,6 +77,12 @@ def revert_provider_scope(mutation: ManagedMutation, manifest: DeploymentManifes
     if not path.exists():
         return
     content = path.read_text()
-    if _CODEX_MARKER_START not in content:
-        return
-    path.write_text(_CODEX_PATTERN.sub("", content).strip() + "\n")
+    # Remove the managed marker block.
+    if _CODEX_MARKER_START in content:
+        content = _CODEX_PATTERN.sub("", content)
+    # Strip any orphan top-level keys that a crashed or partial write may have
+    # left outside the marker block (mirrors wrap.py _strip_codex_headroom_blocks).
+    content = _ORPHAN_MODEL_PROVIDER.sub("", content)
+    content = _ORPHAN_OPENAI_BASE_URL.sub("", content)
+    content = _ORPHAN_HEADROOM_TABLE.sub("", content)
+    path.write_text(content.strip() + "\n")

--- a/headroom/providers/codex/install.py
+++ b/headroom/providers/codex/install.py
@@ -52,7 +52,6 @@ def apply_provider_scope(manifest: DeploymentManifest) -> ManagedMutation | None
         "[model_providers.headroom]\n"
         'name = "Headroom persistent proxy"\n'
         f'base_url = "{proxy_base_url(manifest.port)}"\n'
-        'env_key = "OPENAI_API_KEY"\n'
         "supports_websockets = true\n"
         f"{_CODEX_MARKER_END}\n"
     )

--- a/headroom/providers/codex/install.py
+++ b/headroom/providers/codex/install.py
@@ -18,27 +18,6 @@ _CODEX_PATTERN = re.compile(
 )
 
 
-def build_provider_section(
-    *,
-    port: int,
-    name: str,
-    marker_start: str = _CODEX_MARKER_START,
-    marker_end: str = _CODEX_MARKER_END,
-    include_markers: bool = True,
-) -> str:
-    """Build a managed Codex provider block that preserves OpenAI OAuth."""
-    body = (
-        "[model_providers.headroom]\n"
-        f'name = "{name}"\n'
-        f'base_url = "{proxy_base_url(port)}"\n'
-        "requires_openai_auth = true\n"
-        "supports_websockets = true\n"
-    )
-    if not include_markers:
-        return body
-    return f"{marker_start}\n{body}{marker_end}\n"
-
-
 def build_install_env(*, port: int, backend: str) -> dict[str, str]:
     """Build the persistent install environment for Codex."""
     del backend
@@ -55,12 +34,12 @@ def apply_provider_scope(manifest: DeploymentManifest) -> ManagedMutation | None
     section = (
         f"{_CODEX_MARKER_START}\n"
         'model_provider = "headroom"\n\n'
-        + build_provider_section(
-            port=manifest.port,
-            name="Headroom persistent proxy",
-            include_markers=False,
-        )
-        + f"{_CODEX_MARKER_END}\n"
+        "[model_providers.headroom]\n"
+        'name = "Headroom persistent proxy"\n'
+        f'base_url = "{proxy_base_url(manifest.port)}"\n'
+        'env_key = "OPENAI_API_KEY"\n'
+        "supports_websockets = true\n"
+        f"{_CODEX_MARKER_END}\n"
     )
     if path.exists():
         existing = path.read_text()

--- a/headroom/providers/codex/install.py
+++ b/headroom/providers/codex/install.py
@@ -19,9 +19,7 @@ _CODEX_PATTERN = re.compile(
 
 # Orphan-key patterns: strip any top-level keys that a crashed or partial write
 # may have left outside the marker block.
-_ORPHAN_MODEL_PROVIDER = re.compile(
-    r'(?m)^[ \t]*model_provider[ \t]*=[ \t]*"headroom"[ \t]*\r?\n'
-)
+_ORPHAN_MODEL_PROVIDER = re.compile(r'(?m)^[ \t]*model_provider[ \t]*=[ \t]*"headroom"[ \t]*\r?\n')
 _ORPHAN_OPENAI_BASE_URL = re.compile(
     r'(?m)^[ \t]*openai_base_url[ \t]*=[ \t]*"http://127\.0\.0\.1:\d+/v1"[ \t]*\r?\n'
 )

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -925,3 +925,70 @@ def test_init_hook_ensure_uses_explicit_profile(monkeypatch) -> None:
 
     assert result.exit_code == 0, result.output
     assert ensured == ["init-explicit"]
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 (#406): _ensure_codex_provider must inject openai_base_url
+# ---------------------------------------------------------------------------
+
+
+def test_init_codex_writes_openai_base_url(monkeypatch, tmp_path: Path) -> None:
+    """_ensure_codex_provider must write openai_base_url at the top level so that
+    subscription (ChatGPT plan) users are routed through headroom even when the
+    init entry point is used instead of wrap."""
+    init_cli, _ = _load_init_module(monkeypatch)
+    path = tmp_path / ".codex" / "config.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    init_cli._ensure_codex_provider(path, 8787)
+
+    content = path.read_text(encoding="utf-8")
+    assert 'openai_base_url = "http://127.0.0.1:8787/v1"' in content, (
+        f"openai_base_url missing from init codex config:\n{content}"
+    )
+    # Must NOT appear inside a [section] block.
+    lines = content.splitlines()
+    in_section = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_section = True
+        if in_section and stripped.startswith("openai_base_url"):
+            raise AssertionError(
+                f"openai_base_url appeared inside a section block in init output:\n{content}"
+            )
+    # Bug 3 regression guard.
+    assert "requires_openai_auth" not in content, (
+        f"requires_openai_auth must not appear in init codex config:\n{content}"
+    )
+
+
+def test_init_codex_strip_removes_openai_base_url(monkeypatch, tmp_path: Path) -> None:
+    """_strip_codex_init_block must remove both the managed block and any orphaned
+    openai_base_url lines left by a crashed or partial init."""
+    init_cli, _ = _load_init_module(monkeypatch)
+
+    # Normal install-then-strip cycle.
+    path = tmp_path / "config.toml"
+    path.write_text('model = "gpt-4o"\n', encoding="utf-8")
+    init_cli._ensure_codex_provider(path, 8787)
+    assert 'openai_base_url = "http://127.0.0.1:8787/v1"' in path.read_text(encoding="utf-8")
+
+    stripped = init_cli._strip_codex_init_block(path.read_text(encoding="utf-8"))
+    assert "openai_base_url" not in stripped, (
+        f"_strip_codex_init_block must remove openai_base_url after install:\n{stripped}"
+    )
+    assert "requires_openai_auth" not in stripped
+    assert 'model = "gpt-4o"' in stripped
+
+    # Orphan-cleanup path: openai_base_url left outside marker block.
+    orphan_content = (
+        'model = "gpt-4o"\n'
+        'openai_base_url = "http://127.0.0.1:8787/v1"\n'
+        'model_provider = "headroom"\n'
+    )
+    orphan_stripped = init_cli._strip_codex_init_block(orphan_content)
+    assert "openai_base_url" not in orphan_stripped, (
+        f"_strip_codex_init_block must remove orphaned openai_base_url:\n{orphan_stripped}"
+    )
+    assert 'model = "gpt-4o"' in orphan_stripped

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -489,7 +489,8 @@ def test_headroom_provider_block_never_sets_requires_openai_auth(
     for port in (8787, 9999):
         config_path = tmp_path / f"config_{port}.toml"
         monkeypatch.setattr(
-            "headroom.providers.codex.install.codex_config_path", lambda: config_path
+            "headroom.providers.codex.install.codex_config_path",
+            lambda _p=config_path: _p,
         )
         manifest = _manifest(tmp_path)
         manifest.port = port

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -606,3 +606,84 @@ def test_unwrap_removes_top_level_openai_base_url(
         f"got:\n{stripped}"
     )
     assert 'model = "gpt-4o"' in stripped
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 (#406): openai_base_url must appear in persistent-install and init paths
+# ---------------------------------------------------------------------------
+
+
+def test_apply_provider_scope_writes_openai_base_url(monkeypatch, tmp_path: Path) -> None:
+    """apply_provider_scope must write openai_base_url at the top level (not inside
+    a [model_providers.*] block) so subscription (ChatGPT plan) users are routed
+    through headroom regardless of which entry point they used."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('model = "gpt-4o"\n')
+    monkeypatch.setattr("headroom.providers.codex.install.codex_config_path", lambda: config_path)
+    manifest = _manifest(tmp_path)
+    manifest.port = 8787
+
+    apply_codex_provider_scope(manifest)
+
+    content = config_path.read_text()
+    # Must be present as a top-level key.
+    assert 'openai_base_url = "http://127.0.0.1:8787/v1"' in content, (
+        f"openai_base_url missing from persistent-install config:\n{content}"
+    )
+    # Must NOT be inside any [model_providers.*] block — the key must appear
+    # before the first [section] header that follows it.
+    lines = content.splitlines()
+    in_provider_section = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_provider_section = True
+        if in_provider_section and stripped.startswith("openai_base_url"):
+            raise AssertionError(
+                f"openai_base_url appeared inside a section block:\n{content}"
+            )
+    # Bug 3 regression: requires_openai_auth must NOT appear.
+    assert "requires_openai_auth" not in content, (
+        f"requires_openai_auth must not be present in config:\n{content}"
+    )
+
+
+def test_persistent_install_strip_removes_openai_base_url(monkeypatch, tmp_path: Path) -> None:
+    """revert_provider_scope must remove openai_base_url during uninstall, and
+    must also clean up orphaned openai_base_url lines left by a crashed install."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('model = "gpt-4o"\n')
+    monkeypatch.setattr("headroom.providers.codex.install.codex_config_path", lambda: config_path)
+    manifest = _manifest(tmp_path)
+    manifest.port = 8787
+
+    mutation = apply_codex_provider_scope(manifest)
+    assert mutation is not None
+    assert 'openai_base_url = "http://127.0.0.1:8787/v1"' in config_path.read_text()
+
+    revert_codex_provider_scope(mutation, manifest)
+
+    reverted = config_path.read_text()
+    assert "openai_base_url" not in reverted, (
+        f"openai_base_url must be removed after revert:\n{reverted}"
+    )
+    assert "requires_openai_auth" not in reverted
+    # User's original content must survive.
+    assert 'model = "gpt-4o"' in reverted
+
+    # Also verify orphan-cleanup path: revert on a config where openai_base_url
+    # was left outside the marker block (crash-recovery scenario).
+    config_path.write_text(
+        'model = "gpt-4o"\n'
+        'openai_base_url = "http://127.0.0.1:8787/v1"\n'
+        'model_provider = "headroom"\n'
+    )
+    revert_codex_provider_scope(
+        ManagedMutation(target="codex", kind="toml-block", path=str(config_path)),
+        manifest,
+    )
+    orphan_reverted = config_path.read_text()
+    assert "openai_base_url" not in orphan_reverted, (
+        f"orphaned openai_base_url must be removed by revert:\n{orphan_reverted}"
+    )
+    assert 'model = "gpt-4o"' in orphan_reverted

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -234,51 +234,312 @@ def test_openclaw_revert_provider_scope_skips_without_binary(monkeypatch, tmp_pa
 
     def fail_if_called(command: list[str]) -> None:
         nonlocal called
-    // ... 309 lines omitted
+        called = True
+
+    monkeypatch.setattr("headroom.providers.openclaw.install._invoke_openclaw", fail_if_called)
+
     from headroom.providers.openclaw.install import (
-    // ... 308 lines omitted
+        revert_provider_scope as revert_openclaw_provider_scope,
+    )
+
+    revert_openclaw_provider_scope(
+        ManagedMutation(target="openclaw", kind="openclaw-wrap", path=str(tmp_path / "cfg.json")),
+        _manifest(tmp_path),
+    )
+
+    assert called is False
+
+
 def test_openclaw_revert_provider_scope_invokes_unwrap(monkeypatch, tmp_path: Path) -> None:
-    // ... 307 lines omitted
+    recorded: list[list[str]] = []
+    monkeypatch.setattr("headroom.providers.openclaw.install.shutil_which", lambda name: "openclaw")
+    monkeypatch.setattr(
+        "headroom.providers.openclaw.install.resolve_headroom_command",
+        lambda: ["headroom"],
+    )
+    monkeypatch.setattr(
+        "headroom.providers.openclaw.install._invoke_openclaw",
+        lambda command: recorded.append(command),
+    )
+
     from headroom.providers.openclaw.install import (
-    // ... 306 lines omitted
+        revert_provider_scope as revert_openclaw_provider_scope,
+    )
+
+    revert_openclaw_provider_scope(
+        ManagedMutation(target="openclaw", kind="openclaw-wrap", path=str(tmp_path / "cfg.json")),
+        _manifest(tmp_path),
+    )
+
+    assert recorded == [["headroom", "unwrap", "openclaw"]]
+
+
 def test_windows_env_scope_restores_previous_values(monkeypatch, tmp_path: Path) -> None:
-    // ... 305 lines omitted
+    manifest = _manifest(tmp_path)
+    manifest.scope = "user"
+    manifest.targets = ["claude"]
+    manifest.base_env = {"HEADROOM_PORT": "8787"}
+    manifest.tool_envs = {"claude": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}}
+
+    calls: list[list[str]] = []
+    previous_values = {
+        "HEADROOM_PORT": "7777",
+        "ANTHROPIC_BASE_URL": "https://old",
     }
-    // ... 304 lines omitted
+
     class Result:
         def __init__(self, stdout: str = "") -> None:
-    // ... 302 lines omitted
+            self.stdout = stdout
+
     def fake_run(command: list[str], **kwargs):
-    // ... 301 lines omitted
+        calls.append(command)
+        script = command[-1]
+        if "GetEnvironmentVariable" in script:
+            name = script.split("GetEnvironmentVariable('", 1)[1].split("'", 1)[0]
+            value = previous_values.get(name, "__HEADROOM_UNSET__")
+            return Result(stdout=value)
+        return Result()
+
+    monkeypatch.setattr("headroom.install.providers.subprocess.run", fake_run)
+
+    mutations = _apply_windows_env_scope(manifest)
+    _remove_windows_env_scope(mutations)
+
+    previous_by_name = {mutation.data["name"]: mutation.data["previous"] for mutation in mutations}
+    assert previous_by_name["HEADROOM_PORT"] == "7777"
+    assert previous_by_name["ANTHROPIC_BASE_URL"] == "https://old"
+    assert any(
+        "[Environment]::SetEnvironmentVariable('HEADROOM_PORT','7777','User')" in command[-1]
+        for command in calls
+    )
+    assert any(
+        "[Environment]::SetEnvironmentVariable('ANTHROPIC_BASE_URL','https://old','User')"
+        in command[-1]
+        for command in calls
+    )
+
+
 def test_remove_windows_env_scope_requires_name_and_scope() -> None:
-    // ... 300 lines omitted
+    try:
+        _remove_windows_env_scope([ManagedMutation(target="env", kind="windows-env", data={})])
+    except ValueError as exc:
+        assert "variable name" in str(exc)
+    else:
+        raise AssertionError("expected missing variable name to raise")
+
+    try:
+        _remove_windows_env_scope(
+            [ManagedMutation(target="env", kind="windows-env", data={"name": "X", "scope": 1})]
+        )
+    except ValueError as exc:
+        assert "valid scope" in str(exc)
+    else:
+        raise AssertionError("expected invalid scope to raise")
+
+
 def test_apply_mutations_runs_openclaw_for_user_scope(monkeypatch, tmp_path: Path) -> None:
-    // ... 299 lines omitted
+    manifest = _manifest(tmp_path)
+    manifest.scope = "user"
+    manifest.targets = ["openclaw"]
+    manifest.base_env = {"HEADROOM_PORT": "8787"}
+    manifest.tool_envs = {}
+
+    if os.name == "nt":
+        monkeypatch.setattr(
+            "headroom.install.providers._apply_windows_env_scope", lambda deployment: []
+        )
+    else:
+        monkeypatch.setattr(
+            "headroom.install.providers._apply_unix_env_scope", lambda deployment: []
+        )
+    monkeypatch.setattr(
+        "headroom.install.providers.apply_provider_scope_mutations",
+        lambda deployment: [ManagedMutation(target="openclaw", kind="openclaw-wrap")],
+    )
+
     from headroom.install.providers import apply_mutations
-    // ... 298 lines omitted
+
+    mutations = apply_mutations(manifest)
+
+    assert [mutation.kind for mutation in mutations] == ["openclaw-wrap"]
+
+
 def test_claude_build_install_env_returns_proxy_base_url() -> None:
-    // ... 297 lines omitted
+    # Arrange / Act
+    env = build_claude_install_env(port=5566, backend="ignored")
+
+    # Assert
+    assert env == {"ANTHROPIC_BASE_URL": "http://127.0.0.1:5566"}
+
+
 def test_copilot_build_install_env_uses_provider_type_specific_proxy_urls() -> None:
-    // ... 296 lines omitted
+    anthropic_env = build_copilot_install_env(port=8787, backend="anthropic")
+    openai_env = build_copilot_install_env(port=8787, backend="anyllm")
+
+    assert anthropic_env == {
+        "COPILOT_PROVIDER_TYPE": "anthropic",
+        "COPILOT_PROVIDER_BASE_URL": "http://127.0.0.1:8787",
     }
-    // ... 295 lines omitted
+    assert openai_env == {
+        "COPILOT_PROVIDER_TYPE": "openai",
+        "COPILOT_PROVIDER_BASE_URL": "http://127.0.0.1:8787/v1",
+        "COPILOT_PROVIDER_WIRE_API": "completions",
     }
-    // ... 294 lines omitted
+
+
 def test_apply_claude_provider_scope_skips_non_provider_scope(monkeypatch, tmp_path: Path) -> None:
-    // ... 293 lines omitted
+    # Arrange
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(
+        "headroom.providers.claude.install.claude_settings_path", lambda: settings_path
+    )
+    manifest = _manifest(tmp_path)
+    manifest.scope = "user"
+
+    # Act
+    mutation = apply_claude_provider_scope(manifest)
+
+    # Assert
+    assert mutation is None
+    assert not settings_path.exists()
+
+
 def test_revert_claude_provider_scope_removes_new_values_from_non_mapping_env(
-    // ... 292 lines omitted
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Arrange
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"env": ["not-a-map"]}))
+    monkeypatch.setattr(
+        "headroom.providers.claude.install.claude_settings_path", lambda: settings_path
+    )
+    manifest = _manifest(tmp_path)
+
+    # Act
+    mutation = apply_claude_provider_scope(manifest)
+    apply_payload = json.loads(settings_path.read_text())
+    revert_claude_provider_scope(mutation, manifest)
+    reverted_payload = json.loads(settings_path.read_text())
+
+    # Assert
+    assert mutation is not None
+    assert mutation.data["previous"] == {"ANTHROPIC_BASE_URL": None}
+    assert apply_payload["env"] == {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}
+    assert reverted_payload["env"] == {}
+
+
 def test_apply_claude_provider_scope_creates_settings_when_missing(
-    // ... 291 lines omitted
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Arrange
+    settings_path = tmp_path / "nested" / "settings.json"
+    monkeypatch.setattr(
+        "headroom.providers.claude.install.claude_settings_path", lambda: settings_path
+    )
+    manifest = _manifest(tmp_path)
+
+    # Act
+    mutation = apply_claude_provider_scope(manifest)
+
+    # Assert
+    assert mutation is not None
+    assert json.loads(settings_path.read_text()) == {
+        "env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}
     }
-    // ... 290 lines omitted
+
+
 def test_revert_claude_provider_scope_ignores_missing_mutation_path(tmp_path: Path) -> None:
-    // ... 289 lines omitted
+    # Arrange
+    manifest = _manifest(tmp_path)
+    mutation = ManagedMutation(target="claude", kind="json-env", data={"previous": {}})
+
+    # Act / Assert
+    revert_claude_provider_scope(mutation, manifest)
+
+
 def test_revert_claude_provider_scope_ignores_missing_settings_file(tmp_path: Path) -> None:
-    // ... 288 lines omitted
+    # Arrange
+    manifest = _manifest(tmp_path)
+    mutation = ManagedMutation(
+        target="claude",
+        kind="json-env",
+        path=str(tmp_path / "missing-settings.json"),
+        data={"previous": {}},
+    )
+
+    # Act / Assert
+    revert_claude_provider_scope(mutation, manifest)
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 regression tests (#406): requires_openai_auth and openai_base_url
+# must never appear in the headroom provider block.
+# ---------------------------------------------------------------------------
+
+
 def test_headroom_provider_block_never_sets_requires_openai_auth(
-    // ... 287 lines omitted
+    monkeypatch, tmp_path: Path
+) -> None:
+    """apply_provider_scope must NOT emit requires_openai_auth in the headroom block.
+
+    Bug 3 (#406): requires_openai_auth = true on a custom [model_providers.headroom]
+    block forces codex to demand OpenAI OAuth login for headroom-routed traffic.
+    Headroom is a local proxy — it must not require OpenAI auth.
+    """
+    for port in (8787, 9999):
+        config_path = tmp_path / f"config_{port}.toml"
+        monkeypatch.setattr(
+            "headroom.providers.codex.install.codex_config_path", lambda: config_path
+        )
+        manifest = _manifest(tmp_path)
+        manifest.port = port
+
+        apply_codex_provider_scope(manifest)
+
+        content = config_path.read_text()
+        # The rendered TOML for the headroom provider block must not contain this
+        # field.  If it does, codex will prompt for OpenAI OAuth on every startup.
+        assert "requires_openai_auth" not in content, (
+            f"requires_openai_auth must be absent from the headroom provider block "
+            f"(port={port}); got:\n{content}"
+        )
+        # Sanity: the block itself is present and points at the right port.
+        assert f'base_url = "http://127.0.0.1:{port}/v1"' in content
+        assert "[model_providers.headroom]" in content
+
+
 def test_inject_codex_provider_config_does_not_write_openai_base_url(
-    // ... 286 lines omitted
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_inject_codex_provider_config must NOT write a top-level openai_base_url key.
+
+    Bug 3 (#406): injecting openai_base_url at the top level of config.toml
+    causes ChatGPT/subscription users to bypass headroom and ride the built-in
+    openai provider directly.  The field must be absent after injection.
+    """
     from headroom.cli import wrap as wrap_mod
-// ... 285 more lines (total: 544)
+
+    home = tmp_path
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    wrap_mod._inject_codex_provider_config(8787)
+
+    config_file = home / ".codex" / "config.toml"
+    assert config_file.exists(), "inject must create ~/.codex/config.toml"
+    content = config_file.read_text()
+
+    # The top-level openai_base_url key must be absent.  Its presence would
+    # bypass headroom for subscription/ChatGPT users.
+    assert "openai_base_url" not in content, (
+        "openai_base_url must not appear in config.toml after injection; "
+        f"got:\n{content}"
+    )
+    # Sanity: the provider block is actually there.
+    assert "[model_providers.headroom]" in content
+    assert 'base_url = "http://127.0.0.1:8787/v1"' in content
+    # requires_openai_auth must also be absent (bug 3 regression guard).
+    assert "requires_openai_auth" not in content, (
+        "requires_openai_auth must be absent from the injected provider block; "
+        f"got:\n{content}"
+    )

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -508,14 +508,20 @@ def test_headroom_provider_block_never_sets_requires_openai_auth(
         assert "[model_providers.headroom]" in content
 
 
-def test_inject_codex_provider_config_does_not_write_openai_base_url(
+def test_inject_codex_provider_config_writes_openai_base_url(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """_inject_codex_provider_config must NOT write a top-level openai_base_url key.
+    """_inject_codex_provider_config MUST write a top-level openai_base_url key.
 
-    Bug 3 (#406): injecting openai_base_url at the top level of config.toml
-    causes ChatGPT/subscription users to bypass headroom and ride the built-in
-    openai provider directly.  The field must be absent after injection.
+    Bug 3 (#406) has two halves:
+    1. Strip ``requires_openai_auth`` from the headroom provider block (done in 3ca48d3).
+    2. Inject ``openai_base_url`` at the top level so subscription (ChatGPT plan)
+       users are also routed through headroom.
+
+    Without the top-level ``openai_base_url`` override, Codex subscription mode
+    uses the built-in ``openai`` provider with ``chatgpt.com/backend-api/codex``
+    as the base URL, bypassing the proxy entirely.  This key is the only way to
+    intercept subscription traffic.
     """
     from headroom.cli import wrap as wrap_mod
 
@@ -529,10 +535,12 @@ def test_inject_codex_provider_config_does_not_write_openai_base_url(
     assert config_file.exists(), "inject must create ~/.codex/config.toml"
     content = config_file.read_text()
 
-    # The top-level openai_base_url key must be absent.  Its presence would
-    # bypass headroom for subscription/ChatGPT users.
-    assert "openai_base_url" not in content, (
-        "openai_base_url must not appear in config.toml after injection; "
+    # The top-level openai_base_url key must be present at exactly this value.
+    # Any port drift (e.g. 9999) will break subscription routing and must cause
+    # this test to fail.
+    assert 'openai_base_url = "http://127.0.0.1:8787/v1"' in content, (
+        "openai_base_url must appear at the top level of config.toml after injection "
+        "so that Codex subscription (ChatGPT plan) users are routed through headroom; "
         f"got:\n{content}"
     )
     # Sanity: the provider block is actually there.
@@ -543,3 +551,58 @@ def test_inject_codex_provider_config_does_not_write_openai_base_url(
         "requires_openai_auth must be absent from the injected provider block; "
         f"got:\n{content}"
     )
+    # openai_base_url must be in the top-level block, NOT inside [model_providers.*]
+    lines = content.splitlines()
+    in_provider_section = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_provider_section = stripped.startswith("[model_providers")
+        if in_provider_section and stripped.startswith("openai_base_url"):
+            raise AssertionError(
+                f"openai_base_url must be top-level, not inside a [model_providers.*] section; "
+                f"found it inside a provider section. Config:\n{content}"
+            )
+
+
+def test_unwrap_removes_top_level_openai_base_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """After unwrap, the top-level openai_base_url key must be gone.
+
+    Verifies that ``_restore_codex_provider_config`` (unwrap) removes the
+    ``openai_base_url`` key so orphaned entries don't accumulate between
+    wrap/unwrap cycles.
+    """
+    from headroom.cli import wrap as wrap_mod
+
+    home = tmp_path
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    wrap_mod._inject_codex_provider_config(8787)
+    config_file = home / ".codex" / "config.toml"
+    assert 'openai_base_url = "http://127.0.0.1:8787/v1"' in config_file.read_text()
+
+    wrap_mod._restore_codex_provider_config()
+
+    # After unwrap the file should be gone (no prior content) or cleaned.
+    if config_file.exists():
+        content = config_file.read_text()
+        assert "openai_base_url" not in content, (
+            "openai_base_url must not remain in config.toml after unwrap; "
+            f"got:\n{content}"
+        )
+    # Also verify via _strip_codex_headroom_blocks directly — the orphan-cleanup
+    # path is exercised when there is no backup file (crash-recovery path).
+    orphan_content = (
+        'model = "gpt-4o"\n'
+        'openai_base_url = "http://127.0.0.1:8787/v1"\n'
+        'model_provider = "headroom"\n'
+    )
+    stripped = wrap_mod._strip_codex_headroom_blocks(orphan_content)
+    assert "openai_base_url" not in stripped, (
+        "_strip_codex_headroom_blocks must remove orphaned openai_base_url lines; "
+        f"got:\n{stripped}"
+    )
+    assert 'model = "gpt-4o"' in stripped

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -549,8 +549,7 @@ def test_inject_codex_provider_config_writes_openai_base_url(
     assert 'base_url = "http://127.0.0.1:8787/v1"' in content
     # requires_openai_auth must also be absent (bug 3 regression guard).
     assert "requires_openai_auth" not in content, (
-        "requires_openai_auth must be absent from the injected provider block; "
-        f"got:\n{content}"
+        f"requires_openai_auth must be absent from the injected provider block; got:\n{content}"
     )
     # openai_base_url must be in the top-level block, NOT inside [model_providers.*]
     lines = content.splitlines()
@@ -591,8 +590,7 @@ def test_unwrap_removes_top_level_openai_base_url(
     if config_file.exists():
         content = config_file.read_text()
         assert "openai_base_url" not in content, (
-            "openai_base_url must not remain in config.toml after unwrap; "
-            f"got:\n{content}"
+            f"openai_base_url must not remain in config.toml after unwrap; got:\n{content}"
         )
     # Also verify via _strip_codex_headroom_blocks directly — the orphan-cleanup
     # path is exercised when there is no backup file (crash-recovery path).
@@ -603,8 +601,7 @@ def test_unwrap_removes_top_level_openai_base_url(
     )
     stripped = wrap_mod._strip_codex_headroom_blocks(orphan_content)
     assert "openai_base_url" not in stripped, (
-        "_strip_codex_headroom_blocks must remove orphaned openai_base_url lines; "
-        f"got:\n{stripped}"
+        f"_strip_codex_headroom_blocks must remove orphaned openai_base_url lines; got:\n{stripped}"
     )
     assert 'model = "gpt-4o"' in stripped
 
@@ -640,9 +637,7 @@ def test_apply_provider_scope_writes_openai_base_url(monkeypatch, tmp_path: Path
         if stripped.startswith("["):
             in_provider_section = True
         if in_provider_section and stripped.startswith("openai_base_url"):
-            raise AssertionError(
-                f"openai_base_url appeared inside a section block:\n{content}"
-            )
+            raise AssertionError(f"openai_base_url appeared inside a section block:\n{content}")
     # Bug 3 regression: requires_openai_auth must NOT appear.
     assert "requires_openai_auth" not in content, (
         f"requires_openai_auth must not be present in config:\n{content}"

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -70,7 +70,7 @@ def test_apply_and_revert_codex_provider_scope(monkeypatch, tmp_path: Path) -> N
     content = config_path.read_text()
     assert 'model_provider = "headroom"' in content
     assert 'base_url = "http://127.0.0.1:8787/v1"' in content
-    assert 'env_key = "OPENAI_API_KEY"' in content
+    assert 'env_key = "OPENAI_API_KEY"' not in content
     assert "requires_openai_auth" not in content
 
     assert mutation is not None

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -70,8 +70,8 @@ def test_apply_and_revert_codex_provider_scope(monkeypatch, tmp_path: Path) -> N
     content = config_path.read_text()
     assert 'model_provider = "headroom"' in content
     assert 'base_url = "http://127.0.0.1:8787/v1"' in content
-    assert 'env_key = "OPENAI_API_KEY"' not in content
-    assert "requires_openai_auth = true" in content
+    assert 'env_key = "OPENAI_API_KEY"' in content
+    assert "requires_openai_auth" not in content
 
     assert mutation is not None
     revert_codex_provider_scope(mutation, manifest)
@@ -123,7 +123,8 @@ def test_apply_codex_provider_scope_replaces_existing_managed_block(
     assert content.count("# --- Headroom persistent provider ---") == 1
     assert 'base_url = "http://127.0.0.1:9999/v1"' in content
     assert 'base_url = "http://127.0.0.1:1111/v1"' not in content
-    assert 'env_key = "OPENAI_API_KEY"' not in content
+    # Bug 3 (#406): the replacement block must NOT carry requires_openai_auth.
+    assert "requires_openai_auth" not in content
 
 
 def test_apply_codex_provider_scope_creates_new_config_when_missing(
@@ -233,238 +234,51 @@ def test_openclaw_revert_provider_scope_skips_without_binary(monkeypatch, tmp_pa
 
     def fail_if_called(command: list[str]) -> None:
         nonlocal called
-        called = True
-
-    monkeypatch.setattr("headroom.providers.openclaw.install._invoke_openclaw", fail_if_called)
-
+    // ... 309 lines omitted
     from headroom.providers.openclaw.install import (
-        revert_provider_scope as revert_openclaw_provider_scope,
-    )
-
-    revert_openclaw_provider_scope(
-        ManagedMutation(target="openclaw", kind="openclaw-wrap", path=str(tmp_path / "cfg.json")),
-        _manifest(tmp_path),
-    )
-
-    assert called is False
-
-
+    // ... 308 lines omitted
 def test_openclaw_revert_provider_scope_invokes_unwrap(monkeypatch, tmp_path: Path) -> None:
-    recorded: list[list[str]] = []
-    monkeypatch.setattr("headroom.providers.openclaw.install.shutil_which", lambda name: "openclaw")
-    monkeypatch.setattr(
-        "headroom.providers.openclaw.install.resolve_headroom_command",
-        lambda: ["headroom"],
-    )
-    monkeypatch.setattr(
-        "headroom.providers.openclaw.install._invoke_openclaw",
-        lambda command: recorded.append(command),
-    )
-
+    // ... 307 lines omitted
     from headroom.providers.openclaw.install import (
-        revert_provider_scope as revert_openclaw_provider_scope,
-    )
-
-    revert_openclaw_provider_scope(
-        ManagedMutation(target="openclaw", kind="openclaw-wrap", path=str(tmp_path / "cfg.json")),
-        _manifest(tmp_path),
-    )
-
-    assert recorded == [["headroom", "unwrap", "openclaw"]]
-
-
+    // ... 306 lines omitted
 def test_windows_env_scope_restores_previous_values(monkeypatch, tmp_path: Path) -> None:
-    manifest = _manifest(tmp_path)
-    manifest.scope = "user"
-    manifest.targets = ["claude"]
-    manifest.base_env = {"HEADROOM_PORT": "8787"}
-    manifest.tool_envs = {"claude": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}}
-
-    calls: list[list[str]] = []
-    previous_values = {
-        "HEADROOM_PORT": "7777",
-        "ANTHROPIC_BASE_URL": "https://old",
+    // ... 305 lines omitted
     }
-
+    // ... 304 lines omitted
     class Result:
         def __init__(self, stdout: str = "") -> None:
-            self.stdout = stdout
-
+    // ... 302 lines omitted
     def fake_run(command: list[str], **kwargs):
-        calls.append(command)
-        script = command[-1]
-        if "GetEnvironmentVariable" in script:
-            name = script.split("GetEnvironmentVariable('", 1)[1].split("'", 1)[0]
-            value = previous_values.get(name, "__HEADROOM_UNSET__")
-            return Result(stdout=value)
-        return Result()
-
-    monkeypatch.setattr("headroom.install.providers.subprocess.run", fake_run)
-
-    mutations = _apply_windows_env_scope(manifest)
-    _remove_windows_env_scope(mutations)
-
-    previous_by_name = {mutation.data["name"]: mutation.data["previous"] for mutation in mutations}
-    assert previous_by_name["HEADROOM_PORT"] == "7777"
-    assert previous_by_name["ANTHROPIC_BASE_URL"] == "https://old"
-    assert any(
-        "[Environment]::SetEnvironmentVariable('HEADROOM_PORT','7777','User')" in command[-1]
-        for command in calls
-    )
-    assert any(
-        "[Environment]::SetEnvironmentVariable('ANTHROPIC_BASE_URL','https://old','User')"
-        in command[-1]
-        for command in calls
-    )
-
-
+    // ... 301 lines omitted
 def test_remove_windows_env_scope_requires_name_and_scope() -> None:
-    try:
-        _remove_windows_env_scope([ManagedMutation(target="env", kind="windows-env", data={})])
-    except ValueError as exc:
-        assert "variable name" in str(exc)
-    else:
-        raise AssertionError("expected missing variable name to raise")
-
-    try:
-        _remove_windows_env_scope(
-            [ManagedMutation(target="env", kind="windows-env", data={"name": "X", "scope": 1})]
-        )
-    except ValueError as exc:
-        assert "valid scope" in str(exc)
-    else:
-        raise AssertionError("expected invalid scope to raise")
-
-
+    // ... 300 lines omitted
 def test_apply_mutations_runs_openclaw_for_user_scope(monkeypatch, tmp_path: Path) -> None:
-    manifest = _manifest(tmp_path)
-    manifest.scope = "user"
-    manifest.targets = ["openclaw"]
-    manifest.base_env = {"HEADROOM_PORT": "8787"}
-    manifest.tool_envs = {}
-
-    if os.name == "nt":
-        monkeypatch.setattr(
-            "headroom.install.providers._apply_windows_env_scope", lambda deployment: []
-        )
-    else:
-        monkeypatch.setattr(
-            "headroom.install.providers._apply_unix_env_scope", lambda deployment: []
-        )
-    monkeypatch.setattr(
-        "headroom.install.providers.apply_provider_scope_mutations",
-        lambda deployment: [ManagedMutation(target="openclaw", kind="openclaw-wrap")],
-    )
-
+    // ... 299 lines omitted
     from headroom.install.providers import apply_mutations
-
-    mutations = apply_mutations(manifest)
-
-    assert [mutation.kind for mutation in mutations] == ["openclaw-wrap"]
-
-
+    // ... 298 lines omitted
 def test_claude_build_install_env_returns_proxy_base_url() -> None:
-    # Arrange / Act
-    env = build_claude_install_env(port=5566, backend="ignored")
-
-    # Assert
-    assert env == {"ANTHROPIC_BASE_URL": "http://127.0.0.1:5566"}
-
-
+    // ... 297 lines omitted
 def test_copilot_build_install_env_uses_provider_type_specific_proxy_urls() -> None:
-    anthropic_env = build_copilot_install_env(port=8787, backend="anthropic")
-    openai_env = build_copilot_install_env(port=8787, backend="anyllm")
-
-    assert anthropic_env == {
-        "COPILOT_PROVIDER_TYPE": "anthropic",
-        "COPILOT_PROVIDER_BASE_URL": "http://127.0.0.1:8787",
+    // ... 296 lines omitted
     }
-    assert openai_env == {
-        "COPILOT_PROVIDER_TYPE": "openai",
-        "COPILOT_PROVIDER_BASE_URL": "http://127.0.0.1:8787/v1",
-        "COPILOT_PROVIDER_WIRE_API": "completions",
+    // ... 295 lines omitted
     }
-
-
+    // ... 294 lines omitted
 def test_apply_claude_provider_scope_skips_non_provider_scope(monkeypatch, tmp_path: Path) -> None:
-    # Arrange
-    settings_path = tmp_path / "settings.json"
-    monkeypatch.setattr(
-        "headroom.providers.claude.install.claude_settings_path", lambda: settings_path
-    )
-    manifest = _manifest(tmp_path)
-    manifest.scope = "user"
-
-    # Act
-    mutation = apply_claude_provider_scope(manifest)
-
-    # Assert
-    assert mutation is None
-    assert not settings_path.exists()
-
-
+    // ... 293 lines omitted
 def test_revert_claude_provider_scope_removes_new_values_from_non_mapping_env(
-    monkeypatch, tmp_path: Path
-) -> None:
-    # Arrange
-    settings_path = tmp_path / "settings.json"
-    settings_path.write_text(json.dumps({"env": ["not-a-map"]}))
-    monkeypatch.setattr(
-        "headroom.providers.claude.install.claude_settings_path", lambda: settings_path
-    )
-    manifest = _manifest(tmp_path)
-
-    # Act
-    mutation = apply_claude_provider_scope(manifest)
-    apply_payload = json.loads(settings_path.read_text())
-    revert_claude_provider_scope(mutation, manifest)
-    reverted_payload = json.loads(settings_path.read_text())
-
-    # Assert
-    assert mutation is not None
-    assert mutation.data["previous"] == {"ANTHROPIC_BASE_URL": None}
-    assert apply_payload["env"] == {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}
-    assert reverted_payload["env"] == {}
-
-
+    // ... 292 lines omitted
 def test_apply_claude_provider_scope_creates_settings_when_missing(
-    monkeypatch, tmp_path: Path
-) -> None:
-    # Arrange
-    settings_path = tmp_path / "nested" / "settings.json"
-    monkeypatch.setattr(
-        "headroom.providers.claude.install.claude_settings_path", lambda: settings_path
-    )
-    manifest = _manifest(tmp_path)
-
-    # Act
-    mutation = apply_claude_provider_scope(manifest)
-
-    # Assert
-    assert mutation is not None
-    assert json.loads(settings_path.read_text()) == {
-        "env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}
+    // ... 291 lines omitted
     }
-
-
+    // ... 290 lines omitted
 def test_revert_claude_provider_scope_ignores_missing_mutation_path(tmp_path: Path) -> None:
-    # Arrange
-    manifest = _manifest(tmp_path)
-    mutation = ManagedMutation(target="claude", kind="json-env", data={"previous": {}})
-
-    # Act / Assert
-    revert_claude_provider_scope(mutation, manifest)
-
-
+    // ... 289 lines omitted
 def test_revert_claude_provider_scope_ignores_missing_settings_file(tmp_path: Path) -> None:
-    # Arrange
-    manifest = _manifest(tmp_path)
-    mutation = ManagedMutation(
-        target="claude",
-        kind="json-env",
-        path=str(tmp_path / "missing-settings.json"),
-        data={"previous": {}},
-    )
-
-    # Act / Assert
-    revert_claude_provider_scope(mutation, manifest)
+    // ... 288 lines omitted
+def test_headroom_provider_block_never_sets_requires_openai_auth(
+    // ... 287 lines omitted
+def test_inject_codex_provider_config_does_not_write_openai_base_url(
+    // ... 286 lines omitted
+    from headroom.cli import wrap as wrap_mod
+// ... 285 more lines (total: 544)

--- a/tests/test_provider_codex_install.py
+++ b/tests/test_provider_codex_install.py
@@ -3,12 +3,20 @@ from __future__ import annotations
 from headroom.providers.codex.install import build_provider_section
 
 
-def test_codex_provider_section_preserves_openai_oauth() -> None:
+def test_codex_provider_section_no_requires_openai_auth() -> None:
+    """Bug 3 (#406): build_provider_section must NOT include requires_openai_auth.
+
+    Setting requires_openai_auth on a custom [model_providers.headroom] block
+    forces codex to demand OpenAI OAuth login for every headroom-routed request.
+    Headroom is a local proxy — it must never carry this flag.
+    """
     section = build_provider_section(port=8787, name="OpenAI via Headroom proxy")
 
     assert 'name = "OpenAI via Headroom proxy"' in section
     assert 'base_url = "http://127.0.0.1:8787/v1"' in section
-    assert "requires_openai_auth = true" in section
+    assert "requires_openai_auth" not in section, (
+        f"requires_openai_auth must be absent from the headroom provider section; got:\n{section}"
+    )
     assert "supports_websockets = true" in section
     assert 'env_key = "OPENAI_API_KEY"' not in section
 

--- a/tests/test_provider_codex_runtime.py
+++ b/tests/test_provider_codex_runtime.py
@@ -334,7 +334,10 @@ def test_init_codex_config_routes_messages_through_headroom(
     config_path = tmp_path / ".codex" / "config.toml"
     content = config_path.read_text(encoding="utf-8")
     assert 'env_key = "OPENAI_API_KEY"' not in content
-    assert "requires_openai_auth = true" in content
+    # Bug 3 (#406): requires_openai_auth must be absent from headroom provider blocks.
+    assert "requires_openai_auth" not in content, (
+        f"requires_openai_auth must not appear in init-generated Codex config:\n{content}"
+    )
 
     _assert_delivery(
         codex_proxy_stack,


### PR DESCRIPTION
## Summary

Fixes Bug 3 raised in #406 — the `wrap codex` config injection was broken in two ways, and PR #401 propagated half of the breakage to `init` and persistent install while leaving the other half inconsistent. This PR fixes both halves across all three entry points.

## What was broken

**Half 1 — `requires_openai_auth = true` on `[model_providers.headroom]`:** This field forces codex to demand OpenAI OAuth login for traffic routed via the custom `headroom` provider. Headroom is a local proxy at `127.0.0.1` — it doesn't have or need OpenAI OAuth. The field is meant only for the built-in `openai` provider where codex hardcodes it (see `codex-rs/model-provider-info/src/lib.rs`). Injecting it on the headroom provider block broke API-key users.

**Half 2 — `openai_base_url` injection inconsistency:** Subscription/ChatGPT-plan users use codex's built-in `openai` provider (OAuth path), not the custom `headroom` provider. To intercept that traffic through headroom, the top-level `openai_base_url` TOML key must point to the headroom proxy URL. The wrap path had this (via `5c7a5b4`); the init and persistent-install paths never did. So subscription users were silently bypassing headroom on those paths.

## What this PR does

1. Removes `requires_openai_auth = true` from the `[model_providers.headroom]` block emitted by all three entry points: `wrap` (`headroom/cli/wrap.py`), `init` (`headroom/cli/init.py`), and persistent install (`headroom/providers/codex/install.py`).
2. Ensures `openai_base_url = "http://127.0.0.1:{port}/v1"` is injected at the top level by all three entry points (was only in wrap; now in init and persistent install too).
3. Adds orphan-cleanup for stray `openai_base_url` lines in the strip helpers (handles configs left behind by old/crashed runs).
4. Adds deterministic regression tests pinning the new correct behavior. Tests fail loudly if either field regresses on any entry point.

## Subscription proxy verification

Confirmed `headroom/handlers/openai.py` already handles OAuth/Bearer subscription requests correctly: `_decode_openai_bearer_payload` decodes JWT tokens, `_resolve_codex_routing_headers` extracts `chatgpt_account_id` and injects the `ChatGPT-Account-ID` header, then routes to `chatgpt.com/backend-api/codex/responses`. No proxy-side changes needed.

## Test plan

- [x] `pytest tests/test_install/test_providers.py tests/test_cli/test_wrap_codex.py tests/test_cli/test_init_cli.py` — 95 passed
- [ ] Manual: `wrap codex` against a subscription auth and confirm requests transit headroom (visible in proxy logs)
- [ ] Manual: `wrap codex` against an API-key auth and confirm requests still work
- [ ] Manual: `init codex` then run codex — confirm same as wrap for both auth modes
- [ ] Manual: persistent install + uninstall — confirm config is left clean (no orphan `openai_base_url`)

## Note on commit history

Commit `3ca48d3` removed the `openai_base_url` injection from `wrap.py` while stripping `requires_openai_auth`. That removal was an accidental regression — restored in `bb54b2a`. The two fixes are logically independent; reviewers may prefer to squash on merge.

Closes the bug 3 portion of #406.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>