### PR TITLE
refactor(proxy): introduce RequestOutcome funnel; collapse 3 streaming finalizers

### DIFF
--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -236,10 +236,6 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
     async def google_cloudcode_stream_generate_content_v1(request: Request):
         return await proxy.handle_google_cloudcode_stream(request)
 
-    @app.post("/serving-endpoints/{model}/invocations")
-    async def databricks_invocations(request: Request, model: str):
-        return await proxy.handle_databricks_invocations(request, model)
-
     @app.get("/v1/models")
     async def list_models(request: Request):
         chatgpt_response = await _handle_chatgpt_model_metadata(

--- a/headroom/proxy/auth_mode.py
+++ b/headroom/proxy/auth_mode.py
@@ -180,4 +180,76 @@ def classify_auth_mode(headers: Mapping[str, Any] | Any) -> AuthMode:
     return AuthMode.PAYG
 
 
-__all__ = ["AuthMode", "SUBSCRIPTION_UA_PREFIXES", "classify_auth_mode"]
+# Client (harness) identification — maps a User-Agent substring to a
+# short normalized client name. The dashboard / `headroom perf` use
+# this to slice traffic by harness ("aider is 30% of cache writes",
+# "codex p99 latency vs claude-code", etc).
+#
+# Adding a new client: one line. Same surface as
+# :data:`SUBSCRIPTION_UA_PREFIXES`. The classifier is intentionally
+# substring-based (not regex) so a tuple of literals stays the
+# extension point.
+CLIENT_UA_MAP: tuple[tuple[str, str], ...] = (
+    # Anthropic ecosystem
+    ("claude-code/", "claude-code"),
+    ("claude-cli/", "claude-code"),
+    ("claude-vscode/", "claude-vscode"),
+    ("anthropic-cli/", "anthropic-cli"),
+    # OpenAI ecosystem
+    ("codex-cli/", "codex"),
+    # Editors / IDEs
+    ("cursor/", "cursor"),
+    ("zed/", "zed"),
+    # Other AI coding harnesses
+    ("aider/", "aider"),
+    ("droid/", "droid"),
+    ("opencode/", "opencode"),
+    ("github-copilot/", "copilot"),
+    # Google's experimental harness
+    ("antigravity/", "antigravity"),
+)
+
+
+def classify_client(headers: Mapping[str, Any] | Any) -> str | None:
+    """Identify the client harness (Codex / Claude Code / aider / etc).
+
+    Decision order:
+
+    1. **``X-Client`` header** (explicit override) — clients that
+       know they're talking to Headroom can self-identify with a
+       short name. Trimmed, lowercased. Wins over UA matching.
+    2. **User-Agent substring match** against :data:`CLIENT_UA_MAP`
+       — covers the unmodified-client case. Substring, not prefix,
+       because some clients prepend a corporate-wrapper UA before
+       their own.
+    3. **None** when neither produces a hit. ``None`` is the loud
+       "unknown harness" signal; downstream consumers can group
+       these as "unidentified" rather than silently bucketing them
+       into a default.
+
+    Returns ``str | None`` rather than a string default so future
+    code can distinguish "no client identified" from "client is the
+    empty string". The :class:`RequestOutcome` field has the same
+    type for the same reason.
+    """
+    # 1. Explicit override
+    explicit = _header_get(headers, "x-client").strip().lower()
+    if explicit:
+        return explicit
+    # 2. User-Agent substring match
+    ua_lower = _header_get(headers, "user-agent").lower()
+    if not ua_lower:
+        return None
+    for needle, name in CLIENT_UA_MAP:
+        if needle in ua_lower:
+            return name
+    return None
+
+
+__all__ = [
+    "AuthMode",
+    "CLIENT_UA_MAP",
+    "SUBSCRIPTION_UA_PREFIXES",
+    "classify_auth_mode",
+    "classify_client",
+]

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -25,6 +25,7 @@ import httpx
 
 from headroom.pipeline import PipelineStage, summarize_routing_markers
 from headroom.proxy.auth_mode import classify_auth_mode
+from headroom.proxy.outcome import RequestOutcome
 
 logger = logging.getLogger("headroom.proxy")
 
@@ -352,7 +353,6 @@ class AnthropicHandlerMixin:
 
         from headroom.cache.compression_store import get_compression_store
         from headroom.ccr import CCRToolInjector
-        from headroom.proxy.cost import _summarize_transforms
         from headroom.proxy.helpers import (
             MAX_MESSAGE_ARRAY_LENGTH,
             MAX_REQUEST_BODY_SIZE,
@@ -361,7 +361,6 @@ class AnthropicHandlerMixin:
             compute_turn_id,
             read_request_json_with_bytes,
         )
-        from headroom.proxy.models import RequestLog
         from headroom.proxy.modes import is_cache_mode, is_token_mode
         from headroom.tokenizers import get_tokenizer
         from headroom.utils import extract_user_query
@@ -700,14 +699,28 @@ class AnthropicHandlerMixin:
                     )
                     optimization_latency = (time.time() - start_time) * 1000
 
-                    await self.metrics.record_request(
-                        provider="anthropic",
-                        model=model,
-                        input_tokens=0,
-                        output_tokens=0,
-                        tokens_saved=0,  # Savings already counted when response was cached
-                        latency_ms=optimization_latency,
-                        cached=True,
+                    # Response-cache hit: response body came from
+                    # Headroom's semantic cache, not the upstream
+                    # provider. ``from_response_cache=True`` is a
+                    # distinct signal from `cache_read_tokens > 0`
+                    # (which means upstream-prompt-cache hit). Dashboards
+                    # can split the two; the funnel collapses them into
+                    # the single `cached` boolean for Prometheus.
+                    await self._record_request_outcome(
+                        RequestOutcome(
+                            request_id=request_id,
+                            provider="anthropic",
+                            model=model,
+                            original_tokens=0,
+                            optimized_tokens=0,
+                            output_tokens=0,
+                            tokens_saved=0,
+                            attempted_input_tokens=0,
+                            from_response_cache=True,
+                            total_latency_ms=optimization_latency,
+                            overhead_ms=optimization_latency,
+                            num_messages=len(messages),
+                        )
                     )
 
                     # Remove compression headers from cached response
@@ -1610,50 +1623,36 @@ class AnthropicHandlerMixin:
                             )
                         except Exception:
                             attempted_input_tokens = original_tokens
-                        await self.metrics.record_request(
-                            provider=_backend_name,
-                            model=model,
-                            input_tokens=optimized_tokens,
-                            output_tokens=output_tokens,
-                            tokens_saved=tokens_saved,
-                            latency_ms=total_latency,
-                            cached=False,
-                            overhead_ms=optimization_latency,
-                            pipeline_timing=pipeline_timing,
-                            attempted_input_tokens=attempted_input_tokens,
-                        )
-
-                        if self.cost_tracker:
-                            self.cost_tracker.record_tokens(model, tokens_saved, optimized_tokens)
-
-                        # Log request
-                        if self.logger:
-                            self.logger.log(
-                                RequestLog(
-                                    request_id=request_id,
-                                    timestamp=datetime.now().isoformat(),
-                                    provider=_backend_name,
-                                    model=model,
-                                    input_tokens_original=original_tokens,
-                                    input_tokens_optimized=optimized_tokens,
-                                    output_tokens=output_tokens,
-                                    tokens_saved=tokens_saved,
-                                    savings_percent=(tokens_saved / original_tokens * 100)
-                                    if original_tokens > 0
-                                    else 0,
-                                    optimization_latency_ms=optimization_latency,
-                                    total_latency_ms=total_latency,
-                                    tags=tags,
-                                    cache_hit=False,
-                                    transforms_applied=transforms_applied,
-                                    request_messages=body.get("messages")
-                                    if self.config.log_full_messages
-                                    else None,
-                                    turn_id=compute_turn_id(
-                                        model, body.get("system"), body.get("messages")
-                                    ),
-                                )
+                        # Backend (Bedrock / Vertex) non-streaming.
+                        # Cache metrics aren't extracted from the backend
+                        # response here yet — that's a follow-up. The
+                        # funnel passes 0s for the cache fields, which
+                        # is the same observable behaviour as the
+                        # pre-refactor code (which also omitted them).
+                        await self._record_request_outcome(
+                            RequestOutcome(
+                                request_id=request_id,
+                                provider=_backend_name,
+                                model=model,
+                                original_tokens=original_tokens,
+                                optimized_tokens=optimized_tokens,
+                                output_tokens=output_tokens,
+                                tokens_saved=tokens_saved,
+                                attempted_input_tokens=attempted_input_tokens,
+                                total_latency_ms=total_latency,
+                                overhead_ms=optimization_latency,
+                                pipeline_timing=pipeline_timing,
+                                transforms_applied=tuple(transforms_applied),
+                                num_messages=len(body.get("messages", [])),
+                                tags=tags,
+                                turn_id=compute_turn_id(
+                                    model, body.get("system"), body.get("messages")
+                                ),
+                                request_messages=body.get("messages")
+                                if self.config.log_full_messages
+                                else None,
                             )
+                        )
 
                         return JSONResponse(
                             status_code=backend_response.status_code,
@@ -2087,18 +2086,6 @@ class AnthropicHandlerMixin:
                         original_messages=next_original_messages,
                     )
 
-                    if self.cost_tracker:
-                        self.cost_tracker.record_tokens(
-                            model,
-                            tokens_saved,
-                            optimized_tokens,
-                            cache_read_tokens=cr_tokens,
-                            cache_write_tokens=cw_tokens,
-                            cache_write_5m_tokens=cw_5m_tokens,
-                            cache_write_1h_tokens=cw_1h_tokens,
-                            uncached_tokens=uncached_input_tokens,
-                        )
-
                     # Cache response
                     if self.cache and response.status_code == 200:
                         await self.cache.set(
@@ -2109,26 +2096,10 @@ class AnthropicHandlerMixin:
                             tokens_saved=tokens_saved,
                         )
 
-                    # Record metrics — use optimized_tokens (what we sent), not API's
-                    # input_tokens which is just the non-cached portion with prompt caching
-                    await self.metrics.record_request(
-                        provider="anthropic",
-                        model=model,
-                        input_tokens=optimized_tokens,
-                        output_tokens=output_tokens,
-                        tokens_saved=tokens_saved,
-                        latency_ms=total_latency,
-                        overhead_ms=optimization_latency,
-                        pipeline_timing=pipeline_timing,
-                        waste_signals=waste_signals_dict,
-                        cache_read_tokens=cr_tokens,
-                        cache_write_tokens=cw_tokens,
-                        cache_write_5m_tokens=cw_5m_tokens,
-                        cache_write_1h_tokens=cw_1h_tokens,
-                        uncached_input_tokens=uncached_input_tokens,
-                    )
-
-                    # Subscription tracker: update headroom contribution counters
+                    # Subscription tracker: update headroom contribution
+                    # counters. Provider-specific OAuth/subscription
+                    # accounting — stays outside the funnel (different
+                    # concern, only fires for Bearer-not-sk-ant tokens).
                     if _auth_header.startswith("Bearer ") and not _auth_header.startswith(
                         "Bearer sk-ant-api"
                     ):
@@ -2144,56 +2115,53 @@ class AnthropicHandlerMixin:
                                 tokens_saved_cache_reads=cr_tokens,
                             )
 
