### PR TITLE
fix(ci): update sdist license-packaging invariant test to match new shape

### DIFF
--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -514,12 +514,47 @@ def test_release_workflow_verifies_versions_before_build_outputs() -> None:
 
 
 def test_sdist_license_is_packaged_and_verified_before_upload() -> None:
+    """STRUCTURAL INVARIANT: the sdist tarball must physically contain
+    every license file PEP 639 declares in PKG-INFO, and the release
+    workflow must verify that match before upload.
+
+    PyPI rejects sdists whose `License-File:` metadata entries
+    reference files missing from the tarball with `400 License-File X
+    does not exist in distribution file ...`. Maturin's PEP 639
+    auto-discovery emits both `LICENSE` and `NOTICE` into PKG-INFO
+    because both files exist at the project root and match the default
+    glob — but maturin sdists don't get the package-directory
+    treatment wheels do, so each file must be explicitly listed in
+    `[tool.maturin].include` with `format = "sdist"`. Issue trail:
+    sdist publish broke at v0.20.16 (the hatch -> maturin migration
+    in 2a91cbb dropped NOTICE from the include list), masked for ~22
+    releases by an earlier twine `400 File already exists` failure on
+    duplicate wheels, surfaced once PR #412 added skip-existing.
+    """
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     release_yml = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
-    assert 'include = [{ path = "LICENSE", format = "sdist" }]' in pyproject
-    assert "name: Verify sdist includes top-level LICENSE" in release_yml
-    assert 'license_path = f"{root}/LICENSE"' in release_yml
+    assert '{ path = "LICENSE", format = "sdist" }' in pyproject, (
+        "pyproject.toml [tool.maturin].include must list LICENSE for sdist format"
+    )
+    assert '{ path = "NOTICE", format = "sdist" }' in pyproject, (
+        "pyproject.toml [tool.maturin].include must list NOTICE for sdist format. "
+        "Maturin's PEP 639 auto-discovery emits `License-File: NOTICE` into "
+        "PKG-INFO because NOTICE exists at the project root, so the file MUST "
+        "ship in the tarball or PyPI rejects the sdist with a 400."
+    )
+    assert "name: Verify sdist license-file metadata matches tarball contents" in release_yml, (
+        "release.yml must run the License-File / tarball-contents cross-check before publish"
+    )
+    assert 'if line.startswith("License-File:")' in release_yml, (
+        "release.yml verifier must parse PKG-INFO License-File entries — "
+        "not just a hardcoded LICENSE check — so any future PEP 639-discoverable "
+        "file (COPYING, AUTHORS, ...) is also gated."
+    )
+    assert "declares License-File entries that are missing from the tarball" in release_yml, (
+        "release.yml verifier must fail loudly when declared license files "
+        "are missing — silent passes would let the same regression resurface."
+    )
 
 
 def test_pypi_publish_failure_blocks_github_release() -> None:


### PR DESCRIPTION
## Summary

Follow-up to merged PR #421. The structural-invariant test
`test_sdist_license_is_packaged_and_verified_before_upload` in
`tests/test_release_workflows.py` pins literal strings from the
previous single-LICENSE shape:

- `'include = [{ path = "LICENSE", format = "sdist" }]'` (single-line)
- `'name: Verify sdist includes top-level LICENSE'` (old step name)
- `'license_path = f"{root}/LICENSE"'` (old verifier signature)

PR #421 intentionally changed all three (multi-line include, renamed
step, generic License-File parser), but the matching test update was
prepared as commit `6313e52` on the same branch a few minutes after
GitHub had already auto-merged PR #421 at the prior HEAD — so the
test fix never landed. CI on `main` has been red on every test job
since the merge (run #1170 + #1172 both fail on this assertion).

## Why this got separated from #421

GitHub's PR head SHA didn't refresh promptly after the second push;
the merge resolved against the cached HEAD before the orphan commit
registered. Owning the timing, not blaming the tooling.

## Note on PR #413

@danmunoz independently filed #413 (codex/fix-pypi-notice-sdist) on
2026-05-06 with the same root cause and a similar fix shape. That
PR went unnoticed for ~26 hours and PR #421 ended up landing first.
We can close #413 once this lands; the underlying bug is fixed and
this PR finishes the test update. Thanks @danmunoz.

## Changes

- `tests/test_release_workflows.py` — pin substrings (not full lines)
  for both LICENSE and NOTICE entries; pin the new step name; pin two
  distinctive verifier signatures (the License-File parse line and
  the missing-files error message); add a regression-history docstring.

## Test plan

- [x] `pytest tests/test_release_workflows.py -v` — all 24 pass locally
- [ ] CI green on this PR
- [ ] CI green on `main` after merge