### PR TITLE
fix(tests): widen wrap-e2e openclaw startup timeout to 30s

### DIFF
--- a/e2e/wrap/run.py
+++ b/e2e/wrap/run.py
@@ -714,7 +714,8 @@ def verify_openclaw_wrap(
             "--proxy-port",
             str(port),
             "--startup-timeout-ms",
-            "5000",
+            # 5s is too tight for cold Python+pyo3 import on a busy CI runner.
+            "30000",
             "--verbose",
         ],
         env=base_env,


### PR DESCRIPTION
## Summary
- `e2e/wrap/run.py` called `headroom wrap openclaw` with `--startup-timeout-ms 5000`. On a busy CI runner the openclaw plugin's auto-start launcher gives up before headroom cold-boots, and the run reports `[plugins] Headroom proxy unavailable: health check failed`. This was always coin-flip flake territory — 5s is below the typical cold-import time of `headroom.cli` + pyo3 dlopen + FastAPI boot.
- Bumped to `30000` — matches the existing 20s default in `headroom wrap`'s click option plus a buffer for CI runner contention.

## Root cause / evidence
- Run [25897154424](https://github.com/chopratejas/headroom/actions/runs/25897154424) failed on main with the **exact code** that passed pre-merge on PR #474's `docker-wrap-e2e` check (run 25897085244 — `MERGE_COMMIT_SHA == d73cbd6` on both runs, no extra commits).
- Both logs contain the same openclaw `Config warnings: plugins.entries.headroom: plugin not found (stale config entry ignored)` line — that wording is normal noise, not the failure trigger.
- The differentiator is the very next line:
  - pass: `[plugins] Headroom proxy started and reachable at http://127.0.0.1:28891`
  - fail: `[plugins] Headroom proxy unavailable: Error: Attempted to start Headroom proxy, but it was not reachable ... (health check failed)`
- The 5000ms ceiling is the only knob between those two outcomes.

## Test plan
- [ ] `make ci-precheck` clean locally (passed)
- [ ] CI `docker-native-e2e` + `docker-wrap-e2e` both green on this PR