### PR TITLE
export code-aware flag in proxy

### DIFF
--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -12,6 +12,13 @@ from headroom.proxy.modes import PROXY_MODE_TOKEN, normalize_proxy_mode
 from .main import main
 
 
+def _get_env_bool(name: str, default: bool) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.lower() in ("true", "1", "yes", "on")
+
+
 @main.command()
 @click.option(
     "--host",
@@ -90,6 +97,14 @@ from .main import main
 @click.option("--no-optimize", is_flag=True, help="Disable optimization (passthrough mode)")
 @click.option("--no-cache", is_flag=True, help="Disable semantic caching")
 @click.option("--no-rate-limit", is_flag=True, help="Disable rate limiting")
+@click.option(
+    "--code-aware",
+    is_flag=True,
+    help=(
+        "Enable code-aware compression in the proxy (env: HEADROOM_CODE_AWARE_ENABLED). "
+        "Code-aware remains off by default."
+    ),
+)
 @click.option(
     "--proxy-extension",
     "proxy_extension",
@@ -348,6 +363,7 @@ def proxy(
     no_optimize: bool,
     no_cache: bool,
     no_rate_limit: bool,
+    code_aware: bool,
     proxy_extension: tuple[str, ...],
     no_subscription_tracking: bool,
     subscription_poll_interval: int | None,
@@ -516,6 +532,7 @@ def proxy(
         budget_limit_usd=budget,
         # Code graph: live file watcher for incremental reindexing
         code_graph_watcher=code_graph,
+        code_aware_enabled=code_aware or _get_env_bool("HEADROOM_CODE_AWARE_ENABLED", False),
         # Read lifecycle: ON by default (use --no-read-lifecycle to disable)
         read_lifecycle=not no_read_lifecycle,
         # Memory System (Multi-Provider with auto-detection)

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -80,6 +80,77 @@ class TestCLIProxyEnvVars:
         assert result.exit_code == 0, result.output
         assert captured_config["config"].budget_limit_usd == 100.5
 
+    def test_code_aware_enabled_from_env(self, runner):
+        """HEADROOM_CODE_AWARE_ENABLED env var should be passed to ProxyConfig."""
+        captured_config = {}
+
+        def mock_run_server(config):
+            captured_config["config"] = config
+
+        with patch("headroom.proxy.server.run_server", mock_run_server):
+            result = runner.invoke(
+                main,
+                ["proxy"],
+                env={"HEADROOM_CODE_AWARE_ENABLED": "true"},
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured_config["config"].code_aware_enabled is True
+
+    def test_code_aware_enabled_defaults_false(self, runner):
+        """Without HEADROOM_CODE_AWARE_ENABLED, code-aware stays disabled in the wrapper."""
+        captured_config = {}
+
+        def mock_run_server(config):
+            captured_config["config"] = config
+
+        env = {k: v for k, v in os.environ.items() if k != "HEADROOM_CODE_AWARE_ENABLED"}
+
+        with (
+            patch("headroom.proxy.server.run_server", mock_run_server),
+            patch.dict(os.environ, env, clear=True),
+        ):
+            result = runner.invoke(
+                main,
+                ["proxy"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured_config["config"].code_aware_enabled is False
+
+    def test_code_aware_enabled_from_cli_flag(self, runner):
+        """--code-aware should enable code-aware compression in the wrapper."""
+        captured_config = {}
+
+        def mock_run_server(config):
+            captured_config["config"] = config
+
+        with patch("headroom.proxy.server.run_server", mock_run_server):
+            result = runner.invoke(main, ["proxy", "--code-aware"], catch_exceptions=False)
+
+        assert result.exit_code == 0, result.output
+        assert captured_config["config"].code_aware_enabled is True
+
+    def test_code_aware_flag_overrides_env_var(self, runner):
+        """--code-aware should win over HEADROOM_CODE_AWARE_ENABLED=false."""
+        captured_config = {}
+
+        def mock_run_server(config):
+            captured_config["config"] = config
+
+        with patch("headroom.proxy.server.run_server", mock_run_server):
+            result = runner.invoke(
+                main,
+                ["proxy", "--code-aware"],
+                env={"HEADROOM_CODE_AWARE_ENABLED": "false"},
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured_config["config"].code_aware_enabled is True
+
     def test_openai_target_api_url_from_env(self, runner):
         """OPENAI_TARGET_API_URL env var should be passed to ProxyConfig."""
         captured_config = {}

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -252,6 +252,7 @@ headroom proxy --mode cache
 | `--log-file` | unset | JSONL log output path |
 | `--budget` | unset | Daily USD budget limit |
 | `--no-code-aware` | off | Disable AST-aware code compression |
+| `--code-aware` | off | Enable code-aware compression in the proxy (env: HEADROOM_CODE_AWARE_ENABLED) |
 | `--no-read-lifecycle` | off | Disable stale/superseded read compression |
 | `--no-intelligent-context` | off | Disable intelligent context manager |
 | `--no-intelligent-scoring` | off | Disable multi-factor importance scoring |

--- a/wiki/proxy.md
+++ b/wiki/proxy.md
@@ -74,6 +74,8 @@ When configured, Headroom emits OTLP traces for the shared compression pipeline 
 | `--no-rate-limit` | `false` | Disable rate limiting |
 | `--log-file` | None | Path to JSONL log file |
 | `--budget` | None | Daily budget limit in USD |
+| `--code-aware` | true | Enable AST-based code compression (env: HEADROOM_CODE_AWARE_ENABLED) |
+| `--no-code-aware` | false | Disable code-aware compression |
 | `--openai-api-url` | `https://api.openai.com` | Custom OpenAI API URL endpoint |
 
 ### Run Modes


### PR DESCRIPTION
headroom proxy now accepts --code-aware so callers do not need to drop to the lower-level server entrypoint.

Keep the existing env fallback so HEADROOM_CODE_AWARE_ENABLED still works when the flag is omitted.

Assisted-by: Sisyphus gpt-5.4-mini

## Description

Was not able to change the behaviour of `Code-Aware:      DISABLED` in `headroom proxy`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- expose code-aware flag
- 
## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

## Test Output

```
(headroom) ➜  headroom git:(wip) ✗ python -m pytest tests/test_cli_proxy_env.py -q
=============================================================================================================================================================== test session starts ================================================================================================================================================================
platform linux -- Python 3.10.20, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/user/Projects/headroom
configfile: pyproject.toml
plugins: anyio-4.11.0, libtmux-0.47.0, asyncio-1.2.0, langsmith-0.8.1, cov-7.1.0
asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 22 items

tests/test_cli_proxy_env.py ......................                                                                                                                                                                                                                                                                                           [100%]

================================================================================================================================================================ 22 passed in 2.06s ================================================================================================================================================================
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.
