### PR TITLE
docs: clarify proxy-backed MCP setup

### DIFF
--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -117,6 +117,43 @@ headroom mcp uninstall
 headroom mcp serve --debug
 ```
 
+## MCP host configuration
+
+For MCP hosts that let you configure a local stdio server, point them at `headroom mcp serve`. If you also run the proxy, pass the proxy URL explicitly so retrieval and stats come from the intended proxy instance.
+
+```json
+{
+  "mcpServers": {
+    "headroom": {
+      "type": "stdio",
+      "command": "headroom",
+      "args": ["mcp", "serve", "--proxy-url", "http://127.0.0.1:8787"]
+    }
+  }
+}
+```
+
+For multiple proxy instances, register one stdio MCP server per proxy URL:
+
+```json
+{
+  "mcpServers": {
+    "headroom": {
+      "type": "stdio",
+      "command": "headroom",
+      "args": ["mcp", "serve", "--proxy-url", "http://127.0.0.1:8787"]
+    },
+    "headroom-azure": {
+      "type": "stdio",
+      "command": "headroom",
+      "args": ["mcp", "serve", "--proxy-url", "http://127.0.0.1:8788"]
+    }
+  }
+}
+```
+
+Do not assume that a running proxy exposes an HTTP MCP endpoint at `/mcp`. If `http://127.0.0.1:<port>/mcp` returns `404`, use the stdio configuration above.
+
 ## Cross-tool compatibility
 
 | Tool | MCP Support | Setup |


### PR DESCRIPTION
## Summary

Clarifies that MCP hosts can use `headroom mcp serve --proxy-url ...` as a stdio MCP server when they need proxy-backed retrieval/stats.

Adds examples for:

- one local proxy on `8787`
- multiple local proxy instances, including an Azure proxy on `8788`

Also notes that users should not assume the proxy exposes an HTTP MCP endpoint at `/mcp`; if that endpoint returns `404`, the stdio configuration should be used.

Closes #460.

## Testing

- Verified `headroom mcp serve --proxy-url http://127.0.0.1:8787` exposes `headroom_compress`, `headroom_retrieve`, `headroom_stats`
- Verified `headroom mcp serve --proxy-url http://127.0.0.1:8788` exposes the same tools
- Verified `/mcp` on both proxy ports returned `404` with `headroom 0.21.32`