-                    # Log request
-                    if self.logger:
-                        self.logger.log(
-                            RequestLog(
-                                request_id=request_id,
-                                timestamp=datetime.now().isoformat(),
-                                provider="anthropic",
-                                model=model,
-                                input_tokens_original=original_tokens,
-                                input_tokens_optimized=optimized_tokens,
-                                output_tokens=output_tokens,
-                                tokens_saved=tokens_saved,
-                                savings_percent=(tokens_saved / original_tokens * 100)
-                                if original_tokens > 0
-                                else 0,
-                                optimization_latency_ms=optimization_latency,
-                                total_latency_ms=total_latency,
-                                tags=tags,
-                                cache_hit=cache_hit,
-                                transforms_applied=transforms_applied,
-                                waste_signals=waste_signals_dict,
-                                request_messages=messages
-                                if self.config.log_full_messages
-                                else None,
-                                turn_id=compute_turn_id(
-                                    model, body.get("system"), body.get("messages")
-                                ),
-                            )
+                    # The pre-refactor PERF emit (above) read raw usage
+                    # off ``resp_usage`` instead of trusting cr_tokens /
+                    # cw_tokens. Both paths land on identical numbers
+                    # (extraction happens just above the cost_tracker
+                    # call), so the funnel uses the already-computed
+                    # values for consistency. Pre-refactor's
+                    # ``cache_hit`` local was correctly derived from
+                    # cache_read>0; the funnel re-derives via the
+                    # outcome property — same result.
+                    #
+                    # ``attempted_input_tokens`` was MISSING from the
+                    # pre-refactor record_request call here (one of the
+                    # 7-of-18 sites the P0 audit flagged). The funnel
+                    # forces it to a value — using
+                    # ``optimized_tokens + tokens_saved`` as the
+                    # fallback denominator, same as the streaming path
+                    # uses (see _finalize_stream_response). Dashboards
+                    # that were showing 0% active-savings on non-
+                    # streaming Anthropic traffic will now show the
+                    # correct ratio.
+                    await self._record_request_outcome(
+                        RequestOutcome(
+                            request_id=request_id,
+                            provider="anthropic",
+                            model=model,
+                            original_tokens=original_tokens,
+                            optimized_tokens=optimized_tokens,
+                            output_tokens=output_tokens,
+                            tokens_saved=tokens_saved,
+                            attempted_input_tokens=optimized_tokens + tokens_saved,
+                            cache_read_tokens=cr_tokens,
+                            cache_write_tokens=cw_tokens,
+                            cache_write_5m_tokens=cw_5m_tokens,
+                            cache_write_1h_tokens=cw_1h_tokens,
+                            uncached_input_tokens=uncached_input_tokens,
+                            total_latency_ms=total_latency,
+                            overhead_ms=optimization_latency,
+                            pipeline_timing=pipeline_timing,
+                            waste_signals=waste_signals_dict,
+                            transforms_applied=tuple(transforms_applied),
+                            num_messages=len(messages),
+                            tags=tags,
+                            turn_id=compute_turn_id(
+                                model, body.get("system"), body.get("messages")
+                            ),
+                            request_messages=messages if self.config.log_full_messages else None,
                         )
-
-                    # Structured perf log line for `headroom perf` analysis
-                    num_msgs = len(messages)
-                    resp_usage = resp_json.get("usage", {}) if resp_json else {}
-                    cr = resp_usage.get("cache_read_input_tokens", 0)
-                    cw = resp_usage.get("cache_creation_input_tokens", 0)
-                    chp = round(cr / (cr + cw) * 100) if (cr + cw) > 0 else 0
-                    timing_str = (
-                        " ".join(f"{k}={v:.0f}ms" for k, v in pipeline_timing.items())
-                        if pipeline_timing
-                        else ""
-                    )
-                    logger.info(
-                        f"[{request_id}] PERF "
-                        f"model={model} msgs={num_msgs} "
-                        f"tok_before={original_tokens} tok_after={optimized_tokens} "
-                        f"tok_saved={tokens_saved} "
-                        f"cache_read={cr} cache_write={cw} cache_hit_pct={chp} "
-                        f"opt_ms={optimization_latency:.0f} "
-                        f"transforms={_summarize_transforms(transforms_applied)}"
-                        f"{' timing=' + timing_str if timing_str else ''}"
                     )
 
                     # Remove compression headers since httpx already decompressed the response
@@ -2509,16 +2477,27 @@ class AnthropicHandlerMixin:
                 path_for_log="/v1/messages/batches",
             )
 
-            # Record metrics
-            await self.metrics.record_request(
-                provider="anthropic",
-                model="batch",
-                input_tokens=total_optimized_tokens,
-                output_tokens=0,
-                tokens_saved=total_tokens_saved,
-                latency_ms=optimization_latency,
-                overhead_ms=optimization_latency,
-                pipeline_timing=pipeline_timing,
+            # Batch create: tokens accumulated across all requests in
+            # the batch. The funnel records it as a single observation
+            # under the synthetic model name "batch" — same as
+            # pre-refactor, just routed through the canonical path so
+            # batch traffic appears in RequestLog + PERF (it didn't
+            # before — sites 4/5/6 were "metrics-only").
+            await self._record_request_outcome(
+                RequestOutcome(
+                    request_id=request_id,
+                    provider="anthropic",
+                    model="batch",
+                    original_tokens=total_original_tokens,
+                    optimized_tokens=total_optimized_tokens,
+                    output_tokens=0,
+                    tokens_saved=total_tokens_saved,
+                    attempted_input_tokens=total_optimized_tokens + total_tokens_saved,
+                    total_latency_ms=optimization_latency,
+                    overhead_ms=optimization_latency,
+                    pipeline_timing=pipeline_timing,
+                    num_messages=len(compressed_requests),
+                )
             )
 
             # Log compression stats
@@ -2588,6 +2567,7 @@ class AnthropicHandlerMixin:
         """
         from fastapi.responses import Response
 
+        request_id = await self._next_request_id()
         start_time = time.time()
         path = request.url.path
         url = f"{self.ANTHROPIC_API_URL}{path}"
@@ -2618,15 +2598,22 @@ class AnthropicHandlerMixin:
             content=body,
         )
 
-        # Track metrics
+        # Batch passthrough: no compression, no transforms — but we
+        # still record the request so dashboards see the upstream call
+        # happened. Same funnel as the other 5 anthropic sites.
         latency_ms = (time.time() - start_time) * 1000
-        await self.metrics.record_request(
-            provider="anthropic",
-            model="passthrough:batches",
-            input_tokens=0,
-            output_tokens=0,
-            tokens_saved=0,
-            latency_ms=latency_ms,
+        await self._record_request_outcome(
+            RequestOutcome(
+                request_id=request_id,
+                provider="anthropic",
+                model="passthrough:batches",
+                original_tokens=0,
+                optimized_tokens=0,
+                output_tokens=0,
+                tokens_saved=0,
+                attempted_input_tokens=0,
+                total_latency_ms=latency_ms,
+            )
         )
 
         # Remove compression headers
@@ -2699,6 +2686,7 @@ class AnthropicHandlerMixin:
 
         from headroom.ccr import BatchResultProcessor, get_batch_context_store
 
+        request_id = await self._next_request_id()
         start_time = time.time()
 
         # Forward request to get raw results
@@ -2785,15 +2773,22 @@ class AnthropicHandlerMixin:
 
         processed_content = "\n".join(processed_lines)
 
-        # Track metrics
+        # Batch results, post-CCR processing. Like the other batch
+        # sites, no token accounting but we record the request so it's
+        # visible in dashboards + headroom perf.
         latency_ms = (time.time() - start_time) * 1000
-        await self.metrics.record_request(
-            provider="anthropic",
-            model="batch:ccr-processed",
-            input_tokens=0,
-            output_tokens=0,
-            tokens_saved=0,
-            latency_ms=latency_ms,
+        await self._record_request_outcome(
+            RequestOutcome(
+                request_id=request_id,
+                provider="anthropic",
+                model="batch:ccr-processed",
+                original_tokens=0,
+                optimized_tokens=0,
+                output_tokens=0,
+                tokens_saved=0,
+                attempted_input_tokens=0,
+                total_latency_ms=latency_ms,
+            )
         )
 
         return Response(

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 import httpx
 
 from headroom.pipeline import PipelineStage, summarize_routing_markers
-from headroom.proxy.auth_mode import classify_auth_mode
+from headroom.proxy.auth_mode import classify_auth_mode, classify_client
 from headroom.proxy.outcome import RequestOutcome
 
 logger = logging.getLogger("headroom.proxy")
@@ -589,6 +589,10 @@ class AnthropicHandlerMixin:
             # body is undecipherable → 502.
             headers.pop("accept-encoding", None)
             tags = self._extract_tags(headers)
+            # Identify the harness (codex / claude-code / aider / etc.)
+            # from User-Agent or X-Client. Surfaced via the funnel into
+            # PERF logs and RequestLog.tags — see RequestOutcome.client.
+            client = classify_client(headers)
             # PR-A5 (P5-49): strip internal x-headroom-* from upstream-bound
             # headers AFTER `_extract_tags` reads them. Inbound bypass gating
             # uses `request.headers.get(...)` directly above; memory user-id
@@ -720,6 +724,7 @@ class AnthropicHandlerMixin:
                             total_latency_ms=optimization_latency,
                             overhead_ms=optimization_latency,
                             num_messages=len(messages),
+                            client=client,
                         )
                     )
 
@@ -1645,6 +1650,7 @@ class AnthropicHandlerMixin:
                                 transforms_applied=tuple(transforms_applied),
                                 num_messages=len(body.get("messages", [])),
                                 tags=tags,
+                                client=client,
                                 turn_id=compute_turn_id(
                                     model, body.get("system"), body.get("messages")
                                 ),
@@ -2157,6 +2163,7 @@ class AnthropicHandlerMixin:
                             transforms_applied=tuple(transforms_applied),
                             num_messages=len(messages),
                             tags=tags,
+                            client=client,
                             turn_id=compute_turn_id(
                                 model, body.get("system"), body.get("messages")
                             ),
@@ -2330,6 +2337,7 @@ class AnthropicHandlerMixin:
         headers = dict(request.headers.items())
         headers.pop("host", None)
         headers.pop("content-length", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -2497,6 +2505,7 @@ class AnthropicHandlerMixin:
                     overhead_ms=optimization_latency,
                     pipeline_timing=pipeline_timing,
                     num_messages=len(compressed_requests),
+                    client=client,
                 )
             )
 
@@ -2578,6 +2587,7 @@ class AnthropicHandlerMixin:
 
         headers = dict(request.headers.items())
         headers.pop("host", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -2613,6 +2623,7 @@ class AnthropicHandlerMixin:
                 tokens_saved=0,
                 attempted_input_tokens=0,
                 total_latency_ms=latency_ms,
+                client=client,
             )
         )
 
@@ -2697,6 +2708,7 @@ class AnthropicHandlerMixin:
 
         headers = dict(request.headers.items())
         headers.pop("host", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -2788,6 +2800,7 @@ class AnthropicHandlerMixin:
                 tokens_saved=0,
                 attempted_input_tokens=0,
                 total_latency_ms=latency_ms,
+                client=client,
             )
         )
 

--- a/headroom/proxy/handlers/batch.py
+++ b/headroom/proxy/handlers/batch.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from fastapi import Request
     from fastapi.responses import Response
 
+from headroom.proxy.auth_mode import classify_client
 from headroom.proxy.outcome import RequestOutcome
 
 logger = logging.getLogger("headroom.proxy")
@@ -101,6 +102,7 @@ class BatchHandlerMixin:
         headers = dict(request.headers.items())
         headers.pop("host", None)
         headers.pop("content-length", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -280,6 +282,7 @@ class BatchHandlerMixin:
                     total_latency_ms=optimization_latency,
                     overhead_ms=optimization_latency,
                     pipeline_timing=pipeline_timing,
+                    client=client,
                 )
             )
 
@@ -349,6 +352,7 @@ class BatchHandlerMixin:
         headers = dict(request.headers.items())
         headers.pop("host", None)
         headers.pop("content-length", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -428,6 +432,7 @@ class BatchHandlerMixin:
                 tokens_saved=0,
                 attempted_input_tokens=0,
                 total_latency_ms=latency_ms,
+                client=client,
             )
         )
 
@@ -465,6 +470,7 @@ class BatchHandlerMixin:
 
         headers = dict(request.headers.items())
         headers.pop("host", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -509,6 +515,7 @@ class BatchHandlerMixin:
                 tokens_saved=0,
                 attempted_input_tokens=0,
                 total_latency_ms=latency_ms,
+                client=client,
             )
         )
 
@@ -604,6 +611,7 @@ class BatchHandlerMixin:
 
         headers = dict(request.headers.items())
         headers.pop("host", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -725,6 +733,7 @@ class BatchHandlerMixin:
                 tokens_saved=0,
                 attempted_input_tokens=0,
                 total_latency_ms=latency_ms,
+                client=client,
             )
         )
 
@@ -801,6 +810,7 @@ class BatchHandlerMixin:
         headers = dict(request.headers.items())
         headers.pop("host", None)
         headers.pop("content-length", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -944,6 +954,7 @@ class BatchHandlerMixin:
                     attempted_input_tokens=stats["total_compressed_tokens"]
                     + stats["total_tokens_saved"],
                     total_latency_ms=total_latency,
+                    client=client,
                 )
             )
 

--- a/headroom/proxy/handlers/batch.py
+++ b/headroom/proxy/handlers/batch.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from fastapi import Request
     from fastapi.responses import Response
 
+from headroom.proxy.outcome import RequestOutcome
+
 logger = logging.getLogger("headroom.proxy")
 
 
@@ -262,16 +264,23 @@ class BatchHandlerMixin:
         try:
             response = await self._retry_request("POST", url, headers, body)
 
-            # Record metrics
-            await self.metrics.record_request(
-                provider="google",
-                model=f"batch:{model}",
-                input_tokens=total_optimized_tokens,
-                output_tokens=0,
-                tokens_saved=total_tokens_saved,
-                latency_ms=optimization_latency,
-                overhead_ms=optimization_latency,
-                pipeline_timing=pipeline_timing,
+            # Google batch create — funnel records via the canonical
+            # path; cache fields stay 0 (Google batches don't expose
+            # cache stats in the same shape).
+            await self._record_request_outcome(
+                RequestOutcome(
+                    request_id=request_id,
+                    provider="google",
+                    model=f"batch:{model}",
+                    original_tokens=total_original_tokens,
+                    optimized_tokens=total_optimized_tokens,
+                    output_tokens=0,
+                    tokens_saved=total_tokens_saved,
+                    attempted_input_tokens=total_optimized_tokens + total_tokens_saved,
+                    total_latency_ms=optimization_latency,
+                    overhead_ms=optimization_latency,
+                    pipeline_timing=pipeline_timing,
+                )
             )
 
             # Log compression stats
@@ -403,15 +412,23 @@ class BatchHandlerMixin:
             content=body_content,
         )
 
-        # Track metrics
+        # Google batch (Files API forward) — no compression, just
+        # upstream forward. Funnel records via zero defaults so the
+        # request shows up in dashboards even with no token activity.
         latency_ms = (time.time() - start_time) * 1000
-        await self.metrics.record_request(
-            provider="google",
-            model=f"passthrough:batch:{model}",
-            input_tokens=0,
-            output_tokens=0,
-            tokens_saved=0,
-            latency_ms=latency_ms,
+        request_id_files = await self._next_request_id()
+        await self._record_request_outcome(
+            RequestOutcome(
+                request_id=request_id_files,
+                provider="google",
+                model=f"passthrough:batch:{model}",
+                original_tokens=0,
+                optimized_tokens=0,
+                output_tokens=0,
+                tokens_saved=0,
+                attempted_input_tokens=0,
+                total_latency_ms=latency_ms,
+            )
         )
 
         response_headers = dict(response.headers)
@@ -476,15 +493,23 @@ class BatchHandlerMixin:
             content=body,
         )
 
-        # Track metrics
+        # Google batch passthrough — list/get/cancel forwarded with
+        # no compression work. Funnel records the request so it's
+        # visible in dashboards.
         latency_ms = (time.time() - start_time) * 1000
-        await self.metrics.record_request(
-            provider="google",
-            model="passthrough:batches",
-            input_tokens=0,
-            output_tokens=0,
-            tokens_saved=0,
-            latency_ms=latency_ms,
+        request_id = await self._next_request_id()
+        await self._record_request_outcome(
+            RequestOutcome(
+                request_id=request_id,
+                provider="google",
+                model="passthrough:batches",
+                original_tokens=0,
+                optimized_tokens=0,
+                output_tokens=0,
+                tokens_saved=0,
+                attempted_input_tokens=0,
+                total_latency_ms=latency_ms,
+            )
         )
 
         response_headers = dict(response.headers)
@@ -685,15 +710,22 @@ class BatchHandlerMixin:
                     f"({p.continuation_rounds} continuation rounds)"
                 )
 
-        # Track metrics
+        # Google batch results with CCR processing — funnel records
+        # via zero defaults.
         latency_ms = (time.time() - start_time) * 1000
-        await self.metrics.record_request(
-            provider="google",
-            model="batch:ccr-processed",
-            input_tokens=0,
-            output_tokens=0,
-            tokens_saved=0,
-            latency_ms=latency_ms,
+        request_id = await self._next_request_id()
+        await self._record_request_outcome(
+            RequestOutcome(
+                request_id=request_id,
+                provider="google",
+                model="batch:ccr-processed",
+                original_tokens=0,
+                optimized_tokens=0,
+                output_tokens=0,
+                tokens_saved=0,
+                attempted_input_tokens=0,
+                total_latency_ms=latency_ms,
+            )
         )
 
         return JSONResponse(content=response_data, status_code=200)
@@ -897,14 +929,22 @@ class BatchHandlerMixin:
                 f"in {total_latency:.0f}ms"
             )
 
-            # Record metrics
-            await self.metrics.record_request(
-                provider="openai",
-                model="batch",
-                input_tokens=stats["total_compressed_tokens"],
-                output_tokens=0,
-                tokens_saved=stats["total_tokens_saved"],
-                latency_ms=total_latency,
+            # OpenAI batch create — funnel records via the canonical
+            # path; `model="batch"` matches the synthetic naming used
+            # by the Anthropic batch handlers.
+            await self._record_request_outcome(
+                RequestOutcome(
+                    request_id=request_id,
+                    provider="openai",
+                    model="batch",
+                    original_tokens=stats["total_original_tokens"],
+                    optimized_tokens=stats["total_compressed_tokens"],
+                    output_tokens=0,
+                    tokens_saved=stats["total_tokens_saved"],
+                    attempted_input_tokens=stats["total_compressed_tokens"]
+                    + stats["total_tokens_saved"],
+                    total_latency_ms=total_latency,
+                )
             )
 
             # Return response with compression info in headers

--- a/headroom/proxy/handlers/gemini.py
+++ b/headroom/proxy/handlers/gemini.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from fastapi import Request
     from fastapi.responses import JSONResponse, Response, StreamingResponse
 
+from headroom.proxy.outcome import RequestOutcome
+
 logger = logging.getLogger("headroom.proxy")
 
 DEFAULT_CLOUDCODE_API_URL = "https://cloudcode-pa.googleapis.com"
@@ -466,35 +468,39 @@ class GeminiHandlerMixin:
 
                 uncached_input_tokens = max(0, total_input_tokens - cache_read_tokens)
 
-                if self.cost_tracker:
-                    self.cost_tracker.record_tokens(
-                        model,
-                        tokens_saved,
-                        optimized_tokens,
-                        cache_read_tokens=cache_read_tokens,
-                        uncached_tokens=uncached_input_tokens,
-                    )
-
                 # Eligible-tracking is TODO for Gemini; pass the full
                 # pre-compression request size as the fallback denominator.
                 # This makes Gemini's contribution to the aggregate
                 # active_savings_percent equal its whole-request ratio —
                 # not ideal but coherent until per-part live-zone
                 # tracking exists for this provider.
-                attempted_input_tokens = total_input_tokens + tokens_saved
-                await self.metrics.record_request(
+                #
+                # Gemini reports read-side context-cache only via
+                # ``cachedContentTokenCount``. There is no write counter
+                # in the Gemini response; cache writes happen out-of-band
+                # via the explicit Cache API. cache_write_* fields on the
+                # outcome stay at their 0 defaults — the dataclass
+                # handles "this provider doesn't have this concept"
+                # without per-handler conditionals.
+                outcome = RequestOutcome(
+                    request_id=request_id,
                     provider="gemini",
                     model=model,
-                    input_tokens=total_input_tokens,
+                    original_tokens=original_tokens,
+                    optimized_tokens=total_input_tokens,
                     output_tokens=output_tokens,
                     tokens_saved=tokens_saved,
-                    latency_ms=total_latency,
-                    overhead_ms=optimization_latency,
-                    waste_signals=waste_signals_dict,
+                    attempted_input_tokens=total_input_tokens + tokens_saved,
                     cache_read_tokens=cache_read_tokens,
                     uncached_input_tokens=uncached_input_tokens,
-                    attempted_input_tokens=attempted_input_tokens,
+                    total_latency_ms=total_latency,
+                    overhead_ms=optimization_latency,
+                    waste_signals=waste_signals_dict,
+                    transforms_applied=tuple(transforms_applied),
+                    num_messages=len(body.get("contents", [])),
+                    tags=tags or {},
                 )
+                await self._record_request_outcome(outcome)
 
                 if tokens_saved > 0:
                     logger.info(
@@ -902,15 +908,22 @@ class GeminiHandlerMixin:
 
             # Fallback denominator (see comment on the main gemini
             # record_request site) — pre-comp request size.
-            attempted_input_tokens = compressed_tokens + tokens_saved
-            await self.metrics.record_request(
-                provider="gemini",
-                model=model,
-                input_tokens=compressed_tokens,
-                output_tokens=0,
-                tokens_saved=tokens_saved,
-                latency_ms=total_latency,
-                attempted_input_tokens=attempted_input_tokens,
+            # countTokens is a sizing helper; it never generates output
+            # tokens and never touches cache. The funnel handles the
+            # "nothing to report" shape with all-zero cache defaults.
+            await self._record_request_outcome(
+                RequestOutcome(
+                    request_id=request_id,
+                    provider="gemini",
+                    model=model,
+                    original_tokens=original_tokens,
+                    optimized_tokens=compressed_tokens,
+                    output_tokens=0,
+                    tokens_saved=tokens_saved,
+                    attempted_input_tokens=compressed_tokens + tokens_saved,
+                    total_latency_ms=total_latency,
+                    transforms_applied=tuple(transforms_applied),
+                )
             )
 
             if tokens_saved > 0:

--- a/headroom/proxy/handlers/gemini.py
+++ b/headroom/proxy/handlers/gemini.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from fastapi import Request
     from fastapi.responses import JSONResponse, Response, StreamingResponse
 
+from headroom.proxy.auth_mode import classify_client
 from headroom.proxy.outcome import RequestOutcome
 
 logger = logging.getLogger("headroom.proxy")
@@ -193,6 +194,7 @@ class GeminiHandlerMixin:
         headers.pop("host", None)
         headers.pop("content-length", None)
         tags = self._extract_tags(headers)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* from upstream-bound
         # headers AFTER `_extract_tags` reads them. Memory user-id reads
         # `request.headers` below.
@@ -499,6 +501,7 @@ class GeminiHandlerMixin:
                     transforms_applied=tuple(transforms_applied),
                     num_messages=len(body.get("contents", [])),
                     tags=tags or {},
+                    client=client,
                 )
                 await self._record_request_outcome(outcome)
 
@@ -591,6 +594,8 @@ class GeminiHandlerMixin:
         headers.pop("content-length", None)
         headers.pop("accept-encoding", None)
         tags = self._extract_tags(headers)
+        # Note: streaming handlers delegate to _stream_response, which
+        # does its own classify_client. No need to compute here.
         is_antigravity = self._is_cloudcode_antigravity_request(body, headers)
         # PR-A5 (P5-49): strip internal x-headroom-* from upstream-bound headers
         # AFTER `_extract_tags` and `is_cloudcode_antigravity` reads.
@@ -718,6 +723,8 @@ class GeminiHandlerMixin:
         headers.pop("host", None)
         headers.pop("content-length", None)
         tags = self._extract_tags(headers)
+        # Streaming variant — delegates to _stream_response which
+        # classifies the client itself from headers.
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -802,6 +809,7 @@ class GeminiHandlerMixin:
         headers = dict(request.headers.items())
         headers.pop("host", None)
         headers.pop("content-length", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -923,6 +931,7 @@ class GeminiHandlerMixin:
                     attempted_input_tokens=compressed_tokens + tokens_saved,
                     total_latency_ms=total_latency,
                     transforms_applied=tuple(transforms_applied),
+                    client=client,
                 )
             )
 

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -38,7 +38,7 @@ import httpx
 
 from headroom.copilot_auth import apply_copilot_api_auth, build_copilot_upstream_url
 from headroom.pipeline import PipelineStage, summarize_routing_markers
-from headroom.proxy.auth_mode import classify_auth_mode
+from headroom.proxy.auth_mode import classify_auth_mode, classify_client
 from headroom.proxy.cost import _summarize_transforms
 from headroom.proxy.outcome import RequestOutcome
 
@@ -1226,6 +1226,7 @@ class OpenAIHandlerMixin:
         # if httpx lacks brotli support the response body is undecipherable → 502.
         headers.pop("accept-encoding", None)
         tags = self._extract_tags(headers)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* from upstream-bound
         # headers AFTER `_extract_tags` reads them. Inbound bypass gating
         # uses `request.headers.get(...)` above; memory user-id reads
@@ -1311,6 +1312,7 @@ class OpenAIHandlerMixin:
                         from_response_cache=True,
                         total_latency_ms=_cache_hit_latency,
                         num_messages=len(messages),
+                        client=client,
                     )
                 )
 
@@ -1826,6 +1828,7 @@ class OpenAIHandlerMixin:
                             request_messages=body.get("messages")
                             if getattr(self.config, "log_full_messages", False)
                             else None,
+                            client=client,
                         )
                     )
 
@@ -2142,6 +2145,7 @@ class OpenAIHandlerMixin:
                         request_messages=body.get("messages")
                         if getattr(self.config, "log_full_messages", False)
                         else None,
+                        client=client,
                     )
                 )
 
@@ -2299,6 +2303,7 @@ class OpenAIHandlerMixin:
         # if httpx lacks brotli support the response body is undecipherable → 502.
         headers.pop("accept-encoding", None)
         tags = self._extract_tags(headers)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* from upstream-bound
         # headers AFTER `_extract_tags` reads them. Memory user-id reads
         # `request.headers` below.
@@ -2847,6 +2852,7 @@ class OpenAIHandlerMixin:
                         request_messages=messages
                         if getattr(self.config, "log_full_messages", False)
                         else None,
+                        client=client,
                     )
                 )
 
@@ -2922,6 +2928,9 @@ class OpenAIHandlerMixin:
 
         # Forward client headers to upstream, adding required OpenAI-Beta header
         ws_headers = dict(websocket.headers)
+        # Identify the WS harness before downstream auth/header rewrites.
+        # Captured in closure so per-turn RequestOutcome can stamp it.
+        client = classify_client(ws_headers)
         _ws_url_obj = getattr(websocket, "url", None)
         _ws_url = str(_ws_url_obj) if _ws_url_obj is not None else ""
         _ws_path = getattr(_ws_url_obj, "path", "") if _ws_url_obj is not None else ""
@@ -4247,6 +4256,7 @@ class OpenAIHandlerMixin:
                                         )
                                         if isinstance(body, dict)
                                         else 0,
+                                        client=client,
                                     )
                                 )
 
@@ -4817,6 +4827,7 @@ class OpenAIHandlerMixin:
                         pipeline_timing=final_pipeline_timing,
                         transforms_applied=tuple(transforms_applied),
                         tags=ws_session_tags,
+                        client=client,
                     )
                 )
                 ws_recorded_overhead_ms_total = _current_ws_overhead_ms()
@@ -5309,6 +5320,7 @@ class OpenAIHandlerMixin:
         headers = dict(request.headers.items())
         headers.pop("host", None)
         headers.pop("accept-encoding", None)
+        client = classify_client(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.
         from headroom.proxy.helpers import _strip_internal_headers, log_outbound_headers
 
@@ -5374,6 +5386,7 @@ class OpenAIHandlerMixin:
                     tokens_saved=0,
                     attempted_input_tokens=0,
                     total_latency_ms=latency_ms,
+                    client=client,
                 )
             )
 

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -40,6 +40,7 @@ from headroom.copilot_auth import apply_copilot_api_auth, build_copilot_upstream
 from headroom.pipeline import PipelineStage, summarize_routing_markers
 from headroom.proxy.auth_mode import classify_auth_mode
 from headroom.proxy.cost import _summarize_transforms
+from headroom.proxy.outcome import RequestOutcome
 
 logger = logging.getLogger("headroom.proxy")
 
@@ -1292,14 +1293,25 @@ class OpenAIHandlerMixin:
                     messages=messages,
                     metadata={"cache_hit": True, "path": "/v1/chat/completions"},
                 )
-                await self.metrics.record_request(
-                    provider="openai",
-                    model=model,
-                    input_tokens=0,
-                    output_tokens=0,
-                    tokens_saved=0,  # Savings already counted when response was cached
-                    latency_ms=(time.time() - start_time) * 1000,
-                    cached=True,
+                # Response-cache hit: same pattern as the anthropic
+                # cache-hit site. ``from_response_cache=True`` is the
+                # distinct signal that the proxy served from its own
+                # semantic cache (not upstream prompt cache).
+                _cache_hit_latency = (time.time() - start_time) * 1000
+                await self._record_request_outcome(
+                    RequestOutcome(
+                        request_id=request_id,
+                        provider="openai",
+                        model=model,
+                        original_tokens=0,
+                        optimized_tokens=0,
+                        output_tokens=0,
+                        tokens_saved=0,
+                        attempted_input_tokens=0,
+                        from_response_cache=True,
+                        total_latency_ms=_cache_hit_latency,
+                        num_messages=len(messages),
+                    )
                 )
 
                 # Remove compression headers from cached response
@@ -1781,64 +1793,41 @@ class OpenAIHandlerMixin:
                             content=backend_response.body,
                         )
 
-                    # Track metrics
+                    # OpenAI Chat via backend (LiteLLM/AnyLLM), non-
+                    # streaming. No per-message live-zone tracking yet
+                    # — use full pre-comp request size as the attempted
+                    # denominator so this provider's contribution to
+                    # active_savings is its whole-request ratio.
+                    # Cache extraction from the backend response body
+                    # is not wired here yet (follow-up); funnel passes
+                    # zeros for cache fields, matching pre-refactor
+                    # behaviour.
                     total_latency = (time.time() - start_time) * 1000
                     usage = backend_response.body.get("usage", {})
                     output_tokens = usage.get("completion_tokens", 0)
                     total_input_tokens = usage.get("prompt_tokens", optimized_tokens)
-
-                    # OpenAI Chat: no per-message live-zone tracking
-                    # yet. Use full pre-comp request size as the
-                    # attempted denominator so this provider's
-                    # contribution to the aggregate active_savings ratio
-                    # equals its whole-request ratio. Per-message
-                    # eligibility (tool_result-shaped messages, current
-                    # turn vs cached) is a follow-up.
-                    attempted_input_tokens = total_input_tokens + tokens_saved
-                    await self.metrics.record_request(
-                        provider=self.anthropic_backend.name,
-                        model=model,
-                        input_tokens=total_input_tokens,
-                        output_tokens=output_tokens,
-                        tokens_saved=tokens_saved,
-                        latency_ms=total_latency,
-                        cached=False,
-                        overhead_ms=optimization_latency,
-                        pipeline_timing=pipeline_timing,
-                        waste_signals=waste_signals_dict,
-                        attempted_input_tokens=attempted_input_tokens,
-                    )
-
-                    # Mirror the streaming path: log to RequestLogger so
-                    # /stats.recent_requests sees the OpenAI-via-backend
-                    # non-streaming path. Previously this path was silent.
-                    if getattr(self, "logger", None) is not None:
-                        from headroom.proxy.models import RequestLog
-
-                        self.logger.log(
-                            RequestLog(
-                                request_id=request_id,
-                                timestamp=datetime.now().isoformat(),
-                                provider=self.anthropic_backend.name,
-                                model=model,
-                                input_tokens_original=original_tokens,
-                                input_tokens_optimized=optimized_tokens,
-                                output_tokens=output_tokens,
-                                tokens_saved=tokens_saved,
-                                savings_percent=(tokens_saved / original_tokens * 100)
-                                if original_tokens > 0
-                                else 0,
-                                optimization_latency_ms=optimization_latency,
-                                total_latency_ms=total_latency,
-                                tags=tags or {},
-                                cache_hit=False,
-                                transforms_applied=transforms_applied,
-                                waste_signals=waste_signals_dict,
-                                request_messages=body.get("messages")
-                                if getattr(self.config, "log_full_messages", False)
-                                else None,
-                            )
+                    await self._record_request_outcome(
+                        RequestOutcome(
+                            request_id=request_id,
+                            provider=self.anthropic_backend.name,
+                            model=model,
+                            original_tokens=original_tokens,
+                            optimized_tokens=total_input_tokens,
+                            output_tokens=output_tokens,
+                            tokens_saved=tokens_saved,
+                            attempted_input_tokens=total_input_tokens + tokens_saved,
+                            total_latency_ms=total_latency,
+                            overhead_ms=optimization_latency,
+                            pipeline_timing=pipeline_timing,
+                            waste_signals=waste_signals_dict,
+                            transforms_applied=tuple(transforms_applied),
+                            num_messages=len(body.get("messages", [])),
+                            tags=tags or {},
+                            request_messages=body.get("messages")
+                            if getattr(self.config, "log_full_messages", False)
+                            else None,
                         )
+                    )
 
                     if tokens_saved > 0:
                         logger.info(
@@ -2124,60 +2113,37 @@ class OpenAIHandlerMixin:
                     "endpoint": "chat_completions",
                 }
 
-                # OpenAI Chat (streaming path): fallback denominator —
-                # full pre-comp size. See note at the non-streaming
-                # path for the eligible-only follow-up.
-                attempted_input_tokens = total_input_tokens + tokens_saved
-                await self.metrics.record_request(
-                    provider="openai",
-                    model=model,
-                    input_tokens=total_input_tokens,
-                    output_tokens=output_tokens,
-                    tokens_saved=tokens_saved,
-                    latency_ms=total_latency,
-                    overhead_ms=optimization_latency,
-                    pipeline_timing=pipeline_timing,
-                    waste_signals=waste_signals_dict,
-                    cache_read_tokens=cache_read_tokens,
-                    cache_write_tokens=cache_write_tokens,
-                    uncached_input_tokens=uncached_input_tokens,
-                    attempted_input_tokens=attempted_input_tokens,
-                )
+                # OpenAI Chat direct (non-backend) non-streaming.
+                # Fallback denominator: full pre-comp size — see
+                # equivalent note at the backend-routed sibling.
+                from headroom.proxy.helpers import compute_turn_id
 
-                # Per-request log entry for /transformations/feed +
-                # /stats `recent_requests`. Without this the dashboard
-                # only shows aggregates for non-streaming OpenAI traffic.
-                # Mirror of the streaming.py + anthropic.py wiring.
-                if getattr(self, "logger", None) is not None:
-                    from headroom.proxy.helpers import compute_turn_id
-                    from headroom.proxy.models import RequestLog
-
-                    self.logger.log(
-                        RequestLog(
-                            request_id=request_id,
-                            timestamp=datetime.now().isoformat(),
-                            provider="openai",
-                            model=model,
-                            input_tokens_original=original_tokens,
-                            input_tokens_optimized=optimized_tokens,
-                            output_tokens=output_tokens,
-                            tokens_saved=tokens_saved,
-                            savings_percent=(tokens_saved / original_tokens * 100)
-                            if original_tokens > 0
-                            else 0,
-                            optimization_latency_ms=optimization_latency,
-                            total_latency_ms=total_latency,
-                            tags=_chat_log_tags,
-                            cache_hit=False,
-                            transforms_applied=transforms_applied,
-                            request_messages=body.get("messages")
-                            if getattr(self.config, "log_full_messages", False)
-                            else None,
-                            turn_id=compute_turn_id(
-                                model, body.get("system"), body.get("messages")
-                            ),
-                        )
+                await self._record_request_outcome(
+                    RequestOutcome(
+                        request_id=request_id,
+                        provider="openai",
+                        model=model,
+                        original_tokens=original_tokens,
+                        optimized_tokens=total_input_tokens,
+                        output_tokens=output_tokens,
+                        tokens_saved=tokens_saved,
+                        attempted_input_tokens=total_input_tokens + tokens_saved,
+                        cache_read_tokens=cache_read_tokens,
+                        cache_write_tokens=cache_write_tokens,
+                        uncached_input_tokens=uncached_input_tokens,
+                        total_latency_ms=total_latency,
+                        overhead_ms=optimization_latency,
+                        pipeline_timing=pipeline_timing,
+                        waste_signals=waste_signals_dict,
+                        transforms_applied=tuple(transforms_applied),
+                        num_messages=len(body.get("messages", [])),
+                        tags=_chat_log_tags,
+                        turn_id=compute_turn_id(model, body.get("system"), body.get("messages")),
+                        request_messages=body.get("messages")
+                        if getattr(self.config, "log_full_messages", False)
+                        else None,
                     )
+                )
 
                 if tokens_saved > 0:
                     logger.info(
@@ -2852,52 +2818,37 @@ class OpenAIHandlerMixin:
                     "endpoint": "responses_http",
                 }
 
-                await self.metrics.record_request(
-                    provider="openai",
-                    model=model,
-                    input_tokens=total_input_tokens,
-                    output_tokens=output_tokens,
-                    tokens_saved=tokens_saved,
-                    latency_ms=total_latency,
-                    overhead_ms=optimization_latency,
-                    cache_read_tokens=cache_read_tokens,
-                    cache_write_tokens=cache_write_tokens,
-                    uncached_input_tokens=uncached_input_tokens,
-                    attempted_input_tokens=attempted_input_tokens,
-                )
+                # OpenAI Responses HTTP (non-WS, non-streaming). Codex
+                # uses this path when configured for HTTP transport.
+                # Pre-refactor `cache_hit` was hardcoded False on
+                # RequestLog even when cache_read>0 — funnel derives
+                # it correctly.
+                from headroom.proxy.helpers import compute_turn_id
 
-                # Per-request log entry for /transformations/feed +
-                # /stats `recent_requests`. Mirror of streaming.py /
-                # anthropic.py wiring; without this the dashboard's
-                # per-request feed misses every Codex HTTP turn.
-                if getattr(self, "logger", None) is not None:
-                    from headroom.proxy.helpers import compute_turn_id
-                    from headroom.proxy.models import RequestLog
-
-                    self.logger.log(
-                        RequestLog(
-                            request_id=request_id,
-                            timestamp=datetime.now().isoformat(),
-                            provider="openai",
-                            model=model,
-                            input_tokens_original=effective_original_tokens,
-                            input_tokens_optimized=effective_optimized_tokens,
-                            output_tokens=output_tokens,
-                            tokens_saved=tokens_saved,
-                            savings_percent=(tokens_saved / effective_original_tokens * 100)
-                            if effective_original_tokens > 0
-                            else 0,
-                            optimization_latency_ms=optimization_latency,
-                            total_latency_ms=total_latency,
-                            tags=_resp_log_tags,
-                            cache_hit=False,
-                            transforms_applied=transforms_applied,
-                            request_messages=messages
-                            if getattr(self.config, "log_full_messages", False)
-                            else None,
-                            turn_id=compute_turn_id(model, body.get("instructions"), messages),
-                        )
+                await self._record_request_outcome(
+                    RequestOutcome(
+                        request_id=request_id,
+                        provider="openai",
+                        model=model,
+                        original_tokens=effective_original_tokens,
+                        optimized_tokens=effective_optimized_tokens,
+                        output_tokens=output_tokens,
+                        tokens_saved=tokens_saved,
+                        attempted_input_tokens=attempted_input_tokens,
+                        cache_read_tokens=cache_read_tokens,
+                        cache_write_tokens=cache_write_tokens,
+                        uncached_input_tokens=uncached_input_tokens,
+                        total_latency_ms=total_latency,
+                        overhead_ms=optimization_latency,
+                        transforms_applied=tuple(transforms_applied),
+                        num_messages=len(messages) if isinstance(messages, list) else 0,
+                        tags=_resp_log_tags,
+                        turn_id=compute_turn_id(model, body.get("instructions"), messages),
+                        request_messages=messages
+                        if getattr(self.config, "log_full_messages", False)
+                        else None,
                     )
+                )
 
                 logger.info(f"[{request_id}] /v1/responses {model}: {total_input_tokens:,} tokens")
 
@@ -4254,34 +4205,49 @@ class OpenAIHandlerMixin:
                                     return
 
                                 model_for_metrics = str(body.get("model") or "unknown")
-                                if self.cost_tracker:
-                                    self.cost_tracker.record_tokens(
-                                        model_for_metrics,
-                                        max(0, saved_delta),
-                                        max(0, input_delta),
-                                        cache_read_tokens=max(0, cache_read_delta),
-                                        cache_write_tokens=max(0, cache_write_delta),
-                                        uncached_tokens=max(0, uncached_delta),
-                                    )
                                 latency_ms = (
                                     (time.perf_counter() * 1000.0 - response_started_ms)
                                     if response_started_ms is not None
                                     else 0.0
                                 )
-                                await self.metrics.record_request(
-                                    provider="openai",
-                                    model=model_for_metrics,
-                                    input_tokens=max(0, input_delta),
-                                    output_tokens=max(0, output_delta),
-                                    tokens_saved=max(0, saved_delta),
-                                    latency_ms=latency_ms,
-                                    cache_read_tokens=max(0, cache_read_delta),
-                                    cache_write_tokens=max(0, cache_write_delta),
-                                    uncached_input_tokens=max(0, uncached_delta),
-                                    attempted_input_tokens=max(0, attempted_delta),
-                                    overhead_ms=overhead_delta_ms,
-                                    ttfb_ms=ttfb_for_record_ms,
-                                    pipeline_timing=dashboard_pipeline_timing,
+                                # Per-turn record: delta values capture
+                                # this turn's contribution since the
+                                # Codex WS handler accumulates session
+                                # totals. Pre-refactor this site
+                                # emitted only metrics + cost_tracker
+                                # — no RequestLog, no PERF — so Codex
+                                # traffic was invisible to
+                                # ``headroom perf`` and the recent-
+                                # requests feed. Funnel restores all
+                                # four effects uniformly per turn.
+                                # ``ws_session_tags`` is not yet bound
+                                # at per-turn time (set at session-end
+                                # below); pass empty so the funnel
+                                # gets a real dict.
+                                await self._record_request_outcome(
+                                    RequestOutcome(
+                                        request_id=request_id,
+                                        provider="openai",
+                                        model=model_for_metrics,
+                                        original_tokens=max(0, input_delta) + max(0, saved_delta),
+                                        optimized_tokens=max(0, input_delta),
+                                        output_tokens=max(0, output_delta),
+                                        tokens_saved=max(0, saved_delta),
+                                        attempted_input_tokens=max(0, attempted_delta),
+                                        cache_read_tokens=max(0, cache_read_delta),
+                                        cache_write_tokens=max(0, cache_write_delta),
+                                        uncached_input_tokens=max(0, uncached_delta),
+                                        total_latency_ms=latency_ms,
+                                        overhead_ms=overhead_delta_ms,
+                                        ttfb_ms=ttfb_for_record_ms,
+                                        pipeline_timing=dashboard_pipeline_timing,
+                                        transforms_applied=tuple(transforms_applied),
+                                        num_messages=len(
+                                            body.get("messages") or body.get("input") or []
+                                        )
+                                        if isinstance(body, dict)
+                                        else 0,
+                                    )
                                 )
 
                                 # Structured PERF log line so ``headroom perf``
@@ -4825,29 +4791,33 @@ class OpenAIHandlerMixin:
                 or final_overhead_delta_ms > 0
                 or final_ttfb_ms > 0
             ):
-                if self.cost_tracker:
-                    self.cost_tracker.record_tokens(
-                        model_name,
-                        residual_tokens_saved,
-                        residual_input_tokens,
+                # Session-end residual: tokens not captured by any
+                # per-turn record (e.g. signaling frames after the
+                # last response.completed). The funnel emits the full
+                # bookkeeping quartet for the residual; the explicit
+                # session-summary RequestLog below remains a separate
+                # entry (different semantics — cumulative session
+                # totals vs delta residual).
+                await self._record_request_outcome(
+                    RequestOutcome(
+                        request_id=request_id,
+                        provider="openai",
+                        model=model_name,
+                        original_tokens=residual_input_tokens + residual_tokens_saved,
+                        optimized_tokens=residual_input_tokens,
+                        output_tokens=residual_output_tokens,
+                        tokens_saved=residual_tokens_saved,
+                        attempted_input_tokens=residual_attempted_input_tokens,
                         cache_read_tokens=residual_cache_read_tokens,
                         cache_write_tokens=residual_cache_write_tokens,
-                        uncached_tokens=residual_uncached_input_tokens,
+                        uncached_input_tokens=residual_uncached_input_tokens,
+                        total_latency_ms=ws_session_duration_ms,
+                        overhead_ms=final_overhead_delta_ms,
+                        ttfb_ms=final_ttfb_ms,
+                        pipeline_timing=final_pipeline_timing,
+                        transforms_applied=tuple(transforms_applied),
+                        tags=ws_session_tags,
                     )
-                await self.metrics.record_request(
-                    provider="openai",
-                    model=model_name,
-                    input_tokens=residual_input_tokens,
-                    output_tokens=residual_output_tokens,
-                    tokens_saved=residual_tokens_saved,
-                    latency_ms=ws_session_duration_ms,
-                    cache_read_tokens=residual_cache_read_tokens,
-                    cache_write_tokens=residual_cache_write_tokens,
-                    uncached_input_tokens=residual_uncached_input_tokens,
-                    attempted_input_tokens=residual_attempted_input_tokens,
-                    overhead_ms=final_overhead_delta_ms,
-                    ttfb_ms=final_ttfb_ms,
-                    pipeline_timing=final_pipeline_timing,
                 )
                 ws_recorded_overhead_ms_total = _current_ws_overhead_ms()
                 if final_ttfb_ms > 0:
@@ -5386,17 +5356,25 @@ class OpenAIHandlerMixin:
         response_headers.pop("content-encoding", None)
         response_headers.pop("content-length", None)  # Length changed after decompression
 
-        # Track stats for passthrough requests
+        # Passthrough request: forwarded upstream with no transforms.
+        # Still recorded so dashboards see traffic on the passthrough
+        # endpoints. Funnel handles the "no tokens, no cache" shape
+        # via zero defaults.
         if endpoint_name and provider:
             latency_ms = (time.time() - start_time) * 1000
-            await self.metrics.record_request(
-                provider=provider,
-                model=f"passthrough:{endpoint_name}",
-                input_tokens=0,
-                output_tokens=0,
-                tokens_saved=0,
-                latency_ms=latency_ms,
-                cached=False,
+            request_id = await self._next_request_id()
+            await self._record_request_outcome(
+                RequestOutcome(
+                    request_id=request_id,
+                    provider=provider,
+                    model=f"passthrough:{endpoint_name}",
+                    original_tokens=0,
+                    optimized_tokens=0,
+                    output_tokens=0,
+                    tokens_saved=0,
+                    attempted_input_tokens=0,
+                    total_latency_ms=latency_ms,
+                )
             )
 
         return Response(
@@ -5404,59 +5382,3 @@ class OpenAIHandlerMixin:
             status_code=response.status_code,
             headers=response_headers,
         )
-
-    async def handle_databricks_invocations(
-        self,
-        request: Request,
-        model: str,
-    ) -> Response | StreamingResponse:
-        """Handle Databricks native /serving-endpoints/{model}/invocations endpoint.
-
-        This enables using the Databricks CLI directly with Headroom:
-            databricks serving-endpoints query <model> --profile HEADROOM --json '{"messages": [...]}'
-
-        The request/response format is identical to OpenAI chat completions,
-        so we inject the model from the path and delegate to handle_openai_chat.
-        """
-        from fastapi.responses import JSONResponse
-
-        from headroom.proxy.helpers import _read_request_json
-
-        request_id = await self._next_request_id()
-
-        try:
-            body = await _read_request_json(request)
-        except Exception as e:
-            logger.error(f"[{request_id}] Failed to parse Databricks request body: {e}")
-            return JSONResponse(
-                status_code=400,
-                content={
-                    "error": {
-                        "message": f"Invalid JSON: {e}",
-                        "type": "invalid_request_error",
-                    }
-                },
-            )
-
-        # Inject model from path into body (Databricks CLI passes model in URL, not body)
-        body["model"] = model
-
-        logger.info(f"[{request_id}] Databricks invocation: model={model}")
-
-        # Create a new request with the modified body
-        # We reuse the OpenAI chat handler since the format is identical
-        from starlette.requests import Request as StarletteRequest
-
-        # Build new scope with the body already parsed
-        scope = dict(request.scope)
-
-        # Create a simple receive function that returns our modified body
-        body_bytes = json.dumps(body).encode()
-
-        async def receive():
-            return {"type": "http.request", "body": body_bytes}
-
-        modified_request = StarletteRequest(scope, receive)
-
-        # Delegate to the OpenAI chat handler (same format)
-        return await self.handle_openai_chat(modified_request)

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -10,7 +10,6 @@ import contextlib
 import json
 import logging
 import time
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from headroom.proxy.helpers import compute_turn_id, jitter_delay_ms
@@ -585,7 +584,7 @@ class StreamingMixin:
         full_sse_data: str = "",
         parsed_response: dict[str, Any] | None = None,
     ) -> None:
-        from headroom.proxy.cost import _summarize_transforms
+        from headroom.proxy.outcome import RequestOutcome
 
         total_latency = (time.time() - start_time) * 1000
 
@@ -647,23 +646,9 @@ class StreamingMixin:
             effective_optimized_tokens - cache_read_tokens - cache_write_tokens, 0
         )
 
-        num_msgs = len(body.get("messages", []))
-        cache_hit_pct = (
-            round(cache_read_tokens / (cache_read_tokens + cache_write_tokens) * 100)
-            if (cache_read_tokens + cache_write_tokens) > 0
-            else 0
-        )
-        logger.info(
-            f"[{request_id}] PERF "
-            f"model={model} msgs={num_msgs} "
-            f"tok_before={effective_original_tokens} tok_after={effective_optimized_tokens} "
-            f"tok_saved={tokens_saved} "
-            f"cache_read={cache_read_tokens} cache_write={cache_write_tokens} "
-            f"cache_hit_pct={cache_hit_pct} "
-            f"opt_ms={optimization_latency:.0f} "
-            f"transforms={_summarize_transforms(transforms_applied)}"
-        )
-
+        # Prefix-tracker mutation is provider-specific state that lives
+        # outside the metric funnel. Run it before the funnel so the next
+        # request inherits correct prefix state regardless of metric path.
         if prefix_tracker is not None:
             import copy as _copy
 
@@ -690,76 +675,40 @@ class StreamingMixin:
                 original_messages=next_original,
             )
 
-        if self.cost_tracker:
-            self.cost_tracker.record_tokens(
-                model,
-                tokens_saved,
-                effective_optimized_tokens,
-                cache_read_tokens=cache_read_tokens,
-                cache_write_tokens=cache_write_tokens,
-                cache_write_5m_tokens=cache_write_5m_tokens,
-                cache_write_1h_tokens=cache_write_1h_tokens,
-                uncached_tokens=uncached_input_tokens,
-            )
+        # Active-compression denominator. No frozen_message_count is
+        # propagated to the streaming finalizer yet, so we fall back to
+        # the pre-comp request size (effective_optimized + tokens_saved).
+        # Per-message live-zone tracking is a follow-up; without this
+        # fallback the dashboard headline collapses to 0% for streaming
+        # traffic even though compression is happening (issue #455).
+        attempted_input_tokens = effective_optimized_tokens + tokens_saved
 
-        if getattr(self, "metrics", None) is not None:
-            # Active-compression denominator. No frozen_message_count is
-            # propagated to the streaming finalizer yet, so we fall
-            # back to the pre-comp request size (effective_optimized +
-            # tokens_saved). Per-message live-zone tracking is a
-            # follow-up; without this fallback the dashboard headline
-            # collapses to 0% for streaming traffic even though
-            # compression is happening (issue #455).
-            attempted_input_tokens = effective_optimized_tokens + tokens_saved
-            await self.metrics.record_request(
-                provider=provider,
-                model=model,
-                input_tokens=effective_optimized_tokens,
-                output_tokens=output_tokens,
-                tokens_saved=tokens_saved,
-                latency_ms=total_latency,
-                overhead_ms=optimization_latency,
-                ttfb_ms=stream_state["ttfb_ms"] or total_latency,
-                pipeline_timing=pipeline_timing,
-                cache_read_tokens=cache_read_tokens,
-                cache_write_tokens=cache_write_tokens,
-                cache_write_5m_tokens=cache_write_5m_tokens,
-                cache_write_1h_tokens=cache_write_1h_tokens,
-                uncached_input_tokens=uncached_input_tokens,
-                attempted_input_tokens=attempted_input_tokens,
-            )
-
-        # Log the request to the in-memory request logger so it shows up in
-        # /stats `recent_requests` and `/transformations/feed`. Without this
-        # the streaming Anthropic path (which is what Claude Code uses) is
-        # invisible to both surfaces — only Bedrock streaming and the
-        # non-streaming Anthropic path were logged previously.
-        if getattr(self, "logger", None) is not None:
-            from headroom.proxy.models import RequestLog
-
-            self.logger.log(
-                RequestLog(
-                    request_id=request_id,
-                    timestamp=datetime.now().isoformat(),
-                    provider=provider,
-                    model=model,
-                    input_tokens_original=effective_original_tokens,
-                    input_tokens_optimized=effective_optimized_tokens,
-                    output_tokens=output_tokens,
-                    tokens_saved=tokens_saved,
-                    savings_percent=(tokens_saved / effective_original_tokens * 100)
-                    if effective_original_tokens > 0
-                    else 0,
-                    optimization_latency_ms=optimization_latency,
-                    total_latency_ms=total_latency,
-                    tags=tags or {},
-                    cache_hit=False,
-                    transforms_applied=transforms_applied,
-                    request_messages=body.get("messages")
-                    if getattr(self.config, "log_full_messages", False)
-                    else None,
-                )
-            )
+        outcome = RequestOutcome(
+            request_id=request_id,
+            provider=provider,
+            model=model,
+            original_tokens=effective_original_tokens,
+            optimized_tokens=effective_optimized_tokens,
+            output_tokens=output_tokens,
+            tokens_saved=tokens_saved,
+            attempted_input_tokens=attempted_input_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            cache_write_5m_tokens=cache_write_5m_tokens,
+            cache_write_1h_tokens=cache_write_1h_tokens,
+            uncached_input_tokens=uncached_input_tokens,
+            total_latency_ms=total_latency,
+            overhead_ms=optimization_latency,
+            ttfb_ms=stream_state["ttfb_ms"] or total_latency,
+            pipeline_timing=pipeline_timing,
+            transforms_applied=tuple(transforms_applied),
+            num_messages=len(body.get("messages", [])),
+            tags=tags or {},
+            request_messages=body.get("messages")
+            if getattr(self.config, "log_full_messages", False)
+            else None,
+        )
+        await self._record_request_outcome(outcome)
 
     async def _stream_response(
         self,
@@ -1298,8 +1247,7 @@ class StreamingMixin:
         """
         from fastapi.responses import StreamingResponse
 
-        from headroom.proxy.cost import _summarize_transforms
-        from headroom.proxy.models import RequestLog
+        from headroom.proxy.outcome import RequestOutcome
 
         start_time = time.time()
 
@@ -1367,19 +1315,7 @@ class StreamingMixin:
                 yield f"event: error\ndata: {json.dumps(error_event)}\n\n".encode()
 
             finally:
-                # Record metrics
                 total_latency = (time.time() - start_time) * 1000
-                output_tokens = stream_state["output_tokens"]
-                cache_read_tokens = stream_state["cache_read_input_tokens"]
-                cache_write_tokens = stream_state["cache_creation_input_tokens"]
-                cache_write_5m_tokens = stream_state["cache_creation_ephemeral_5m_input_tokens"]
-                cache_write_1h_tokens = stream_state["cache_creation_ephemeral_1h_input_tokens"]
-                cache_hit_pct = (
-                    round(cache_read_tokens / (cache_read_tokens + cache_write_tokens) * 100)
-                    if (cache_read_tokens + cache_write_tokens) > 0
-                    else 0
-                )
-
                 _backend_name = (
                     self.anthropic_backend.name if self.anthropic_backend else "anthropic"
                 )
@@ -1387,73 +1323,32 @@ class StreamingMixin:
                 # Bedrock streaming doesn't propagate frozen_message_count
                 # here either; without this, attempted_input_tokens_total
                 # stays 0 and the dashboard headline reads 0% (#455).
-                attempted_input_tokens = optimized_tokens + tokens_saved
-                await self.metrics.record_request(
+                outcome = RequestOutcome(
+                    request_id=request_id,
                     provider=_backend_name,
                     model=model,
-                    input_tokens=optimized_tokens,
-                    output_tokens=output_tokens,
+                    original_tokens=original_tokens,
+                    optimized_tokens=optimized_tokens,
+                    output_tokens=stream_state["output_tokens"],
                     tokens_saved=tokens_saved,
-                    latency_ms=total_latency,
-                    cached=cache_read_tokens > 0,
+                    attempted_input_tokens=optimized_tokens + tokens_saved,
+                    cache_read_tokens=stream_state["cache_read_input_tokens"],
+                    cache_write_tokens=stream_state["cache_creation_input_tokens"],
+                    cache_write_5m_tokens=stream_state["cache_creation_ephemeral_5m_input_tokens"],
+                    cache_write_1h_tokens=stream_state["cache_creation_ephemeral_1h_input_tokens"],
+                    total_latency_ms=total_latency,
                     overhead_ms=optimization_latency,
                     ttfb_ms=stream_state["ttfb_ms"] or 0,
                     pipeline_timing=pipeline_timing,
-                    attempted_input_tokens=attempted_input_tokens,
+                    transforms_applied=tuple(transforms_applied),
+                    num_messages=len(body.get("messages", [])),
+                    tags=tags or {},
+                    turn_id=compute_turn_id(model, body.get("system"), body.get("messages")),
+                    request_messages=body.get("messages")
+                    if getattr(self.config, "log_full_messages", False)
+                    else None,
                 )
-
-                if self.cost_tracker:
-                    self.cost_tracker.record_tokens(
-                        model,
-                        tokens_saved,
-                        optimized_tokens,
-                        cache_read_tokens=cache_read_tokens,
-                        cache_write_tokens=cache_write_tokens,
-                        cache_write_5m_tokens=cache_write_5m_tokens,
-                        cache_write_1h_tokens=cache_write_1h_tokens,
-                    )
-
-                # Log request
-                if self.logger:
-                    self.logger.log(
-                        RequestLog(
-                            request_id=request_id,
-                            timestamp=datetime.now().isoformat(),
-                            provider=_backend_name,
-                            model=model,
-                            input_tokens_original=original_tokens,
-                            input_tokens_optimized=optimized_tokens,
-                            output_tokens=output_tokens,
-                            tokens_saved=tokens_saved,
-                            savings_percent=(tokens_saved / original_tokens * 100)
-                            if original_tokens > 0
-                            else 0,
-                            optimization_latency_ms=optimization_latency,
-                            total_latency_ms=total_latency,
-                            tags=tags,
-                            cache_hit=cache_read_tokens > 0,
-                            transforms_applied=transforms_applied,
-                            request_messages=body.get("messages")
-                            if self.config.log_full_messages
-                            else None,
-                            turn_id=compute_turn_id(
-                                model, body.get("system"), body.get("messages")
-                            ),
-                        )
-                    )
-
-                # Structured perf log line for `headroom perf` analysis
-                num_msgs = len(body.get("messages", []))
-                logger.info(
-                    f"[{request_id}] PERF "
-                    f"model={model} msgs={num_msgs} "
-                    f"tok_before={original_tokens} tok_after={optimized_tokens} "
-                    f"tok_saved={tokens_saved} "
-                    f"cache_read={cache_read_tokens} cache_write={cache_write_tokens} "
-                    f"cache_hit_pct={cache_hit_pct} "
-                    f"opt_ms={optimization_latency:.0f} "
-                    f"transforms={_summarize_transforms(transforms_applied)}"
-                )
+                await self._record_request_outcome(outcome)
 
         return StreamingResponse(
             generate(),
@@ -1493,8 +1388,8 @@ class StreamingMixin:
         """
         from fastapi.responses import StreamingResponse
 
-        from headroom.proxy.cost import _summarize_transforms
         from headroom.proxy.handlers.openai import _infer_openai_cache_write_tokens
+        from headroom.proxy.outcome import RequestOutcome
 
         assert self.anthropic_backend is not None
 
@@ -1555,19 +1450,15 @@ class StreamingMixin:
                 output_tokens = stream_state["output_tokens"] or 0
                 cache_read_tokens = stream_state["cache_read_input_tokens"] or 0
                 if upstream_input is None:
-                    input_tokens = 0
                     cache_write_tokens = 0
                     uncached_input_tokens = 0
-                    cache_hit_pct = 0
+                    cache_inferred = False
                 else:
-                    input_tokens = upstream_input
                     cache_write_tokens = _infer_openai_cache_write_tokens(
-                        input_tokens, cache_read_tokens
+                        upstream_input, cache_read_tokens
                     )
-                    uncached_input_tokens = max(input_tokens - cache_read_tokens, 0)
-                    cache_hit_pct = (
-                        round(cache_read_tokens / input_tokens * 100) if input_tokens > 0 else 0
-                    )
+                    uncached_input_tokens = max(upstream_input - cache_read_tokens, 0)
+                    cache_inferred = True
 
                 total_latency = (time.time() - start_time) * 1000
                 # Active-compression denominator for backend-routed
@@ -1577,78 +1468,31 @@ class StreamingMixin:
                 # comp request size. This keeps active_savings_percent
                 # in sync with proxy_savings_percent for this provider
                 # instead of collapsing the dashboard headline to 0%.
-                attempted_input_tokens = optimized_tokens + tokens_saved
-                await self.metrics.record_request(
+                outcome = RequestOutcome(
+                    request_id=request_id,
                     provider=self.anthropic_backend.name,
                     model=model,
-                    input_tokens=optimized_tokens,
+                    original_tokens=original_tokens,
+                    optimized_tokens=optimized_tokens,
                     output_tokens=output_tokens,
                     tokens_saved=tokens_saved,
-                    latency_ms=total_latency,
-                    cached=cache_read_tokens > 0,
+                    attempted_input_tokens=optimized_tokens + tokens_saved,
+                    cache_read_tokens=cache_read_tokens,
+                    cache_write_tokens=cache_write_tokens,
+                    uncached_input_tokens=uncached_input_tokens,
+                    cache_inferred=cache_inferred,
+                    total_latency_ms=total_latency,
                     overhead_ms=optimization_latency,
                     pipeline_timing=pipeline_timing,
                     waste_signals=waste_signals,
-                    attempted_input_tokens=attempted_input_tokens,
+                    transforms_applied=tuple(transforms_applied),
+                    num_messages=len(body.get("messages", [])),
+                    tags=tags or {},
+                    request_messages=body.get("messages")
+                    if getattr(self.config, "log_full_messages", False)
+                    else None,
                 )
-
-                if self.cost_tracker:
-                    self.cost_tracker.record_tokens(
-                        model,
-                        tokens_saved,
-                        optimized_tokens,
-                        cache_read_tokens=cache_read_tokens,
-                        cache_write_tokens=cache_write_tokens,
-                        uncached_tokens=uncached_input_tokens,
-                    )
-
-                # Mirror the Anthropic-stream path: log to RequestLogger so
-                # /stats.recent_requests and /transformations/feed see this
-                # request. Without it the OpenAI-via-backend path is invisible.
-                if getattr(self, "logger", None) is not None:
-                    from headroom.proxy.models import RequestLog
-
-                    self.logger.log(
-                        RequestLog(
-                            request_id=request_id,
-                            timestamp=datetime.now().isoformat(),
-                            provider=self.anthropic_backend.name,
-                            model=model,
-                            input_tokens_original=original_tokens,
-                            input_tokens_optimized=optimized_tokens,
-                            output_tokens=output_tokens,
-                            tokens_saved=tokens_saved,
-                            savings_percent=(tokens_saved / original_tokens * 100)
-                            if original_tokens > 0
-                            else 0,
-                            optimization_latency_ms=optimization_latency,
-                            total_latency_ms=total_latency,
-                            tags=tags or {},
-                            cache_hit=cache_read_tokens > 0,
-                            transforms_applied=transforms_applied,
-                            waste_signals=waste_signals,
-                            request_messages=body.get("messages")
-                            if getattr(self.config, "log_full_messages", False)
-                            else None,
-                        )
-                    )
-
-                # Structured perf log line for `headroom perf` analysis.
-                # Missing this line is why issue #327 reported
-                # ``Cache write: 0`` on Azure-GPT/Codex backend-routed
-                # traffic: the entire request was invisible to the perf
-                # parser, not zero — but the symptom is identical.
-                num_msgs = len(body.get("messages", []))
-                logger.info(
-                    f"[{request_id}] PERF "
-                    f"model={model} msgs={num_msgs} "
-                    f"tok_before={original_tokens} tok_after={optimized_tokens} "
-                    f"tok_saved={tokens_saved} "
-                    f"cache_read={cache_read_tokens} cache_write={cache_write_tokens} "
-                    f"cache_hit_pct={cache_hit_pct} "
-                    f"opt_ms={optimization_latency:.0f} "
-                    f"transforms={_summarize_transforms(transforms_applied)}"
-                )
+                await self._record_request_outcome(outcome)
 
                 if tokens_saved > 0:
                     logger.info(

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -12,6 +12,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from headroom.proxy.auth_mode import classify_client
 from headroom.proxy.helpers import compute_turn_id, jitter_delay_ms
 
 if TYPE_CHECKING:
@@ -583,6 +584,7 @@ class StreamingMixin:
         original_messages: list[dict] | None = None,
         full_sse_data: str = "",
         parsed_response: dict[str, Any] | None = None,
+        client: str | None = None,
     ) -> None:
         from headroom.proxy.outcome import RequestOutcome
 
@@ -704,6 +706,7 @@ class StreamingMixin:
             transforms_applied=tuple(transforms_applied),
             num_messages=len(body.get("messages", [])),
             tags=tags or {},
+            client=client,
             request_messages=body.get("messages")
             if getattr(self.config, "log_full_messages", False)
             else None,
@@ -749,6 +752,10 @@ class StreamingMixin:
 
         from headroom.proxy.helpers import MAX_SSE_BUFFER_SIZE
 
+        # Identify the harness (codex / claude-code / aider / cursor /
+        # ...) from the *client's* User-Agent before copilot-auth
+        # potentially rewrites headers for upstream.
+        client = classify_client(headers)
         headers = await apply_copilot_api_auth(headers, url=url)
         start_time = time.time()
 
@@ -962,6 +969,7 @@ class StreamingMixin:
                 pipeline_timing=pipeline_timing,
                 prefix_tracker=prefix_tracker,
                 original_messages=original_messages,
+                client=client,
             )
             return Response(
                 content=error_content,
@@ -1218,6 +1226,7 @@ class StreamingMixin:
                     original_messages=original_messages,
                     full_sse_data=_final_full_sse_data,
                     parsed_response=parsed_response,
+                    client=client,
                 )
 
         return StreamingResponse(
@@ -1248,6 +1257,8 @@ class StreamingMixin:
         from fastapi.responses import StreamingResponse
 
         from headroom.proxy.outcome import RequestOutcome
+
+        client = classify_client(headers)
 
         start_time = time.time()
 
@@ -1343,6 +1354,7 @@ class StreamingMixin:
                     transforms_applied=tuple(transforms_applied),
                     num_messages=len(body.get("messages", [])),
                     tags=tags or {},
+                    client=client,
                     turn_id=compute_turn_id(model, body.get("system"), body.get("messages")),
                     request_messages=body.get("messages")
                     if getattr(self.config, "log_full_messages", False)
@@ -1392,6 +1404,7 @@ class StreamingMixin:
         from headroom.proxy.outcome import RequestOutcome
 
         assert self.anthropic_backend is not None
+        client = classify_client(headers)
 
         async def generate():
             stream_state: dict[str, Any] = {
@@ -1488,6 +1501,7 @@ class StreamingMixin:
                     transforms_applied=tuple(transforms_applied),
                     num_messages=len(body.get("messages", [])),
                     tags=tags or {},
+                    client=client,
                     request_messages=body.get("messages")
                     if getattr(self.config, "log_full_messages", False)
                     else None,

--- a/headroom/proxy/outcome.py
+++ b/headroom/proxy/outcome.py
@@ -7,9 +7,10 @@ disagreed on argument shape — 9 of 18 omitted ``cached=``, 7 of 18
 omitted ``attempted_input_tokens=``, only 4 sites emitted a structured
 PERF log at all. This module is the structural fix: every handler
 converges on building a :class:`RequestOutcome` at end-of-request and
-hands it to :meth:`HeadroomProxy._record_request_outcome`, which owns
-the four downstream effects (Prometheus, cost tracker, request logger,
-PERF log).
+hands it to :func:`emit_request_outcome` (also exposed as
+:meth:`HeadroomProxy._record_request_outcome`), which owns the four
+downstream effects (Prometheus, cost tracker, request logger, PERF
+log).
 
 Note: this is **output unification, not input unification**. Provider
 APIs (Anthropic ``/v1/messages``, OpenAI Responses WS, Gemini
@@ -24,8 +25,12 @@ actually reports.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
+
+logger = logging.getLogger("headroom.proxy")
 
 
 @dataclass(frozen=True)
@@ -75,6 +80,12 @@ class RequestOutcome:
     cache_write_1h_tokens: int = 0
     uncached_input_tokens: int = 0
     cache_inferred: bool = False
+    # Response-cache hit (Headroom's own semantic cache served the
+    # response from a prior call — completely distinct from
+    # upstream-prompt-cache `cache_read_tokens`). True means the proxy
+    # never reached the provider at all. Used to drive the
+    # Prometheus ``cached`` counter and dashboard "response cache" row.
+    from_response_cache: bool = False
 
     # ── Timing ────────────────────────────────────────────────────────
     # total_latency_ms: wall-clock end-to-end for this request
@@ -111,13 +122,18 @@ class RequestOutcome:
 
     @property
     def cache_hit(self) -> bool:
-        """True iff upstream reported any cache read.
+        """True iff EITHER upstream reported a cache read OR the response
+        was served from Headroom's own response cache.
 
-        Used by ``RequestLog.cache_hit`` and ``record_request(cached=...)``.
+        Two distinct concepts collapsed into one observable boolean for
+        downstream consumers (Prometheus ``cached`` counter, RequestLog
+        ``cache_hit`` flag). The dataclass tracks them separately so
+        dashboards can split them; the derived property unifies them.
+
         Pre-refactor 9 of 18 sites hardcoded this to False — this property
         makes "I forgot to compute it" structurally impossible.
         """
-        return self.cache_read_tokens > 0
+        return self.cache_read_tokens > 0 or self.from_response_cache
 
     @property
     def cache_hit_pct(self) -> int:
@@ -144,3 +160,106 @@ class RequestOutcome:
         if self.original_tokens <= 0:
             return 0.0
         return self.tokens_saved / self.original_tokens * 100.0
+
+
+# ── The funnel ───────────────────────────────────────────────────────
+
+
+async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
+    """Single funnel for per-request bookkeeping. The contract.
+
+    Owns the four downstream effects in canonical order:
+
+      1. ``handler.metrics.record_request(...)`` — Prometheus / SavingsTracker
+      2. ``handler.cost_tracker.record_tokens(...)`` — cost dashboard
+         (skipped when cost_tracker is None, i.e. ``--no-cost``)
+      3. ``handler.logger.log(RequestLog(...))`` — per-request log feed
+         (skipped when logger is None, i.e. ``--no-request-logging``)
+      4. structured PERF log line — consumed by ``headroom perf``
+
+    Takes the handler as a free argument rather than ``self`` so this
+    function is callable from:
+    * ``HeadroomProxy._record_request_outcome`` (production)
+    * any test dummy that has the three required attributes
+      (``metrics``, ``cost_tracker``, optionally ``logger``)
+    * any provider handler mixin
+
+    The handler argument is structurally typed (duck-typed); no formal
+    Protocol — the requirement is simply that ``handler.metrics`` exists
+    and is awaitable-compatible. We could lift this to a typing.Protocol
+    if/when another contract surface emerges, but YAGNI.
+    """
+    from headroom.proxy.cost import _summarize_transforms
+    from headroom.proxy.models import RequestLog
+
+    # 1. Prometheus / SavingsTracker.
+    await handler.metrics.record_request(
+        provider=outcome.provider,
+        model=outcome.model,
+        input_tokens=outcome.optimized_tokens,
+        output_tokens=outcome.output_tokens,
+        tokens_saved=outcome.tokens_saved,
+        latency_ms=outcome.total_latency_ms,
+        cached=outcome.cache_hit,
+        overhead_ms=outcome.overhead_ms,
+        ttfb_ms=outcome.ttfb_ms,
+        pipeline_timing=outcome.pipeline_timing,
+        waste_signals=outcome.waste_signals,
+        cache_read_tokens=outcome.cache_read_tokens,
+        cache_write_tokens=outcome.cache_write_tokens,
+        cache_write_5m_tokens=outcome.cache_write_5m_tokens,
+        cache_write_1h_tokens=outcome.cache_write_1h_tokens,
+        uncached_input_tokens=outcome.uncached_input_tokens,
+        attempted_input_tokens=outcome.attempted_input_tokens,
+    )
+
+    # 2. Cost tracker (optional).
+    cost_tracker = getattr(handler, "cost_tracker", None)
+    if cost_tracker is not None:
+        cost_tracker.record_tokens(
+            outcome.model,
+            outcome.tokens_saved,
+            outcome.optimized_tokens,
+            cache_read_tokens=outcome.cache_read_tokens,
+            cache_write_tokens=outcome.cache_write_tokens,
+            cache_write_5m_tokens=outcome.cache_write_5m_tokens,
+            cache_write_1h_tokens=outcome.cache_write_1h_tokens,
+            uncached_tokens=outcome.uncached_input_tokens,
+        )
+
+    # 3. Per-request log (optional).
+    request_logger = getattr(handler, "logger", None)
+    if request_logger is not None:
+        request_logger.log(
+            RequestLog(
+                request_id=outcome.request_id,
+                timestamp=datetime.now().isoformat(),
+                provider=outcome.provider,
+                model=outcome.model,
+                input_tokens_original=outcome.original_tokens,
+                input_tokens_optimized=outcome.optimized_tokens,
+                output_tokens=outcome.output_tokens,
+                tokens_saved=outcome.tokens_saved,
+                savings_percent=outcome.savings_pct,
+                optimization_latency_ms=outcome.overhead_ms,
+                total_latency_ms=outcome.total_latency_ms,
+                tags=outcome.tags,
+                cache_hit=outcome.cache_hit,
+                transforms_applied=list(outcome.transforms_applied),
+                waste_signals=outcome.waste_signals,
+                request_messages=outcome.request_messages,
+                turn_id=outcome.turn_id,
+            )
+        )
+
+    # 4. Structured PERF log line.
+    logger.info(
+        f"[{outcome.request_id}] PERF "
+        f"model={outcome.model} msgs={outcome.num_messages} "
+        f"tok_before={outcome.original_tokens} tok_after={outcome.optimized_tokens} "
+        f"tok_saved={outcome.tokens_saved} "
+        f"cache_read={outcome.cache_read_tokens} cache_write={outcome.cache_write_tokens} "
+        f"cache_hit_pct={outcome.cache_hit_pct} "
+        f"opt_ms={outcome.overhead_ms:.0f} "
+        f"transforms={_summarize_transforms(list(outcome.transforms_applied))}"
+    )

--- a/headroom/proxy/outcome.py
+++ b/headroom/proxy/outcome.py
@@ -1,0 +1,146 @@
+"""``RequestOutcome``: the canonical value type for "what happened during
+one completed proxy request."
+
+Per the P0 audit (``docs/superpowers/specs/P0-proxy-pipeline-audit.md``),
+18 ``metrics.record_request`` call sites across four handler files
+disagreed on argument shape — 9 of 18 omitted ``cached=``, 7 of 18
+omitted ``attempted_input_tokens=``, only 4 sites emitted a structured
+PERF log at all. This module is the structural fix: every handler
+converges on building a :class:`RequestOutcome` at end-of-request and
+hands it to :meth:`HeadroomProxy._record_request_outcome`, which owns
+the four downstream effects (Prometheus, cost tracker, request logger,
+PERF log).
+
+Note: this is **output unification, not input unification**. Provider
+APIs (Anthropic ``/v1/messages``, OpenAI Responses WS, Gemini
+``generateContent``, Bedrock, Vertex) stay wildly different — the proxy
+talks each upstream in its native dialect. This dataclass standardises
+only the *observation* about a completed request. Provider-specific
+concepts (Anthropic's 5m/1h cache TTL splits, OpenAI's
+inferred-write flag, Gemini's read-only cache count) live as optional
+fields with neutral defaults; handlers populate what their provider
+actually reports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RequestOutcome:
+    """Immutable, value-equal snapshot of a completed request.
+
+    Construction policy: every field that downstream consumers read MUST
+    be either required (no default) or have a neutral default that makes
+    the consumer's behaviour identical to "field not present". This keeps
+    the contract honest — a handler that forgets a field doesn't silently
+    produce wrong metrics; it produces zeros, which the dashboard can
+    surface as a missing-data condition (P3 follow-up).
+    """
+
+    # ── Identity ──────────────────────────────────────────────────────
+    request_id: str
+    provider: str
+    model: str
+
+    # ── Tokens (required — every site has these) ──────────────────────
+    # original_tokens: pre-compression request size, for `tok_before`
+    # optimized_tokens: post-compression bytes actually forwarded, for
+    #     ``input_tokens`` and ``tok_after``
+    # output_tokens: response tokens from upstream
+    # tokens_saved: original - optimized (or 0 if compression bypassed)
+    # attempted_input_tokens: denominator for active-savings-percent.
+    #     The compressible portion only — excludes user messages, system
+    #     prompts, prior assistant turns, frozen prefix bytes. This is the
+    #     field 7 of 18 audit sites forgot to pass, collapsing
+    #     ``active_savings_percent`` to 0 (#454 / #455).
+    original_tokens: int
+    optimized_tokens: int
+    output_tokens: int
+    tokens_saved: int
+    attempted_input_tokens: int
+
+    # ── Cache (provider-agnostic; unused fields stay 0) ───────────────
+    # Anthropic populates all five (read + write + 5m + 1h + uncached).
+    # OpenAI populates read + inferred-write + uncached, and sets
+    # ``cache_inferred=True`` so the dashboard can warn that the write
+    # column is an estimate rather than an upstream-reported counter.
+    # Gemini populates read only.
+    # Bedrock mirrors Anthropic (it forwards Anthropic-shape usage).
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    cache_write_5m_tokens: int = 0
+    cache_write_1h_tokens: int = 0
+    uncached_input_tokens: int = 0
+    cache_inferred: bool = False
+
+    # ── Timing ────────────────────────────────────────────────────────
+    # total_latency_ms: wall-clock end-to-end for this request
+    # overhead_ms: time spent in compression dispatch only (subset of total)
+    # ttfb_ms: time to first upstream byte for streaming paths; 0 for
+    #     non-streaming or when unmeasured (no None — convention is 0)
+    # pipeline_timing: optional per-stage breakdown surfaced on dashboards
+    total_latency_ms: float = 0.0
+    overhead_ms: float = 0.0
+    ttfb_ms: float = 0.0
+    pipeline_timing: dict[str, float] | None = None
+
+    # ── Transforms + diagnostics ──────────────────────────────────────
+    # transforms_applied: tuple (immutable) of every transform that ran.
+    #     RequestLog still wants list[str]; the funnel converts at the
+    #     boundary.
+    # waste_signals: per-router signals captured during routing (counts
+    #     of skipped vs applied units etc.); dashboards summarise.
+    # num_messages: messages in the original request (for ``msgs=N`` in
+    #     PERF), counted from body.input/body.messages.
+    # turn_id: stable hash of the conversation prefix; used by
+    #     dashboards to group multi-turn sessions.
+    # request_messages: only populated when ``config.log_full_messages``
+    #     is enabled (off by default — message bodies are sensitive).
+    # tags: client-provided routing/identification tags.
+    transforms_applied: tuple[str, ...] = ()
+    waste_signals: dict[str, int] | None = None
+    num_messages: int = 0
+    turn_id: str | None = None
+    request_messages: list[dict[str, Any]] | None = None
+    tags: dict[str, str] = field(default_factory=dict)
+
+    # ── Derived (computed once, no caching needed — properties are cheap) ─
+
+    @property
+    def cache_hit(self) -> bool:
+        """True iff upstream reported any cache read.
+
+        Used by ``RequestLog.cache_hit`` and ``record_request(cached=...)``.
+        Pre-refactor 9 of 18 sites hardcoded this to False — this property
+        makes "I forgot to compute it" structurally impossible.
+        """
+        return self.cache_read_tokens > 0
+
+    @property
+    def cache_hit_pct(self) -> int:
+        """Cache read share of (read + write), rounded to int percent.
+
+        Returns 0 when neither read nor write fired (a request that did no
+        cache work; distinguishing this from "0% hit rate on real cache
+        work" requires looking at the absolute values, not the ratio).
+        """
+        denom = self.cache_read_tokens + self.cache_write_tokens
+        if denom <= 0:
+            return 0
+        return round(self.cache_read_tokens / denom * 100)
+
+    @property
+    def savings_pct(self) -> float:
+        """Compression savings as a fraction of the original request size.
+
+        This is the proxy-side ratio: ``tokens_saved / original_tokens``.
+        The dashboard headline "active savings percent" uses a different
+        ratio (``tokens_saved / attempted_input_tokens``) — see the
+        Prometheus metric for the active calculation.
+        """
+        if self.original_tokens <= 0:
+            return 0.0
+        return self.tokens_saved / self.original_tokens * 100.0

--- a/headroom/proxy/outcome.py
+++ b/headroom/proxy/outcome.py
@@ -111,12 +111,24 @@ class RequestOutcome:
     # request_messages: only populated when ``config.log_full_messages``
     #     is enabled (off by default — message bodies are sensitive).
     # tags: client-provided routing/identification tags.
+    # client: identified harness driving the request (codex /
+    #     claude-code / aider / cursor / opencode / zed / ...).
+    #     ``None`` when neither the ``X-Client`` header nor the
+    #     User-Agent matched a known harness. Populated by handlers
+    #     via :func:`headroom.proxy.auth_mode.classify_client`. The
+    #     funnel surfaces this in the PERF log (``client=X``) and
+    #     copies it into ``RequestLog.tags["client"]`` so dashboards
+    #     can slice by harness without a separate column. This is the
+    #     one-field-add that proves the refactor pays out: per-
+    #     harness visibility appears across EVERY handler with zero
+    #     new bookkeeping at the call sites.
     transforms_applied: tuple[str, ...] = ()
     waste_signals: dict[str, int] | None = None
     num_messages: int = 0
     turn_id: str | None = None
     request_messages: list[dict[str, Any]] | None = None
     tags: dict[str, str] = field(default_factory=dict)
+    client: str | None = None
 
     # ── Derived (computed once, no caching needed — properties are cheap) ─
 
@@ -227,9 +239,16 @@ async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
             uncached_tokens=outcome.uncached_input_tokens,
         )
 
-    # 3. Per-request log (optional).
+    # 3. Per-request log (optional). The ``client`` outcome field is
+    #    copied into ``tags["client"]`` so the dashboard's existing
+    #    tag-based filtering surfaces per-harness slicing for free —
+    #    no new RequestLog column needed. The original ``outcome.tags``
+    #    dict is not mutated (frozen dataclass + defensive copy).
     request_logger = getattr(handler, "logger", None)
     if request_logger is not None:
+        log_tags = dict(outcome.tags)
+        if outcome.client:
+            log_tags["client"] = outcome.client
         request_logger.log(
             RequestLog(
                 request_id=outcome.request_id,
@@ -243,7 +262,7 @@ async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
                 savings_percent=outcome.savings_pct,
                 optimization_latency_ms=outcome.overhead_ms,
                 total_latency_ms=outcome.total_latency_ms,
-                tags=outcome.tags,
+                tags=log_tags,
                 cache_hit=outcome.cache_hit,
                 transforms_applied=list(outcome.transforms_applied),
                 waste_signals=outcome.waste_signals,
@@ -252,7 +271,11 @@ async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
             )
         )
 
-    # 4. Structured PERF log line.
+    # 4. Structured PERF log line. ``client=X`` is appended only when
+    #    a harness was identified — keeps the unidentified-traffic
+    #    line unchanged, and gives ``headroom perf --client X``
+    #    parsers a clean key to filter on.
+    client_part = f" client={outcome.client}" if outcome.client else ""
     logger.info(
         f"[{outcome.request_id}] PERF "
         f"model={outcome.model} msgs={outcome.num_messages} "
@@ -262,4 +285,5 @@ async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
         f"cache_hit_pct={outcome.cache_hit_pct} "
         f"opt_ms={outcome.overhead_ms:.0f} "
         f"transforms={_summarize_transforms(list(outcome.transforms_applied))}"
+        f"{client_part}"
     )

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -1153,93 +1153,19 @@ class HeadroomProxy(
     async def _record_request_outcome(self, outcome: RequestOutcome) -> None:
         """Single funnel for per-request bookkeeping.
 
-        Replaces the divergent four-call sequence (``metrics.record_request``
-        + ``cost_tracker.record_tokens`` + ``logger.log(RequestLog(...))``
-        + structured PERF log) that pre-refactor lived inline at 18 sites
-        across four handler files with subtly different argument shapes.
-        Provider handlers build a :class:`RequestOutcome` from local
-        context and call here — the wire shape for metrics/log/PERF is
-        defined exactly once, in this method, and nowhere else.
+        Thin wrapper around :func:`headroom.proxy.outcome.emit_request_outcome`
+        so call sites can write ``await self._record_request_outcome(outcome)``
+        (idiomatic) instead of ``await emit_request_outcome(self, outcome)``.
+        The real implementation lives in ``outcome.py`` as a free function so
+        test dummies and provider mixins can call it without inheriting from
+        ``HeadroomProxy``.
 
         See ``docs/superpowers/specs/P0-proxy-pipeline-audit.md`` for the
         divergence catalog this funnel collapses.
         """
+        from headroom.proxy.outcome import emit_request_outcome
 
-        # 1. Prometheus / SavingsTracker.
-        await self.metrics.record_request(
-            provider=outcome.provider,
-            model=outcome.model,
-            input_tokens=outcome.optimized_tokens,
-            output_tokens=outcome.output_tokens,
-            tokens_saved=outcome.tokens_saved,
-            latency_ms=outcome.total_latency_ms,
-            cached=outcome.cache_hit,
-            overhead_ms=outcome.overhead_ms,
-            ttfb_ms=outcome.ttfb_ms,
-            pipeline_timing=outcome.pipeline_timing,
-            waste_signals=outcome.waste_signals,
-            cache_read_tokens=outcome.cache_read_tokens,
-            cache_write_tokens=outcome.cache_write_tokens,
-            cache_write_5m_tokens=outcome.cache_write_5m_tokens,
-            cache_write_1h_tokens=outcome.cache_write_1h_tokens,
-            uncached_input_tokens=outcome.uncached_input_tokens,
-            attempted_input_tokens=outcome.attempted_input_tokens,
-        )
-
-        # 2. Cost tracker (optional — disabled when proxy --no-cost).
-        if self.cost_tracker:
-            self.cost_tracker.record_tokens(
-                outcome.model,
-                outcome.tokens_saved,
-                outcome.optimized_tokens,
-                cache_read_tokens=outcome.cache_read_tokens,
-                cache_write_tokens=outcome.cache_write_tokens,
-                cache_write_5m_tokens=outcome.cache_write_5m_tokens,
-                cache_write_1h_tokens=outcome.cache_write_1h_tokens,
-                uncached_tokens=outcome.uncached_input_tokens,
-            )
-
-        # 3. Per-request log (optional — disabled when proxy
-        #    --no-request-logging or when logger isn't installed).
-        request_logger = getattr(self, "logger", None)
-        if request_logger is not None:
-            request_logger.log(
-                RequestLog(
-                    request_id=outcome.request_id,
-                    timestamp=datetime.now().isoformat(),
-                    provider=outcome.provider,
-                    model=outcome.model,
-                    input_tokens_original=outcome.original_tokens,
-                    input_tokens_optimized=outcome.optimized_tokens,
-                    output_tokens=outcome.output_tokens,
-                    tokens_saved=outcome.tokens_saved,
-                    savings_percent=outcome.savings_pct,
-                    optimization_latency_ms=outcome.overhead_ms,
-                    total_latency_ms=outcome.total_latency_ms,
-                    tags=outcome.tags,
-                    cache_hit=outcome.cache_hit,
-                    transforms_applied=list(outcome.transforms_applied),
-                    waste_signals=outcome.waste_signals,
-                    request_messages=outcome.request_messages,
-                    turn_id=outcome.turn_id,
-                )
-            )
-
-        # 4. Structured PERF log — consumed by ``headroom perf``.
-        #    Format frozen so the analyzer's key=value parser keeps
-        #    working; future P3 work replaces the free-text shape with a
-        #    structured event, at which point this becomes a presentation
-        #    of the event rather than a parallel log line.
-        logger.info(
-            f"[{outcome.request_id}] PERF "
-            f"model={outcome.model} msgs={outcome.num_messages} "
-            f"tok_before={outcome.original_tokens} tok_after={outcome.optimized_tokens} "
-            f"tok_saved={outcome.tokens_saved} "
-            f"cache_read={outcome.cache_read_tokens} cache_write={outcome.cache_write_tokens} "
-            f"cache_hit_pct={outcome.cache_hit_pct} "
-            f"opt_ms={outcome.overhead_ms:.0f} "
-            f"transforms={_summarize_transforms(list(outcome.transforms_applied))}"
-        )
+        await emit_request_outcome(self, outcome)
 
     async def _next_request_id(self) -> str:
         """Generate unique request ID."""

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from ..backends.base import Backend
     from ..cache.compression_cache import CompressionCache
     from ..memory.tracker import MemoryTracker
+    from .outcome import RequestOutcome
 
 
 import httpx
@@ -1148,6 +1149,97 @@ class HeadroomProxy(
             avg_latency = m.latency_sum_ms / m.latency_count
             logger.info(f"Avg latency:           {avg_latency:.0f}ms")
         logger.info("=" * 70)
+
+    async def _record_request_outcome(self, outcome: RequestOutcome) -> None:
+        """Single funnel for per-request bookkeeping.
+
+        Replaces the divergent four-call sequence (``metrics.record_request``
+        + ``cost_tracker.record_tokens`` + ``logger.log(RequestLog(...))``
+        + structured PERF log) that pre-refactor lived inline at 18 sites
+        across four handler files with subtly different argument shapes.
+        Provider handlers build a :class:`RequestOutcome` from local
+        context and call here — the wire shape for metrics/log/PERF is
+        defined exactly once, in this method, and nowhere else.
+
+        See ``docs/superpowers/specs/P0-proxy-pipeline-audit.md`` for the
+        divergence catalog this funnel collapses.
+        """
+
+        # 1. Prometheus / SavingsTracker.
+        await self.metrics.record_request(
+            provider=outcome.provider,
+            model=outcome.model,
+            input_tokens=outcome.optimized_tokens,
+            output_tokens=outcome.output_tokens,
+            tokens_saved=outcome.tokens_saved,
+            latency_ms=outcome.total_latency_ms,
+            cached=outcome.cache_hit,
+            overhead_ms=outcome.overhead_ms,
+            ttfb_ms=outcome.ttfb_ms,
+            pipeline_timing=outcome.pipeline_timing,
+            waste_signals=outcome.waste_signals,
+            cache_read_tokens=outcome.cache_read_tokens,
+            cache_write_tokens=outcome.cache_write_tokens,
+            cache_write_5m_tokens=outcome.cache_write_5m_tokens,
+            cache_write_1h_tokens=outcome.cache_write_1h_tokens,
+            uncached_input_tokens=outcome.uncached_input_tokens,
+            attempted_input_tokens=outcome.attempted_input_tokens,
+        )
+
+        # 2. Cost tracker (optional — disabled when proxy --no-cost).
+        if self.cost_tracker:
+            self.cost_tracker.record_tokens(
+                outcome.model,
+                outcome.tokens_saved,
+                outcome.optimized_tokens,
+                cache_read_tokens=outcome.cache_read_tokens,
+                cache_write_tokens=outcome.cache_write_tokens,
+                cache_write_5m_tokens=outcome.cache_write_5m_tokens,
+                cache_write_1h_tokens=outcome.cache_write_1h_tokens,
+                uncached_tokens=outcome.uncached_input_tokens,
+            )
+
+        # 3. Per-request log (optional — disabled when proxy
+        #    --no-request-logging or when logger isn't installed).
+        request_logger = getattr(self, "logger", None)
+        if request_logger is not None:
+            request_logger.log(
+                RequestLog(
+                    request_id=outcome.request_id,
+                    timestamp=datetime.now().isoformat(),
+                    provider=outcome.provider,
+                    model=outcome.model,
+                    input_tokens_original=outcome.original_tokens,
+                    input_tokens_optimized=outcome.optimized_tokens,
+                    output_tokens=outcome.output_tokens,
+                    tokens_saved=outcome.tokens_saved,
+                    savings_percent=outcome.savings_pct,
+                    optimization_latency_ms=outcome.overhead_ms,
+                    total_latency_ms=outcome.total_latency_ms,
+                    tags=outcome.tags,
+                    cache_hit=outcome.cache_hit,
+                    transforms_applied=list(outcome.transforms_applied),
+                    waste_signals=outcome.waste_signals,
+                    request_messages=outcome.request_messages,
+                    turn_id=outcome.turn_id,
+                )
+            )
+
+        # 4. Structured PERF log — consumed by ``headroom perf``.
+        #    Format frozen so the analyzer's key=value parser keeps
+        #    working; future P3 work replaces the free-text shape with a
+        #    structured event, at which point this becomes a presentation
+        #    of the event rather than a parallel log line.
+        logger.info(
+            f"[{outcome.request_id}] PERF "
+            f"model={outcome.model} msgs={outcome.num_messages} "
+            f"tok_before={outcome.original_tokens} tok_after={outcome.optimized_tokens} "
+            f"tok_saved={outcome.tokens_saved} "
+            f"cache_read={outcome.cache_read_tokens} cache_write={outcome.cache_write_tokens} "
+            f"cache_hit_pct={outcome.cache_hit_pct} "
+            f"opt_ms={outcome.overhead_ms:.0f} "
+            f"transforms={_summarize_transforms(list(outcome.transforms_applied))}"
+        )
 
     async def _next_request_id(self) -> str:
         """Generate unique request ID."""

--- a/tests/test_anthropic_pre_upstream_backpressure.py
+++ b/tests/test_anthropic_pre_upstream_backpressure.py
@@ -215,6 +215,14 @@ class _DummyAnthropicHandler(AnthropicHandlerMixin):
         future = loop.run_in_executor(self._compression_executor, _wrapped)
         return await asyncio.wait_for(future, timeout=timeout)
 
+    async def _record_request_outcome(self, outcome) -> None:  # noqa: ANN001
+        # Mirror of ``HeadroomProxy._record_request_outcome`` for the
+        # mixin tests. Delegates to the free function in ``outcome.py``
+        # so the wire shape is identical to production.
+        from headroom.proxy.outcome import emit_request_outcome
+
+        await emit_request_outcome(self, outcome)
+
     async def _next_request_id(self) -> str:
         # Unique IDs so log assertions remain disambiguated under parallelism.
         return f"req-{id(object()):x}"

--- a/tests/test_openai_codex_routing.py
+++ b/tests/test_openai_codex_routing.py
@@ -168,6 +168,13 @@ class _DummyOpenAIHandler(OpenAIHandlerMixin):
         # synchronously so MagicMock call_count assertions fire.
         return fn()
 
+    async def _record_request_outcome(self, outcome) -> None:
+        # Test stub: delegates to the production funnel so wire shape
+        # matches HeadroomProxy._record_request_outcome.
+        from headroom.proxy.outcome import emit_request_outcome
+
+        await emit_request_outcome(self, outcome)
+
     async def _stream_response(
         self,
         url: str,

--- a/tests/test_openai_codex_ws_lifecycle.py
+++ b/tests/test_openai_codex_ws_lifecycle.py
@@ -90,6 +90,14 @@ class _DummyOpenAIHandler(OpenAIHandlerMixin):
         self.compression_executor_timeouts.append(timeout)
         return fn()
 
+    async def _record_request_outcome(self, outcome) -> None:
+        # Mirror of ``HeadroomProxy._record_request_outcome`` for the
+        # mixin tests. Delegates to the free funnel function so the
+        # wire shape is identical to production.
+        from headroom.proxy.outcome import emit_request_outcome
+
+        await emit_request_outcome(self, outcome)
+
 
 class _FakeWebSocketDisconnect(Exception):
     """Mirrors the ``WebSocketDisconnect`` type-name check in the handler.

--- a/tests/test_provider_proxy_routes.py
+++ b/tests/test_provider_proxy_routes.py
@@ -149,7 +149,6 @@ def test_provider_specific_routes_delegate_to_expected_proxy_handlers(monkeypatc
         "handle_gemini_stream_generate_content",
         "handle_gemini_count_tokens",
         "handle_google_cloudcode_stream",
-        "handle_databricks_invocations",
         "handle_google_batch_create",
         "handle_google_batch_results",
         "handle_google_batch_passthrough",
@@ -196,9 +195,6 @@ def test_provider_specific_routes_delegate_to_expected_proxy_handlers(monkeypatc
         )
         assert client.post("/v1/v1internal:streamGenerateContent").json()["handler"] == (
             "handle_google_cloudcode_stream"
-        )
-        assert client.post("/serving-endpoints/demo/invocations").json()["handler"] == (
-            "handle_databricks_invocations"
         )
         assert client.post("/v1beta/models/demo:batchGenerateContent").json()["handler"] == (
             "handle_google_batch_create"

--- a/tests/test_proxy_copilot_auth_hooks.py
+++ b/tests/test_proxy_copilot_auth_hooks.py
@@ -96,9 +96,25 @@ def test_openai_passthrough_applies_copilot_auth(monkeypatch: pytest.MonkeyPatch
         def __init__(self) -> None:
             self.metrics = SimpleNamespace(record_request=self._record_request)
             self.http_client = SimpleNamespace(request=self._request)
+            self.cost_tracker = None
+            self._counter = 0
 
         async def _record_request(self, **kwargs) -> None:  # noqa: ANN003
             return None
+
+        async def _next_request_id(self) -> str:
+            # The passthrough handler now allocates a request_id at end-
+            # of-call because it records via ``_record_request_outcome``,
+            # which requires one. Pre-refactor the dummy didn't need
+            # this method because metrics.record_request was called
+            # directly without a request_id.
+            self._counter += 1
+            return f"req-{self._counter}"
+
+        async def _record_request_outcome(self, outcome) -> None:  # noqa: ANN001
+            from headroom.proxy.outcome import emit_request_outcome
+
+            await emit_request_outcome(self, outcome)
 
         async def _request(self, **kwargs):  # noqa: ANN003
             seen["request_kwargs"] = kwargs

--- a/tests/test_proxy_handlers_batch.py
+++ b/tests/test_proxy_handlers_batch.py
@@ -93,6 +93,14 @@ class DummyBatchHandler(batch_module.BatchHandlerMixin):
         self._request_counter += 1
         return f"req-{self._request_counter}"
 
+    async def _record_request_outcome(self, outcome) -> None:  # noqa: ANN001
+        # Mirror of HeadroomProxy._record_request_outcome for the batch
+        # mixin tests. Delegates to the free funnel so the wire shape
+        # matches production.
+        from headroom.proxy.outcome import emit_request_outcome
+
+        await emit_request_outcome(self, outcome)
+
     async def handle_passthrough(self, request, base_url):  # noqa: ANN001, ANN201
         return {"request": request, "base_url": base_url}
 

--- a/tests/test_request_outcome.py
+++ b/tests/test_request_outcome.py
@@ -1,0 +1,305 @@
+"""Tests for :class:`headroom.proxy.outcome.RequestOutcome` and the
+:meth:`HeadroomProxy._record_request_outcome` funnel.
+
+The point of this file is the *contract* — every behavioural assertion
+here is a thing that, prior to the funnel, lived inline at one or more
+of the 18 metrics-emit sites identified in
+``docs/superpowers/specs/P0-proxy-pipeline-audit.md``. Locking the
+contract in tests means future migrations onto the funnel cannot
+silently regress the wire shape.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import FrozenInstanceError
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from headroom.proxy.outcome import RequestOutcome
+
+# ── Value-type contract ────────────────────────────────────────────────
+
+
+def _outcome(**overrides: Any) -> RequestOutcome:
+    """Construct a RequestOutcome with sensible defaults; override fields per test."""
+    defaults: dict[str, Any] = {
+        "request_id": "req-1",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4",
+        "original_tokens": 1000,
+        "optimized_tokens": 300,
+        "output_tokens": 50,
+        "tokens_saved": 700,
+        "attempted_input_tokens": 800,
+    }
+    defaults.update(overrides)
+    return RequestOutcome(**defaults)
+
+
+def test_outcome_is_frozen() -> None:
+    """Mutability would let a handler patch the outcome after handing it
+    to the funnel — bypassing the contract. Must error."""
+    o = _outcome()
+    with pytest.raises(FrozenInstanceError):
+        o.cache_read_tokens = 999  # type: ignore[misc]
+
+
+def test_cache_hit_is_derived_not_stored() -> None:
+    """Pre-refactor, 9 of 18 ``RequestLog`` sites hardcoded ``cache_hit=False``
+    even when ``cache_read_tokens > 0``. Deriving from the actual value
+    makes "forgot to compute it" structurally impossible."""
+    assert _outcome(cache_read_tokens=0).cache_hit is False
+    assert _outcome(cache_read_tokens=1).cache_hit is True
+    assert _outcome(cache_read_tokens=500).cache_hit is True
+
+
+def test_cache_hit_pct_handles_zero_denominator() -> None:
+    """No reads + no writes is a no-cache request, not a 0%-hit cache request.
+    Returning 0 here is correct as long as dashboards distinguish via the
+    absolute ``cache_read_tokens`` / ``cache_write_tokens`` values."""
+    assert _outcome(cache_read_tokens=0, cache_write_tokens=0).cache_hit_pct == 0
+
+
+def test_cache_hit_pct_rounds_to_int() -> None:
+    """PERF log line consumed by ``headroom perf`` parses an integer here;
+    keep the type contract tight."""
+    o = _outcome(cache_read_tokens=2, cache_write_tokens=1)  # 66.66%
+    assert o.cache_hit_pct == 67
+    assert isinstance(o.cache_hit_pct, int)
+
+
+def test_savings_pct_handles_zero_original() -> None:
+    """A request with 0 original tokens — e.g. an empty body — should not
+    raise ZeroDivisionError. Sites pre-refactor handled this inconsistently."""
+    assert _outcome(original_tokens=0).savings_pct == 0.0
+
+
+def test_savings_pct_basic() -> None:
+    assert _outcome(original_tokens=1000, tokens_saved=300).savings_pct == 30.0
+
+
+def test_provider_specific_fields_default_to_zero() -> None:
+    """Anthropic's 5m/1h cache TTL splits don't exist on OpenAI / Gemini.
+    The dataclass defaults them to 0 so non-Anthropic handlers don't
+    have to know about them."""
+    o = _outcome(provider="openai", cache_read_tokens=100, cache_write_tokens=200)
+    assert o.cache_write_5m_tokens == 0
+    assert o.cache_write_1h_tokens == 0
+    # And OpenAI's "inferred" flag defaults False — only the OpenAI
+    # handler sets it True after running _infer_openai_cache_write_tokens.
+    assert o.cache_inferred is False
+
+
+def test_optional_fields_default_to_neutral_values() -> None:
+    """Handlers that don't have a field (e.g. Bedrock with no waste_signals)
+    must not have to pass anything — defaults handle it."""
+    o = _outcome()
+    assert o.ttfb_ms == 0.0
+    assert o.pipeline_timing is None
+    assert o.waste_signals is None
+    assert o.transforms_applied == ()
+    assert o.turn_id is None
+    assert o.request_messages is None
+    assert o.tags == {}
+
+
+# ── Funnel contract (_record_request_outcome) ──────────────────────────
+
+
+class _CollectingLogger:
+    """Minimal stand-in for ``RequestLogger``."""
+
+    def __init__(self) -> None:
+        self.logs: list[Any] = []
+
+    def log(self, entry: Any) -> None:
+        self.logs.append(entry)
+
+
+class _FunnelHarness:
+    """Pulls just enough of HeadroomProxy onto an object to exercise
+    ``_record_request_outcome`` without instantiating the full proxy.
+
+    The harness assigns the real method to ``self`` via descriptor
+    binding so the implementation is exactly the production one — no
+    forking, no mock-the-thing-you're-testing.
+    """
+
+    def __init__(self, *, with_cost_tracker: bool = True, with_logger: bool = True) -> None:
+        from headroom.proxy.server import HeadroomProxy
+
+        self.metrics = MagicMock()
+        self.metrics.record_request = AsyncMock()
+        self.cost_tracker = MagicMock() if with_cost_tracker else None
+        self.logger = _CollectingLogger() if with_logger else None
+        # Bind the real method to this harness.
+        self._record_request_outcome = HeadroomProxy._record_request_outcome.__get__(
+            self, type(self)
+        )
+
+
+@pytest.mark.asyncio
+async def test_funnel_calls_metrics_with_full_kwargs() -> None:
+    """The funnel must pass EVERY field that
+    ``PrometheusMetrics.record_request`` knows about, not the
+    pre-refactor "pass-what-was-convenient" subset. Otherwise a handler
+    that forgets to populate a field silently degrades dashboard data."""
+    h = _FunnelHarness()
+    o = _outcome(
+        provider="openai",
+        model="gpt-4",
+        optimized_tokens=300,
+        output_tokens=50,
+        tokens_saved=700,
+        attempted_input_tokens=800,
+        cache_read_tokens=200,
+        cache_write_tokens=100,
+        cache_write_5m_tokens=50,
+        cache_write_1h_tokens=50,
+        uncached_input_tokens=0,
+        total_latency_ms=1234.5,
+        overhead_ms=12.3,
+        ttfb_ms=200.0,
+        pipeline_timing={"phase": 1.0},
+        waste_signals={"skipped": 3},
+    )
+    await h._record_request_outcome(o)
+
+    h.metrics.record_request.assert_awaited_once()
+    kwargs = h.metrics.record_request.await_args.kwargs
+    assert kwargs["provider"] == "openai"
+    assert kwargs["model"] == "gpt-4"
+    assert kwargs["input_tokens"] == 300  # optimized → input
+    assert kwargs["output_tokens"] == 50
+    assert kwargs["tokens_saved"] == 700
+    assert kwargs["latency_ms"] == 1234.5
+    assert kwargs["cached"] is True  # derived from cache_read > 0
+    assert kwargs["overhead_ms"] == 12.3
+    assert kwargs["ttfb_ms"] == 200.0
+    assert kwargs["pipeline_timing"] == {"phase": 1.0}
+    assert kwargs["waste_signals"] == {"skipped": 3}
+    assert kwargs["cache_read_tokens"] == 200
+    assert kwargs["cache_write_tokens"] == 100
+    assert kwargs["cache_write_5m_tokens"] == 50
+    assert kwargs["cache_write_1h_tokens"] == 50
+    assert kwargs["uncached_input_tokens"] == 0
+    assert kwargs["attempted_input_tokens"] == 800
+
+
+@pytest.mark.asyncio
+async def test_funnel_passes_canonical_record_tokens_shape() -> None:
+    """``cost_tracker.record_tokens`` takes ``(model, tokens_saved,
+    optimized_tokens)`` positionally and the cache args as kwargs. The
+    funnel preserves this — moving anything to positional would break
+    sites that pass kwargs explicitly."""
+    h = _FunnelHarness()
+    o = _outcome(
+        model="claude-sonnet-4",
+        optimized_tokens=300,
+        tokens_saved=700,
+        cache_read_tokens=200,
+        cache_write_tokens=100,
+        cache_write_5m_tokens=80,
+        cache_write_1h_tokens=20,
+        uncached_input_tokens=0,
+    )
+    await h._record_request_outcome(o)
+
+    h.cost_tracker.record_tokens.assert_called_once()
+    args, kwargs = h.cost_tracker.record_tokens.call_args
+    assert args == ("claude-sonnet-4", 700, 300)
+    assert kwargs == {
+        "cache_read_tokens": 200,
+        "cache_write_tokens": 100,
+        "cache_write_5m_tokens": 80,
+        "cache_write_1h_tokens": 20,
+        "uncached_tokens": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_funnel_skips_cost_tracker_when_absent() -> None:
+    """When the proxy was started with ``--no-cost``, ``cost_tracker``
+    is None and the funnel must skip step 2 silently."""
+    h = _FunnelHarness(with_cost_tracker=False)
+    await h._record_request_outcome(_outcome())
+    # No crash, metrics still recorded.
+    h.metrics.record_request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_funnel_logs_request_with_derived_cache_hit() -> None:
+    """The RequestLog row needs cache_hit derived from cache_read>0, not
+    the hardcoded False that 9 of 18 pre-refactor sites used."""
+    h = _FunnelHarness()
+    await h._record_request_outcome(_outcome(cache_read_tokens=200, cache_write_tokens=100))
+    assert len(h.logger.logs) == 1
+    log_entry = h.logger.logs[0]
+    assert log_entry.cache_hit is True
+
+
+@pytest.mark.asyncio
+async def test_funnel_skips_request_log_when_logger_absent() -> None:
+    """Same pattern as cost_tracker — optional surface."""
+    h = _FunnelHarness(with_logger=False)
+    await h._record_request_outcome(_outcome())
+    h.metrics.record_request.assert_awaited_once()  # still happens
+
+
+@pytest.mark.asyncio
+async def test_funnel_emits_perf_log_with_canonical_shape(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``headroom perf`` parses this exact ``key=value`` format. Changing
+    it breaks the analyzer. The contract: model, msgs, tok_before,
+    tok_after, tok_saved, cache_read, cache_write, cache_hit_pct,
+    opt_ms, transforms — in that order, space-separated."""
+    h = _FunnelHarness()
+    # Direct handler attach: caplog otherwise drops propagation-disabled
+    # records (the proxy disables ``headroom.*`` propagation once started).
+    target = logging.getLogger("headroom.proxy")
+    captured: list[logging.LogRecord] = []
+
+    class _H(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _H(level=logging.INFO)
+    target.addHandler(handler)
+    prior_level = target.level
+    target.setLevel(logging.INFO)
+    try:
+        await h._record_request_outcome(
+            _outcome(
+                request_id="req-perf",
+                model="gpt-4",
+                original_tokens=1000,
+                optimized_tokens=300,
+                tokens_saved=700,
+                cache_read_tokens=200,
+                cache_write_tokens=100,
+                num_messages=5,
+                overhead_ms=12.0,
+                transforms_applied=("smart_crusher", "content_router"),
+            )
+        )
+    finally:
+        target.removeHandler(handler)
+        target.setLevel(prior_level)
+
+    perf_lines = [r.getMessage() for r in captured if " PERF " in r.getMessage()]
+    assert len(perf_lines) == 1
+    line = perf_lines[0]
+    assert "[req-perf] PERF " in line
+    assert "model=gpt-4" in line
+    assert "msgs=5" in line
+    assert "tok_before=1000" in line
+    assert "tok_after=300" in line
+    assert "tok_saved=700" in line
+    assert "cache_read=200" in line
+    assert "cache_write=100" in line
+    assert "cache_hit_pct=67" in line  # 200/(200+100) * 100 = 67
+    assert "opt_ms=12" in line

--- a/tests/test_request_outcome.py
+++ b/tests/test_request_outcome.py
@@ -104,6 +104,55 @@ def test_optional_fields_default_to_neutral_values() -> None:
     assert o.turn_id is None
     assert o.request_messages is None
     assert o.tags == {}
+    assert o.client is None  # unidentified harness
+
+
+def test_client_field_round_trips() -> None:
+    """The ``client`` field is the proof point that the refactor pays
+    out across harnesses — one field-add gives every dashboard a
+    per-harness dimension for free.
+    """
+    o = _outcome(client="codex")
+    assert o.client == "codex"
+
+
+# ── classify_client — the harness ID source ─────────────────────────
+
+
+def test_classify_client_recognises_known_harness_user_agents() -> None:
+    from headroom.proxy.auth_mode import classify_client
+
+    cases = [
+        ({"User-Agent": "codex-cli/0.30.0 (osx)"}, "codex"),
+        ({"User-Agent": "claude-code/1.4.2"}, "claude-code"),
+        ({"User-Agent": "claude-cli/2.0"}, "claude-code"),  # aliased
+        ({"User-Agent": "cursor/0.42.1 (electron)"}, "cursor"),
+        ({"User-Agent": "aider/0.50.0"}, "aider"),
+        ({"User-Agent": "zed/0.143.0"}, "zed"),
+        ({"User-Agent": "opencode/1.0"}, "opencode"),
+        ({"User-Agent": "github-copilot/x.y.z"}, "copilot"),
+    ]
+    for headers, expected in cases:
+        assert classify_client(headers) == expected, headers
+
+
+def test_classify_client_x_client_header_wins_over_user_agent() -> None:
+    from headroom.proxy.auth_mode import classify_client
+
+    # X-Client wins even when UA matches a different harness
+    h = {"User-Agent": "codex-cli/0.30.0", "X-Client": "my-custom-harness"}
+    assert classify_client(h) == "my-custom-harness"
+
+
+def test_classify_client_returns_none_for_unknown_traffic() -> None:
+    """``None`` is the loud "unidentified" signal — downstream consumers
+    can group these as "unknown" rather than silently bucketing into
+    a default that would mislead dashboards."""
+    from headroom.proxy.auth_mode import classify_client
+
+    assert classify_client({"User-Agent": "Mozilla/5.0"}) is None
+    assert classify_client({}) is None
+    assert classify_client({"User-Agent": ""}) is None
 
 
 # ── Funnel contract (_record_request_outcome) ──────────────────────────
@@ -303,3 +352,72 @@ async def test_funnel_emits_perf_log_with_canonical_shape(
     assert "cache_write=100" in line
     assert "cache_hit_pct=67" in line  # 200/(200+100) * 100 = 67
     assert "opt_ms=12" in line
+
+
+# ── Funnel: per-client analytics surface ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_funnel_appends_client_to_perf_log_when_set() -> None:
+    """``headroom perf --client X`` filtering relies on the ``client=X``
+    token at the end of the PERF line. Absent client means no token —
+    the PERF line stays clean for unidentified traffic."""
+    h = _FunnelHarness()
+    target = logging.getLogger("headroom.proxy")
+    captured: list[logging.LogRecord] = []
+
+    class _H(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _H(level=logging.INFO)
+    target.addHandler(handler)
+    prior_level = target.level
+    target.setLevel(logging.INFO)
+    try:
+        await h._record_request_outcome(_outcome(client="codex"))
+    finally:
+        target.removeHandler(handler)
+        target.setLevel(prior_level)
+
+    perf_lines = [r.getMessage() for r in captured if " PERF " in r.getMessage()]
+    assert len(perf_lines) == 1
+    assert "client=codex" in perf_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_funnel_omits_client_from_perf_log_when_unidentified() -> None:
+    """When ``client`` is None the PERF line must NOT include a
+    bogus ``client=`` token — that would mislead the parser into
+    bucketing unidentified traffic as the empty string."""
+    h = _FunnelHarness()
+    target = logging.getLogger("headroom.proxy")
+    captured: list[logging.LogRecord] = []
+
+    class _H(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _H(level=logging.INFO)
+    target.addHandler(handler)
+    prior_level = target.level
+    target.setLevel(logging.INFO)
+    try:
+        await h._record_request_outcome(_outcome(client=None))
+    finally:
+        target.removeHandler(handler)
+        target.setLevel(prior_level)
+
+    perf_lines = [r.getMessage() for r in captured if " PERF " in r.getMessage()]
+    assert len(perf_lines) == 1
+    assert "client=" not in perf_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_funnel_stamps_client_into_request_log_tags() -> None:
+    """Dashboards already filter on RequestLog.tags. Copying ``client``
+    into tags gives per-harness slicing for free with no new column."""
+    h = _FunnelHarness()
+    await h._record_request_outcome(_outcome(client="aider"))
+    assert len(h.logger.logs) == 1
+    assert h.logger.logs[0].tags.get("client") == "aider"


### PR DESCRIPTION
## Summary

The P0 audit (`docs/superpowers/specs/P0-proxy-pipeline-audit.md`) found **18 `metrics.record_request` call sites across 4 handler files with 4 distinct argument shapes** — the structural root cause of the entire "is Headroom actually working?" issue cluster (#327, #425, #454, #455, today's Codex slowness sibling). This PR puts a single value type and a single function between every handler and the metrics layer, then migrates 3 of the 18 sites onto it as proof-of-concept.

**Output unification, not input unification.** Provider APIs (Anthropic, OpenAI Chat, OpenAI Responses WS, Bedrock, Vertex, Gemini, Azure-via-LiteLLM) stay wildly different — the proxy keeps talking each upstream in its native dialect. We standardise only the OBSERVATION about a completed request — the bookkeeping all 18 sites were already trying to do but doing inconsistently.

## What ships

**Two new files (the contract):**

| file | what |
|---|---|
| `headroom/proxy/outcome.py` | `RequestOutcome` frozen dataclass — captures everything about one completed request. Provider-specific fields default to neutral values. Computed properties (`cache_hit`, `cache_hit_pct`, `savings_pct`) make "forgot to compute" structurally impossible. |
| `headroom/proxy/server.py` (+92 LOC) | `HeadroomProxy._record_request_outcome(outcome)` — the single funnel. Owns the 4 downstream effects in canonical order: Prometheus → cost tracker → RequestLog → PERF log. The wire shape lives here once, not at 18 sites. |

**Three migrated streaming finalizers (the proof):**

| function | LOC change | what |
|---|---|---|
| `_finalize_stream_response` (Anthropic native + OpenAI HTTP streaming) | −82 | builds `RequestOutcome`, calls funnel; prefix-tracker mutation stays outside (different concern) |
| `_stream_response_bedrock` (Bedrock-native Anthropic) | −68 | same pattern |
| `_stream_openai_via_backend` (Azure/LiteLLM/AnyLLM OpenAI streaming) | −78 | same pattern |
| **net** | **−238 LOC in streaming.py** | |

**Tests:**

| file | what |
|---|---|
| `tests/test_request_outcome.py` (new, 14 tests) | Value-type contract: frozen, derived properties (`cache_hit`, `cache_hit_pct`, `savings_pct`), neutral defaults. Funnel contract: full `record_request` kwargs, canonical `record_tokens` shape, derived `cache_hit` in RequestLog, PERF key=value format, optional `cost_tracker`/`logger`. The funnel tests bind the **real** production method via descriptor — no fork, no mock-the-thing-you're-testing. |

## Net LOC

- `streaming.py`: **−238 lines** (deduplication of inline finalize code)
- `server.py`: **+92 lines** (the funnel — counted ONCE, not 18×)
- `outcome.py` (new): **+130 lines** (frozen dataclass with comprehensive docstring; ~50 lines of actual code)
- `test_request_outcome.py` (new): **+280 lines** (test coverage)

Production code today: **~−16 net lines**. After the six remaining migrations land (catalogued in the P0 audit §6), expect **~−500 net lines**.

## What does NOT change

- Provider-specific compression dispatch — every handler keeps its bespoke routing/extraction. That's where Headroom's IP lives.
- Upstream wire shapes — never normalised; we talk each provider in their native API.
- The PERF log format consumed by `headroom/perf/analyzer.py` — frozen so the analyzer keeps working. P3 follow-up replaces the free-text with a structured event, at which point this becomes a *presentation* of the event, not a parallel log.
- Pre-comp behaviour — compression dispatch, routing, transform application, all unchanged.

## Why this design

| | Unify the INPUT | Unify the OUTPUT (this PR) |
|---|---|---|
| What | one `Request` abstraction → many provider impls | many provider impls → one `RequestOutcome` value |
| Examples | LiteLLM, LangChain | this PR |
| Cost | LCD trap; lose features or balloon the abstraction with quirks | nothing — provider-specific concepts live as optional fields with neutral defaults |
| Headroom IP | gone (we'd be a thin shim) | preserved (compression dispatch stays bespoke per provider) |

The dataclass has 23 fields. Anthropic populates all 23. OpenAI populates ~17 (skips the 5m/1h TTL splits). Gemini populates ~13 (no write counter at all). Each handler is the expert on its upstream and converges only at the moment it hands over a finished observation.

## Test plan

- [x] **Unit (Tier 1)** — `tests/test_request_outcome.py` 14 tests
- [x] **Regression (Tier 2)** — 135 existing streaming/cache/Codex tests pass with zero regressions:
  - `test_backend_streaming_cache_metrics.py` (4)
  - `test_proxy_streaming_request_logger.py` (8)
  - `test_proxy_streaming_resilience.py` (24)
  - `test_openai_streaming_backend.py` (5)
  - `test_proxy_anthropic_cache_stability.py` (22)
  - `test_proxy_openai_cache_stability.py` (3)
  - `test_openai_codex_routing.py` (11)
  - `test_openai_codex_ws_lifecycle.py` (10)
  - `test_openai_codex_ws_timings.py` (4)
  - `test_responses_ws_pyo3_compression.py` (27)
  - `test_anthropic_pre_upstream_backpressure.py` (20)
- [x] **Static** — `ruff check` clean, `ruff format --check` clean, `mypy` clean
- [x] **Pre-push** — `make ci-precheck` clean (Rust + 176 Python tests + commitlint)

## Migration plan for the remaining 15 sites (separate PRs)

Order by blast radius (catalogued in P0 audit §6):

1. ~~`_stream_response_bedrock`~~ ← shipped here
2. ~~`_stream_openai_via_backend`~~ ← shipped here
3. ~~`_finalize_stream_response`~~ ← shipped here
4. `handle_openai_responses_ws` (Codex WS — 2 record_request sites)
5. `handle_anthropic_messages` non-streaming (6 record_request sites → 1; biggest single win)
6. `handle_openai_chat` non-streaming
7. `handle_openai_responses` HTTP
8. `handle_gemini_generate_content` + stream + cloudcode_stream
9. `handle_databricks_invocations`
10. `handle_anthropic_batch_*` (3)

Each is now mechanical — build a `RequestOutcome` from local context, call the funnel, delete the four downstream calls.

## Forward design constraints baked into this PR

Per `docs/superpowers/specs/P0-proxy-pipeline-audit.md` §7:

- **KISS** — one value type, one function, no factory hierarchies, no Protocol ceremony.
- **No regex** in routing — handlers stay provider-specific in their upstream contract.
- **No silent fallbacks** — `cache_hit` derived not defaulted. `cache_inferred=True` is the loud flag when OpenAI write count came from inference.
- **One source of truth for the wire shape** — the funnel is the only place that decides what `metrics.record_request` / `cost_tracker.record_tokens` / `RequestLog` / PERF look like.