### PR TITLE
fix(ci): pypi publish skip-existing to unblock idempotent re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -616,6 +616,15 @@ jobs:
       - name: Publish ${{ env.PYPI_PACKAGE }} to PyPI
         id: pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Idempotent re-runs: when a wheel filename for the computed
+          # version is already on PyPI (e.g. a previous push to main
+          # already published this version, or this run's computed
+          # semver hasn't bumped past the last release), treat the
+          # existing file as a no-op instead of a hard failure. PyPA's
+          # recommended pattern for release workflows that may run
+          # multiple times against the same version.
+          skip-existing: true
 
   publish-npm:
     needs: [detect-version, build]


### PR DESCRIPTION
## Summary

One-line workflow change: adds `skip-existing: true` to `pypa/gh-action-pypi-publish` so duplicate-version uploads become no-ops instead of hard failures.

## Why

Every push to main since v0.21.5 published has failed the `publish-pypi` job with **`400 File already exists`**. PyPI's twine refuses to overwrite an existing wheel filename — and the workflow's `detect-version` step has been computing v0.21.5 repeatedly (the canonical+commit-height algorithm hasn't bumped past it for the recent fix-only commits).

Failed runs:

| Run | Trigger | Failure |
|---|---|---|
| 25443521479 | PR #406 merge (15:04 UTC) | `400 File already exists` for v0.21.5 wheels |
| 25452026402 | PR #409 merge (17:55 UTC) | same |
| 25452038283 | next push (17:56 UTC) | same |

PyPI confirmed has 12 files for v0.21.5 (sdist + 11 platform wheels — looks complete).

## Fix

`pypa/gh-action-pypi-publish` supports `skip-existing: true` — its documented pattern for exactly this scenario:

> "Whether or not the action should attempt to publish a package even if a version with same name and version already exists. The default is `false`."

After this lands, the publish job becomes idempotent:

- **Same-version re-run** → twine skips files PyPI already has, exit 0, downstream jobs (`publish-npm`, `publish-docker`, `create-release`) run normally.
- **New-version run** → wheels publish as before, no behaviour change.

## What this does NOT do

This is the minimum change to unblock main. It does **not** audit the version-detection algorithm in `headroom/release_version.py` — that's the deeper question of why v0.21.5 keeps getting re-computed for fix-only commits. Worth a separate follow-up but out of scope here.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — YAML parses
- [x] Diff is exactly 9 lines added (no line-ending noise; surgical insert via byte-preserving Python edit)
- [x] `commitlint` clean via pre-push hook
- [ ] Validation on merge: next push to main publishes (or skips) v0.21.5 wheels without failing the job

Refs: failed runs above, PR #406, PR #409, PR #410