### PR TITLE
fix(bedrock): use floor_char_boundary to avoid UTF-8 slice panic in header preview

### DIFF
--- a/crates/headroom-proxy/src/bedrock/eventstream_to_sse.rs
+++ b/crates/headroom-proxy/src/bedrock/eventstream_to_sse.rs
@@ -404,8 +404,14 @@ mod tests {
         let s = "x".repeat(63) + "éfoo";
         assert!(s.len() > 64);
         let preview = header_value_preview(&HeaderValue::String(s));
-        assert!(preview.ends_with('…'), "expected ellipsis suffix: {preview:?}");
-        assert!(!preview.contains('é'), "must not include the split codepoint");
+        assert!(
+            preview.ends_with('…'),
+            "expected ellipsis suffix: {preview:?}"
+        );
+        assert!(
+            !preview.contains('é'),
+            "must not include the split codepoint"
+        );
     }
 
     #[test]

--- a/crates/headroom-proxy/src/bedrock/eventstream_to_sse.rs
+++ b/crates/headroom-proxy/src/bedrock/eventstream_to_sse.rs
@@ -238,7 +238,15 @@ pub fn header_value_preview(v: &HeaderValue) -> String {
             if s.len() <= 64 {
                 s.clone()
             } else {
-                let end = s.floor_char_boundary(64);
+                // Walk back from byte 64 to the last char boundary so we don't
+                // split a multi-byte codepoint. UTF-8 chars are at most 4 bytes,
+                // so this loop runs at most 3 times.
+                // (`str::floor_char_boundary` would do this in one call but it
+                // was only stabilised in Rust 1.91; headroom's MSRV is 1.80.)
+                let mut end = 64;
+                while !s.is_char_boundary(end) {
+                    end -= 1;
+                }
                 format!("{}…", &s[..end])
             }
         }

--- a/crates/headroom-proxy/src/bedrock/eventstream_to_sse.rs
+++ b/crates/headroom-proxy/src/bedrock/eventstream_to_sse.rs
@@ -238,7 +238,8 @@ pub fn header_value_preview(v: &HeaderValue) -> String {
             if s.len() <= 64 {
                 s.clone()
             } else {
-                format!("{}…", &s[..64])
+                let end = s.floor_char_boundary(64);
+                format!("{}…", &s[..end])
             }
         }
         HeaderValue::Bytes(b) => format!("[{} bytes]", b.len()),
@@ -393,5 +394,24 @@ mod tests {
             header_value_preview(&HeaderValue::Bytes(Bytes::from_static(&[1, 2, 3])))
                 .starts_with("[3 bytes")
         );
+    }
+
+    #[test]
+    fn header_value_preview_truncates_at_char_boundary() {
+        // 63 ASCII bytes + a 2-byte UTF-8 char (é = U+00E9) puts a char
+        // boundary at byte 63 but NOT at byte 64 — the old `&s[..64]`
+        // would panic here. floor_char_boundary(64) must return 63.
+        let s = "x".repeat(63) + "éfoo";
+        assert!(s.len() > 64);
+        let preview = header_value_preview(&HeaderValue::String(s));
+        assert!(preview.ends_with('…'), "expected ellipsis suffix: {preview:?}");
+        assert!(!preview.contains('é'), "must not include the split codepoint");
+    }
+
+    #[test]
+    fn header_value_preview_exact_boundary_not_truncated() {
+        // A string whose UTF-8 length is exactly 64 must not be truncated.
+        let s = "x".repeat(64);
+        assert_eq!(header_value_preview(&HeaderValue::String(s.clone())), s);
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `&s[..64]` byte-slice in `header_value_preview` with a char-boundary walk-back loop to prevent a runtime panic when byte 64 lands inside a multi-byte UTF-8 codepoint
- Adds two regression tests covering the char-boundary split case and the exact-64-byte case

## Root cause

`header_value_preview` in `crates/headroom-proxy/src/bedrock/eventstream_to_sse.rs` truncated long header strings for log output using a raw byte slice `&s[..64]`. Rust's `str` indexing requires the index to land on a char boundary; if a multi-byte codepoint (é, emoji, CJK, etc.) straddles byte 64 the call panics at runtime.

Reproducer: send a Bedrock request whose header contains 63 ASCII chars followed by `é` (U+00E9, 2 UTF-8 bytes). The preview function will attempt `&s[..64]` where byte 64 is the second byte of `é` — not a char boundary — and panic.

## Fix

```rust
// before
format!("{}…", &s[..64])

// after — walk back to the last char boundary
let mut end = 64;
while !s.is_char_boundary(end) {
    end -= 1;
}
format!("{}…", &s[..end])
```

UTF-8 codepoints are at most 4 bytes, so the loop runs at most 3 times. `str::floor_char_boundary` would do this in one call but it was only stabilised in Rust 1.91 — headroom's MSRV is 1.80, so we use `is_char_boundary` directly.

## Test plan

- [x] `cargo test -p headroom-proxy --lib bedrock::eventstream_to_sse` — 13/13 pass including both new tests
- [x] `cargo clippy -p headroom-proxy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)