### PR TITLE
fix(build): shrink Rust extension wheels (strip + thin-LTO + single codegen unit)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.21.33"
+    "version": "0.21.37"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.21.33",
+      "version": "0.21.37",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.21.33"
+    "version": "0.21.37"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.21.33",
+      "version": "0.21.37",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,34 @@ aws-smithy-runtime-api = { version = "1", default-features = false, features = [
 # us baking provider-specific knowledge in. The token source is wrapped
 # in a `TokenSource` trait so tests inject a static-token mock.
 gcp_auth = "0.12"
+
+
+# ── Release profile — wheel size optimization ───────────────────────
+#
+# PyPI imposes a 10 GB cumulative storage limit per project. We hit it
+# at version 0.21.36 (191 versions × ~213 MB/release = 10.00 GB
+# exactly). Recent wheels were ~16-18 MB each, of which ~6.4 MB was
+# pure debug metadata (`.strtab` + `.symtab` ELF sections; uncovered
+# by post-mortem inspection of an actual production wheel).
+#
+# This profile shrinks each Linux wheel from ~18 MB → ~10-11 MB by:
+# * Stripping symbol/string tables (~6.4 MB direct savings)
+# * Link-time optimization across crate boundaries (~5-10% .text
+#   savings via dead-code elim across the workspace)
+# * Single codegen unit (better inlining + dead-code elim, at the
+#   cost of slightly slower release builds)
+#
+# We deliberately do NOT set ``panic = "abort"``. The proxy is a
+# long-lived async process — a single misbehaving request triggering
+# panic-abort would terminate the whole proxy and disconnect every
+# concurrent client. Accept the smaller savings; keep unwind behaviour.
+#
+# Estimated impact: 213 MB/release → ~130 MB/release. Buys ~30+ more
+# release slots within the 10 GB ceiling at the current release
+# cadence. Per-PyPI-version savings AND faster downloads for end
+# users. Tradeoff: release builds take ~30-50% longer due to
+# `codegen-units = 1` + LTO; acceptable for the size win.
+[profile.release]
+strip = "symbols"
+lto = "thin"
+codegen-units = 1

--- a/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.21.33",
+  "version": "0.21.37",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/plugins/headroom-agent-hooks/.github/plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.21.33",
+  "version": "0.21.37",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",


### PR DESCRIPTION
## The problem

v0.21.37 release publish failed:

\`\`\`
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
Project size too large. Limit for project 'headroom-ai' total size is 10 GB.
\`\`\`

PyPI inventory confirmed: **191 versions × ~213 MB/release = 10.00 GB exactly**. At the ceiling.

## Why each wheel is so big

Post-mortem on \`headroom_ai-0.21.36-cp311-cp311-manylinux_2_28_x86_64.whl\` showed the embedded \`headroom/_core.*.so\` was **41 MB uncompressed (~18 MB packed)**, and \`file\` reported it as \`not stripped\`:

| section | size | what |
|---|---:|---|
| \`.text\` | 18.3 MB | code |
| \`.rodata\` | 11.4 MB | embedded model data |
| \`.strtab\` | 4.9 MB | **debug strings — strippable** |
| \`.eh_frame\` | 1.9 MB | unwind tables |
| \`.symtab\` | 1.5 MB | **debug symbols — strippable** |

**~6.4 MB of every wheel was pure debug metadata.**

## The fix

\`\`\`toml
[profile.release]
strip      = "symbols"
lto        = "thin"
codegen-units = 1
\`\`\`

- **\`strip = \"symbols\"\`** — drops \`.symtab\` + \`.strtab\` (~6.4 MB)
- **\`lto = \"thin\"\`** — cross-crate dead-code elimination (~5-10% \`.text\` savings)
- **\`codegen-units = 1\`** — better inlining + DCE at the cost of ~30-50% slower release builds

**Deliberately NOT setting \`panic = \"abort\"\`** — the proxy is long-lived async; a panic-abort on one bad request would kill the whole process and disconnect every concurrent client. Accept the smaller savings.

## Verification

- Local build of \`headroom._core\` with the new profile: macOS .so dropped to 29 MB (was ~45 MB pre-fix).
- 77 Rust-parity tests pass — extension still functional.
- Pre-commit hooks (ruff/format/mypy) clean (no Python changes).

## Estimated impact

| | before | after |
|---|---:|---:|
| per wheel (compressed) | ~16-18 MB | ~10-11 MB |
| per release (12 wheels) | ~213 MB | ~130 MB |
| PyPI capacity remaining | 0 GB | ~3.5 GB (~30 more releases) |

## Out of scope for this PR — follow-ups

1. **Submit a PyPI project-size-limit-increase request** — unblocks the immediate v0.21.37 release. Manual issue submission at \`https://docs.pypi.org/project-management/storage-limits#requesting-a-project-size-limit-increase\`.
2. **Adopt a deprecation policy** — yank+delete versions older than N patches per minor. Drop Python 3.10 wheels (EOL'd Oct 2026) and manylinux_2_28_aarch64 wheels (niche audience, the largest at 18.75 MB each).
3. **Magika runtime download** — currently bundled in \`.rodata\` (~10 MB). Same pattern Kompress already uses for its ONNX model would save ~10 MB more per wheel.

## Test plan

- [x] Local Rust build succeeds with new profile
- [x] 77 Rust-parity tests pass
- [x] Pre-commit hooks clean
- [ ] CI build matrix (\`cibuildwheel\` on Linux/macOS) — will be exercised by this PR's CI
- [ ] Manual download + size verification of the resulting wheels (post-CI)

🤖 Generated with Claude Code