### PR TITLE
test(init-e2e): expect mcp add in seq_claude_local install sequence

### DIFF
--- a/e2e/init/run.py
+++ b/e2e/init/run.py
@@ -92,9 +92,27 @@ def _verify_claude_local(ctx: CaseContext) -> None:
     claude_calls = [
         record["argv"] for record in _read_jsonl(ctx.shim_log) if record["tool"] == "claude"
     ]
+    # `init` auto-registers the headroom MCP server after the marketplace
+    # install (see d9d8972 — keeps `[Retrieve more: hash=…]` markers from
+    # being dead pointers for users who never ran `headroom mcp install`).
+    # The `-e HEADROOM_PROXY_URL=…` arg is only emitted when the proxy
+    # port differs from the 8787 default; this case uses --port 9011.
     expected = [
         ["plugin", "marketplace", "add", str(REPO_ROOT_IN_CONTAINER)],
         ["plugin", "install", "headroom@headroom-marketplace", "--scope", "local"],
+        [
+            "mcp",
+            "add",
+            "headroom",
+            "-s",
+            "user",
+            "-e",
+            "HEADROOM_PROXY_URL=http://127.0.0.1:9011",
+            "--",
+            "headroom",
+            "mcp",
+            "serve",
+        ],
     ]
     if claude_calls != expected:
         raise AssertionError(f"Unexpected Claude install commands: {claude_calls}")


### PR DESCRIPTION
d9d8972 wired auto-MCP registration into ``init`` so ``[Retrieve more: hash=…]`` markers stay live for users who never ran ``headroom mcp install`` separately, but the ``seq_claude_local`` e2e assertion was still pinned to the pre-MCP two-command sequence and failed in docker-native-e2e on main.

The ``-e HEADROOM_PROXY_URL=…`` arg is only emitted when the proxy port differs from the 8787 default; this case sets ``--port 9011``, so the env arg is included in the expected argv.

## Description

Brief description of changes and motivation.

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [ ] Manual testing performed

## Test Output

```
# Paste relevant test output here
pytest -v tests/test_your_feature.py
```

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.
