### PR TITLE
fix(cli): wrap CLI breadth — cline, continue, goose, openhands

### DIFF
--- a/e2e/wrap/run.py
+++ b/e2e/wrap/run.py
@@ -26,6 +26,14 @@ CODEX_PORT = 28888
 AIDER_PORT = 28889
 CURSOR_PORT = 28890
 OPENCLAW_PROXY_PORT = 28891
+# Phase G PR-G1: new wrap subcommands. Smoke-tested via --prepare-only since
+# their CLIs may not exist on the e2e image and the wrap commands without
+# --prepare-only block on the proxy. The wiring is otherwise covered by the
+# unit tests in tests/test_cli/test_wrap_{cline,continue,goose,openhands}.py.
+CLINE_PORT = 28892
+CONTINUE_PORT = 28893
+GOOSE_PORT = 28894
+OPENHANDS_PORT = 28895
 
 
 def log(message: str) -> None:
@@ -697,6 +705,71 @@ def verify_cursor_wrap(base_env: dict[str, str], project_dir: Path) -> None:
         stop_process(proc)
 
 
+def verify_cline_wrap(base_env: dict[str, str], project_dir: Path) -> None:
+    """Smoke test: `wrap cline --prepare-only` writes RTK guidance to .clinerules."""
+    run(
+        ["headroom", "wrap", "cline", "--prepare-only", "--port", str(CLINE_PORT)],
+        env=base_env,
+        cwd=project_dir,
+        timeout=60,
+    )
+    clinerules = project_dir / ".clinerules"
+    assert_true(clinerules.exists(), "Cline wrap should create .clinerules")
+    assert_true(
+        RTK_MARKER in clinerules.read_text(encoding="utf-8"),
+        "Cline wrap should inject RTK instructions",
+    )
+
+
+def verify_continue_wrap(base_env: dict[str, str], project_dir: Path) -> None:
+    """Smoke test: `wrap continue --prepare-only` injects RTK into .continue/config.json."""
+    run(
+        ["headroom", "wrap", "continue", "--prepare-only", "--port", str(CONTINUE_PORT)],
+        env=base_env,
+        cwd=project_dir,
+        timeout=60,
+    )
+    config_file = project_dir / ".continue" / "config.json"
+    assert_true(config_file.exists(), "Continue wrap should create .continue/config.json")
+    data = json.loads(config_file.read_text(encoding="utf-8"))
+    system_message = data.get("systemMessage", "")
+    assert_true(
+        RTK_MARKER in system_message,
+        "Continue wrap should inject RTK instructions into systemMessage",
+    )
+
+
+def verify_goose_wrap(base_env: dict[str, str], project_dir: Path) -> None:
+    """Smoke test: `wrap goose --prepare-only` writes RTK guidance to .goosehints."""
+    run(
+        ["headroom", "wrap", "goose", "--prepare-only", "--port", str(GOOSE_PORT)],
+        env=base_env,
+        cwd=project_dir,
+        timeout=60,
+    )
+    goosehints = project_dir / ".goosehints"
+    assert_true(goosehints.exists(), "Goose wrap should create .goosehints")
+    assert_true(
+        RTK_MARKER in goosehints.read_text(encoding="utf-8"),
+        "Goose wrap should inject RTK instructions",
+    )
+
+
+def verify_openhands_wrap(base_env: dict[str, str], project_dir: Path) -> None:
+    """Smoke test: `wrap openhands --prepare-only` exits clean and ensures rtk is present.
+
+    OpenHands wires instructions via the OPENHANDS_INSTRUCTIONS env var at launch
+    time (no on-disk artifact), so --prepare-only just exercises the rtk-binary
+    setup path. The env-var wiring is covered by the unit tests.
+    """
+    run(
+        ["headroom", "wrap", "openhands", "--prepare-only", "--port", str(OPENHANDS_PORT)],
+        env=base_env,
+        cwd=project_dir,
+        timeout=60,
+    )
+
+
 def verify_openclaw_wrap(
     base_env: dict[str, str],
     project_dir: Path,
@@ -827,6 +900,10 @@ def main() -> None:
             verify_codex_wrap(base_env, project_dir, log_dir, mock_server)
             verify_aider_wrap(base_env, project_dir, log_dir)
             verify_cursor_wrap(base_env, project_dir)
+            verify_cline_wrap(base_env, project_dir)
+            verify_continue_wrap(base_env, project_dir)
+            verify_goose_wrap(base_env, project_dir)
+            verify_openhands_wrap(base_env, project_dir)
             local_plugin_dir = prepare_local_openclaw_plugin(base_env, tmp_dir)
             verify_openclaw_wrap(base_env, project_dir, local_plugin_dir)
         finally:

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -994,6 +994,64 @@ def _inject_memory_agents_md(file_path: Path) -> bool:
     return True
 
 
+def _inject_continue_rtk_systemmessage(config_file: Path, verbose: bool = False) -> bool:
+    """Inject the rtk instructions block into Continue's ``.continue/config.json``.
+
+    Continue's schema supports a top-level ``systemMessage`` string applied to
+    every model. We treat the RTK marker as the idempotency token: if a prior
+    ``systemMessage`` already contains the ``<!-- headroom:rtk-instructions -->``
+    marker we leave it alone. Otherwise we either set the field (if absent) or
+    append the rtk block to the existing string with a separator.
+
+    The config file is read/written as JSON. Malformed JSON is left untouched
+    and the helper returns ``False`` — we do not silently overwrite user data.
+    Returns ``True`` if the instructions were successfully written or already
+    present.
+    """
+    if config_file.exists():
+        try:
+            content = config_file.read_text()
+        except OSError as exc:
+            click.echo(f"  Warning: could not read {config_file}: {exc}")
+            return False
+        if not content.strip():
+            data: dict[str, Any] = {}
+        else:
+            try:
+                parsed = json.loads(content)
+            except json.JSONDecodeError as exc:
+                click.echo(
+                    f"  Warning: {config_file} is not valid JSON ({exc.msg}); "
+                    "not modifying — fix the file manually before re-running."
+                )
+                return False
+            if not isinstance(parsed, dict):
+                click.echo(
+                    f"  Warning: {config_file} top-level value is not an object; "
+                    "Continue expects a JSON object — leaving file untouched."
+                )
+                return False
+            data = parsed
+    else:
+        data = {}
+
+    existing_msg = data.get("systemMessage")
+    if isinstance(existing_msg, str) and _RTK_MARKER in existing_msg:
+        if verbose:
+            click.echo(f"  rtk instructions already in {config_file.name}")
+        return True
+
+    if isinstance(existing_msg, str) and existing_msg.strip():
+        data["systemMessage"] = existing_msg.rstrip() + "\n\n" + RTK_INSTRUCTIONS_BLOCK
+    else:
+        data["systemMessage"] = RTK_INSTRUCTIONS_BLOCK
+
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(json.dumps(data, indent=2) + "\n")
+    click.echo(f"  rtk instructions injected into {config_file}")
+    return True
+
+
 def _resolve_copilot_provider_type(backend: str | None, provider_type: str) -> str:
     """Resolve Copilot BYOK provider type for the current proxy backend."""
     return _copilot_resolve_provider_type(backend, provider_type)
@@ -1752,6 +1810,10 @@ def wrap() -> None:
         headroom wrap copilot -- --model claude-sonnet-4-20250514
         headroom wrap aider               # Aider
         headroom wrap cursor              # Cursor (prints config instructions)
+        headroom wrap cline               # Cline (VS Code; prints config instructions)
+        headroom wrap continue            # Continue (VS Code/JetBrains; injects systemMessage)
+        headroom wrap goose               # Goose (Block) CLI
+        headroom wrap openhands           # OpenHands CLI
         headroom wrap openclaw            # OpenClaw plugin bootstrap
 
     \b
@@ -1760,9 +1822,7 @@ def wrap() -> None:
           sets the right env vars, and launches the wrapped CLI.
         - `headroom proxy` — just the proxy. Use this with any
           OpenAI/Anthropic-compatible client by setting
-          ANTHROPIC_BASE_URL / OPENAI_BASE_URL yourself. Required for
-          tools without a dedicated `wrap` subcommand
-          (e.g. opencode, Cline, Continue).
+          ANTHROPIC_BASE_URL / OPENAI_BASE_URL yourself.
 
     \b
     Note: `headroom wrap opencode` does NOT exist. For opencode, run
@@ -2624,6 +2684,480 @@ def cursor(
         raise SystemExit(1) from e
     finally:
         cleanup()
+
+
+# =============================================================================
+# Cline (VS Code extension)
+# =============================================================================
+
+
+@wrap.command(context_settings={"ignore_unknown_options": True})
+@click.option("--port", "-p", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option(
+    "--no-context-tool",
+    "--no-rtk",
+    "no_rtk",
+    is_flag=True,
+    help="Skip CLI context-tool setup",
+)
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option("--learn", is_flag=True, help="Enable live traffic learning")
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+@click.option("--prepare-only", is_flag=True, hidden=True)
+def cline(
+    port: int,
+    no_rtk: bool,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    verbose: bool,
+    prepare_only: bool,
+) -> None:
+    """Start Headroom proxy for use with Cline (VS Code extension).
+
+    \b
+    Cline is a VS Code extension that reads its API configuration from the
+    VS Code settings UI, not from environment variables. This command starts
+    the proxy, sets up the selected CLI context tool (injecting RTK guidance
+    into .clinerules at the project root), and prints the Cline settings the
+    user should configure.
+
+    \b
+    After running this command, open Cline's settings in VS Code and configure
+    the API Base URL to point at the local Headroom proxy.
+
+    \b
+    Examples:
+        headroom wrap cline                  # Start proxy + .clinerules instructions
+        headroom wrap cline --no-context-tool # Proxy only, no CLI context tool
+        headroom wrap cline --port 9999      # Custom proxy port
+    """
+    if not no_rtk:
+        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+            click.echo("  Setting up lean-ctx for Cline...")
+            _setup_lean_ctx_agent("cline", verbose=verbose)
+        else:
+            click.echo("  Setting up rtk for Cline...")
+            rtk_path = _ensure_rtk_binary(verbose=verbose)
+            if rtk_path:
+                clinerules = Path.cwd() / ".clinerules"
+                _inject_rtk_instructions(clinerules, verbose=verbose)
+
+    if prepare_only:
+        return
+
+    proxy_holder: list[subprocess.Popen | None] = [None]
+    cleanup = _make_cleanup(proxy_holder, port)
+    signal.signal(signal.SIGINT, cleanup)
+    signal.signal(signal.SIGTERM, cleanup)
+
+    try:
+        click.echo()
+        click.echo("  ╔═══════════════════════════════════════════════╗")
+        click.echo("  ║             HEADROOM WRAP: CLINE              ║")
+        click.echo("  ╚═══════════════════════════════════════════════╝")
+        click.echo()
+
+        proxy_holder[0] = _ensure_proxy(
+            port, no_proxy, learn=learn, memory=memory, agent_type="cline"
+        )
+
+        anthropic_base = _claude_proxy_base_url(port)
+        openai_base = f"http://127.0.0.1:{port}/v1"
+        click.echo()
+        click.echo("  Configure Cline in VS Code:")
+        click.echo("    Settings > Cline > API Provider")
+        click.echo(f"    Anthropic Base URL: {anthropic_base}")
+        click.echo(f"    OpenAI Compatible Base URL: {openai_base}")
+        if not no_rtk:
+            click.echo()
+            if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+                click.echo("  lean-ctx configured for Cline")
+            else:
+                click.echo("  rtk instructions injected into .clinerules")
+            click.echo("  Cline will use token-optimized commands automatically.")
+        click.echo()
+        click.echo("  Press Ctrl+C to stop the proxy.")
+        click.echo()
+
+        try:
+            while True:
+                time.sleep(1)
+                proc = proxy_holder[0]
+                if proc and proc.poll() is not None:
+                    click.echo("  Proxy process exited unexpectedly.")
+                    raise SystemExit(1)
+        except KeyboardInterrupt:
+            click.echo("\n  Shutting down...")
+
+    except SystemExit:
+        raise
+    except Exception as e:
+        click.echo(f"  Error: {e}")
+        raise SystemExit(1) from e
+    finally:
+        cleanup()
+
+
+# =============================================================================
+# Continue (VS Code / JetBrains extension)
+# =============================================================================
+
+
+@wrap.command("continue", context_settings={"ignore_unknown_options": True})
+@click.option("--port", "-p", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option(
+    "--no-context-tool",
+    "--no-rtk",
+    "no_rtk",
+    is_flag=True,
+    help="Skip CLI context-tool setup",
+)
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option("--learn", is_flag=True, help="Enable live traffic learning")
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(path_type=Path, file_okay=True, dir_okay=False),
+    default=None,
+    help="Path to Continue config.json (default: ./.continue/config.json)",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+@click.option("--prepare-only", is_flag=True, hidden=True)
+def continue_dev(
+    port: int,
+    no_rtk: bool,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    config_path: Path | None,
+    verbose: bool,
+    prepare_only: bool,
+) -> None:
+    """Start Headroom proxy for use with Continue (VS Code / JetBrains).
+
+    \b
+    Continue reads its model configuration from .continue/config.json (a JSON
+    document with a top-level ``systemMessage`` and a ``models`` array). This
+    command starts the proxy, sets up the selected CLI context tool by
+    extending ``systemMessage`` with RTK guidance, and prints the per-model
+    ``apiBase`` the user should configure manually.
+
+    \b
+    Continue is an IDE extension — its API base URL is configured per-model
+    in config.json (or via the IDE UI), not via environment variables. The
+    config file is overridable via --config.
+
+    \b
+    Examples:
+        headroom wrap continue                # Start proxy + inject systemMessage
+        headroom wrap continue --no-context-tool   # Proxy only
+        headroom wrap continue --port 9999    # Custom proxy port
+        headroom wrap continue --config path/to/config.json
+    """
+    config_file = config_path or (Path.cwd() / ".continue" / "config.json")
+
+    if not no_rtk:
+        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+            click.echo("  Setting up lean-ctx for Continue...")
+            _setup_lean_ctx_agent("continue", verbose=verbose)
+        else:
+            click.echo("  Setting up rtk for Continue...")
+            rtk_path = _ensure_rtk_binary(verbose=verbose)
+            if rtk_path:
+                _inject_continue_rtk_systemmessage(config_file, verbose=verbose)
+
+    if prepare_only:
+        return
+
+    proxy_holder: list[subprocess.Popen | None] = [None]
+    cleanup = _make_cleanup(proxy_holder, port)
+    signal.signal(signal.SIGINT, cleanup)
+    signal.signal(signal.SIGTERM, cleanup)
+
+    try:
+        click.echo()
+        click.echo("  ╔═══════════════════════════════════════════════╗")
+        click.echo("  ║           HEADROOM WRAP: CONTINUE             ║")
+        click.echo("  ╚═══════════════════════════════════════════════╝")
+        click.echo()
+
+        proxy_holder[0] = _ensure_proxy(
+            port, no_proxy, learn=learn, memory=memory, agent_type="continue"
+        )
+
+        anthropic_base = _claude_proxy_base_url(port)
+        openai_base = f"http://127.0.0.1:{port}/v1"
+        click.echo()
+        click.echo("  Configure Continue in your IDE:")
+        click.echo(f"    Edit {config_file} and set, per model:")
+        click.echo(f'      "apiBase": "{openai_base}"          # OpenAI-compatible models')
+        click.echo(f'      "apiBase": "{anthropic_base}"       # Anthropic models')
+        if not no_rtk:
+            click.echo()
+            if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+                click.echo("  lean-ctx configured for Continue")
+            else:
+                click.echo(f"  rtk instructions injected into {config_file.name} systemMessage")
+            click.echo("  Continue will use token-optimized commands automatically.")
+        click.echo()
+        click.echo("  Press Ctrl+C to stop the proxy.")
+        click.echo()
+
+        try:
+            while True:
+                time.sleep(1)
+                proc = proxy_holder[0]
+                if proc and proc.poll() is not None:
+                    click.echo("  Proxy process exited unexpectedly.")
+                    raise SystemExit(1)
+        except KeyboardInterrupt:
+            click.echo("\n  Shutting down...")
+
+    except SystemExit:
+        raise
+    except Exception as e:
+        click.echo(f"  Error: {e}")
+        raise SystemExit(1) from e
+    finally:
+        cleanup()
+
+
+# =============================================================================
+# Goose (Block)
+# =============================================================================
+
+
+@wrap.command(context_settings={"ignore_unknown_options": True})
+@click.option("--port", "-p", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option(
+    "--no-context-tool",
+    "--no-rtk",
+    "no_rtk",
+    is_flag=True,
+    help="Skip CLI context-tool setup",
+)
+@click.option(
+    "--code-graph",
+    is_flag=True,
+    help="Enable code graph indexing via codebase-memory-mcp (optional)",
+)
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option("--learn", is_flag=True, help="Enable live traffic learning")
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--backend", default=None, help="API backend: 'anthropic', 'anyllm', 'litellm-vertex', etc."
+)
+@click.option("--anyllm-provider", default=None, help="Provider for any-llm backend")
+@click.option("--region", default=None, help="Cloud region for Bedrock/Vertex")
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+@click.option("--prepare-only", is_flag=True, hidden=True)
+@click.argument("goose_args", nargs=-1, type=click.UNPROCESSED)
+def goose(
+    port: int,
+    no_rtk: bool,
+    code_graph: bool,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    backend: str | None,
+    anyllm_provider: str | None,
+    region: str | None,
+    verbose: bool,
+    prepare_only: bool,
+    goose_args: tuple,
+) -> None:
+    """Launch Goose (Block) CLI through Headroom proxy.
+
+    \b
+    Sets OPENAI_BASE_URL and ANTHROPIC_BASE_URL to route Goose's API calls
+    through Headroom. Sets up the selected CLI context tool by injecting RTK
+    guidance into .goosehints at the project root (Goose reads this file as
+    extra system context).
+
+    \b
+    Examples:
+        headroom wrap goose                          # Start proxy + context tool + goose
+        headroom wrap goose -- session               # Start a Goose session
+        headroom wrap goose -- --provider anthropic  # Pass args to goose
+        headroom wrap goose --no-context-tool        # Skip CLI context-tool setup
+    """
+    if not no_rtk:
+        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+            click.echo("  Setting up lean-ctx for Goose...")
+            _setup_lean_ctx_agent("goose", verbose=verbose)
+        else:
+            click.echo("  Setting up rtk for Goose...")
+            rtk_path = _ensure_rtk_binary(verbose=verbose)
+            if rtk_path:
+                # Goose reads .goosehints from the project root as extra context.
+                goosehints = Path.cwd() / ".goosehints"
+                _inject_rtk_instructions(goosehints, verbose=verbose)
+
+    if prepare_only:
+        return
+
+    goose_bin = shutil.which("goose")
+    if not goose_bin:
+        click.echo("Error: 'goose' not found in PATH.")
+        click.echo("Install Goose: https://block.github.io/goose/")
+        raise SystemExit(1)
+
+    # Goose accepts OpenAI- and Anthropic-compatible providers; route both.
+    env = os.environ.copy()
+    openai_base = f"http://127.0.0.1:{port}/v1"
+    anthropic_base = _claude_proxy_base_url(port)
+    env["OPENAI_BASE_URL"] = openai_base
+    env["OPENAI_API_BASE"] = openai_base
+    env["ANTHROPIC_BASE_URL"] = anthropic_base
+    env_vars_display = [
+        f"OPENAI_BASE_URL={openai_base}",
+        f"ANTHROPIC_BASE_URL={anthropic_base}",
+    ]
+
+    _launch_tool(
+        binary=goose_bin,
+        args=goose_args,
+        env=env,
+        port=port,
+        no_proxy=no_proxy,
+        tool_label="GOOSE",
+        env_vars_display=env_vars_display,
+        learn=learn,
+        memory=memory,
+        agent_type="goose",
+        code_graph=code_graph,
+        backend=backend,
+        anyllm_provider=anyllm_provider,
+        region=region,
+    )
+
+
+# =============================================================================
+# OpenHands
+# =============================================================================
+
+
+@wrap.command(context_settings={"ignore_unknown_options": True})
+@click.option("--port", "-p", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option(
+    "--no-context-tool",
+    "--no-rtk",
+    "no_rtk",
+    is_flag=True,
+    help="Skip CLI context-tool setup",
+)
+@click.option(
+    "--code-graph",
+    is_flag=True,
+    help="Enable code graph indexing via codebase-memory-mcp (optional)",
+)
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option("--learn", is_flag=True, help="Enable live traffic learning")
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--backend", default=None, help="API backend: 'anthropic', 'anyllm', 'litellm-vertex', etc."
+)
+@click.option("--anyllm-provider", default=None, help="Provider for any-llm backend")
+@click.option("--region", default=None, help="Cloud region for Bedrock/Vertex")
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+@click.option("--prepare-only", is_flag=True, hidden=True)
+@click.argument("openhands_args", nargs=-1, type=click.UNPROCESSED)
+def openhands(
+    port: int,
+    no_rtk: bool,
+    code_graph: bool,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    backend: str | None,
+    anyllm_provider: str | None,
+    region: str | None,
+    verbose: bool,
+    prepare_only: bool,
+    openhands_args: tuple,
+) -> None:
+    """Launch OpenHands CLI through Headroom proxy.
+
+    \b
+    Sets OPENAI_BASE_URL / ANTHROPIC_BASE_URL to route OpenHands' API calls
+    through Headroom. Instructions are injected via the
+    ``OPENHANDS_INSTRUCTIONS`` environment variable at launch time so the
+    on-disk OpenHands config is left untouched.
+
+    \b
+    Examples:
+        headroom wrap openhands                # Start proxy + context tool + openhands
+        headroom wrap openhands -- --task ...  # Pass args to openhands
+        headroom wrap openhands --no-context-tool
+    """
+    if not no_rtk:
+        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+            click.echo("  Setting up lean-ctx for OpenHands...")
+            _setup_lean_ctx_agent("openhands", verbose=verbose)
+        else:
+            click.echo("  Setting up rtk for OpenHands...")
+            _ensure_rtk_binary(verbose=verbose)
+
+    if prepare_only:
+        return
+
+    openhands_bin = shutil.which("openhands")
+    if not openhands_bin:
+        click.echo("Error: 'openhands' not found in PATH.")
+        click.echo("Install OpenHands: https://docs.all-hands.dev/")
+        raise SystemExit(1)
+
+    env = os.environ.copy()
+    openai_base = f"http://127.0.0.1:{port}/v1"
+    anthropic_base = _claude_proxy_base_url(port)
+    env["OPENAI_BASE_URL"] = openai_base
+    env["OPENAI_API_BASE"] = openai_base
+    env["ANTHROPIC_BASE_URL"] = anthropic_base
+    # Also set LLM_BASE_URL for OpenHands' generic LLM provider config.
+    env["LLM_BASE_URL"] = openai_base
+    if not no_rtk:
+        # Inject rtk guidance via env var so OpenHands picks it up as the
+        # session's instruction prefix. Appending instead of overwriting any
+        # pre-existing OPENHANDS_INSTRUCTIONS so user-supplied instructions are
+        # preserved.
+        existing_instructions = env.get("OPENHANDS_INSTRUCTIONS", "")
+        if _RTK_MARKER in existing_instructions:
+            # Already injected (re-invocation in the same shell session).
+            pass
+        elif existing_instructions.strip():
+            env["OPENHANDS_INSTRUCTIONS"] = (
+                existing_instructions.rstrip() + "\n\n" + RTK_INSTRUCTIONS_BLOCK
+            )
+        else:
+            env["OPENHANDS_INSTRUCTIONS"] = RTK_INSTRUCTIONS_BLOCK
+
+    env_vars_display = [
+        f"OPENAI_BASE_URL={openai_base}",
+        f"ANTHROPIC_BASE_URL={anthropic_base}",
+        f"LLM_BASE_URL={openai_base}",
+    ]
+    if not no_rtk and "OPENHANDS_INSTRUCTIONS" in env:
+        env_vars_display.append("OPENHANDS_INSTRUCTIONS=<rtk instructions injected>")
+
+    _launch_tool(
+        binary=openhands_bin,
+        args=openhands_args,
+        env=env,
+        port=port,
+        no_proxy=no_proxy,
+        tool_label="OPENHANDS",
+        env_vars_display=env_vars_display,
+        learn=learn,
+        memory=memory,
+        agent_type="openhands",
+        code_graph=code_graph,
+        backend=backend,
+        anyllm_provider=anyllm_provider,
+        region=region,
+    )
 
 
 # =============================================================================

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -890,6 +890,26 @@ def _restore_codex_provider_config() -> tuple[str, Path]:
     return "noop", config_file
 
 
+def _emit_wrap_interrupted(agent: str, marker_path: Path | None) -> None:
+    """Log a clear interruption message after a partial wrap setup.
+
+    Called when a wrap subcommand catches ``KeyboardInterrupt`` between marker
+    injection and proxy startup. The marker file (if any) is left on disk —
+    re-running the same ``headroom wrap <agent>`` command is idempotent and
+    safe.
+    """
+    if marker_path is not None:
+        click.echo(
+            f"\n  Wrap was interrupted; marker file at {marker_path} is on "
+            f"disk. Rerun `headroom wrap {agent}` to retry — it's idempotent."
+        )
+    else:
+        click.echo(
+            f"\n  Wrap was interrupted before any on-disk changes. Rerun "
+            f"`headroom wrap {agent}` to retry — it's idempotent."
+        )
+
+
 def _inject_rtk_instructions(file_path: Path, verbose: bool = False) -> bool:
     """Inject rtk instructions into a file (AGENTS.md, .cursorrules, etc.).
 
@@ -994,19 +1014,79 @@ def _inject_memory_agents_md(file_path: Path) -> bool:
     return True
 
 
+def _apply_rtk_to_systemmessage_field(
+    container: dict[str, Any],
+    location_label: str,
+    verbose: bool = False,
+) -> tuple[bool, bool]:
+    """Apply the RTK block to ``container["systemMessage"]`` in place.
+
+    Returns ``(changed, ok)``:
+
+    * ``changed`` is ``True`` if the field was written (or rewritten) on this
+      call. ``False`` for idempotent skips and for refusals.
+    * ``ok`` is ``True`` for "RTK guidance is now present (or refused-safely)",
+      ``False`` only for refusals where the user must intervene. Callers
+      surface ``not ok`` as a warning to the user.
+
+    Refusal cases (loud, no silent overwrite):
+
+    * ``systemMessage`` exists and is **not a string** (dict / list / number).
+      We never clobber user data of an unknown shape. The user must remove or
+      clear the field before re-running.
+    """
+    existing_msg = container.get("systemMessage")
+
+    if isinstance(existing_msg, str) and _RTK_MARKER in existing_msg:
+        if verbose:
+            click.echo(f"  rtk instructions already in {location_label}")
+        return False, True
+
+    if existing_msg is None or (isinstance(existing_msg, str) and not existing_msg.strip()):
+        container["systemMessage"] = RTK_INSTRUCTIONS_BLOCK
+        return True, True
+
+    if isinstance(existing_msg, str):
+        container["systemMessage"] = existing_msg.rstrip() + "\n\n" + RTK_INSTRUCTIONS_BLOCK
+        return True, True
+
+    # Non-string, non-null value present — refuse loudly. We will not clobber
+    # user data of unknown shape.
+    click.echo(
+        f"  Warning: {location_label} systemMessage is not a string "
+        f"(type={type(existing_msg).__name__}); refusing to overwrite. "
+        "To opt in, remove or clear the existing systemMessage value and re-run."
+    )
+    return False, False
+
+
 def _inject_continue_rtk_systemmessage(config_file: Path, verbose: bool = False) -> bool:
     """Inject the rtk instructions block into Continue's ``.continue/config.json``.
 
-    Continue's schema supports a top-level ``systemMessage`` string applied to
-    every model. We treat the RTK marker as the idempotency token: if a prior
-    ``systemMessage`` already contains the ``<!-- headroom:rtk-instructions -->``
-    marker we leave it alone. Otherwise we either set the field (if absent) or
-    append the rtk block to the existing string with a separator.
+    Continue's schema supports both a top-level ``systemMessage`` string and a
+    per-model ``systemMessage`` on each entry in the ``models`` array. The
+    per-model value, when set, overrides the top-level one — so users with
+    per-model configs would otherwise silently get no RTK guidance. This
+    helper writes the RTK block into **every** ``systemMessage`` site:
+
+    * top-level ``systemMessage``
+    * each ``models[i].systemMessage`` where ``models[i]`` is a dict
+
+    The RTK marker (``<!-- headroom:rtk-instructions -->``) is the idempotency
+    token: if a prior ``systemMessage`` already contains the marker we leave
+    that site alone. If the existing value is a non-empty string we append
+    with a separator. If the existing value is **non-string** (dict / list /
+    number) we refuse loudly and leave it untouched — we do not clobber user
+    data of unknown shape. To opt in to overwrite, the user must clear the
+    existing value first.
 
     The config file is read/written as JSON. Malformed JSON is left untouched
-    and the helper returns ``False`` — we do not silently overwrite user data.
-    Returns ``True`` if the instructions were successfully written or already
-    present.
+    and the helper returns ``False``. Note: Continue's modern config is
+    YAML-first; users on the YAML schema should configure systemMessage
+    through that file instead — this helper only handles the JSON variant.
+
+    Returns ``True`` if injection succeeded (or was already idempotent at
+    every site); ``False`` if any site refused or the file was malformed.
     """
     if config_file.exists():
         try:
@@ -1035,21 +1115,41 @@ def _inject_continue_rtk_systemmessage(config_file: Path, verbose: bool = False)
     else:
         data = {}
 
-    existing_msg = data.get("systemMessage")
-    if isinstance(existing_msg, str) and _RTK_MARKER in existing_msg:
-        if verbose:
-            click.echo(f"  rtk instructions already in {config_file.name}")
-        return True
+    any_changed = False
+    all_ok = True
 
-    if isinstance(existing_msg, str) and existing_msg.strip():
-        data["systemMessage"] = existing_msg.rstrip() + "\n\n" + RTK_INSTRUCTIONS_BLOCK
-    else:
-        data["systemMessage"] = RTK_INSTRUCTIONS_BLOCK
+    # 1. Top-level systemMessage.
+    changed, ok = _apply_rtk_to_systemmessage_field(
+        data, location_label=f"{config_file.name} (top-level)", verbose=verbose
+    )
+    any_changed = any_changed or changed
+    all_ok = all_ok and ok
 
-    config_file.parent.mkdir(parents=True, exist_ok=True)
-    config_file.write_text(json.dumps(data, indent=2) + "\n")
-    click.echo(f"  rtk instructions injected into {config_file}")
-    return True
+    # 2. Per-model systemMessage. Continue's models[] entry overrides the
+    # top-level value when set, so we must visit each one.
+    models = data.get("models")
+    if isinstance(models, list):
+        for idx, model in enumerate(models):
+            if not isinstance(model, dict):
+                continue
+            label = f"{config_file.name} models[{idx}]"
+            if isinstance(model.get("title"), str):
+                label = f"{config_file.name} models[{idx}] ({model['title']})"
+            changed_i, ok_i = _apply_rtk_to_systemmessage_field(
+                model, location_label=label, verbose=verbose
+            )
+            any_changed = any_changed or changed_i
+            all_ok = all_ok and ok_i
+
+    if any_changed:
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(json.dumps(data, indent=2) + "\n")
+        click.echo(f"  rtk instructions injected into {config_file}")
+    elif all_ok and verbose:
+        # Idempotent re-run with no refusals — nothing to do.
+        click.echo(f"  rtk instructions already present in {config_file.name}")
+
+    return all_ok
 
 
 def _resolve_copilot_provider_type(backend: str | None, provider_type: str) -> str:
@@ -2728,21 +2828,39 @@ def cline(
     the API Base URL to point at the local Headroom proxy.
 
     \b
+    Uninstall: there is no ``headroom unwrap cline`` subcommand. To remove the
+    injected guidance, hand-edit ``.clinerules`` at the project root and
+    delete everything between ``<!-- headroom:rtk-instructions -->`` and
+    ``<!-- /headroom:rtk-instructions -->`` (inclusive). If ``lean-ctx`` mode
+    is selected, the lean-ctx agent name ``cline`` may not be recognized by
+    the local lean-ctx binary; a warning is printed in that case and setup
+    is skipped silently.
+
+    \b
     Examples:
         headroom wrap cline                  # Start proxy + .clinerules instructions
         headroom wrap cline --no-context-tool # Proxy only, no CLI context tool
         headroom wrap cline --port 9999      # Custom proxy port
     """
-    if not no_rtk:
-        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
-            click.echo("  Setting up lean-ctx for Cline...")
-            _setup_lean_ctx_agent("cline", verbose=verbose)
-        else:
-            click.echo("  Setting up rtk for Cline...")
-            rtk_path = _ensure_rtk_binary(verbose=verbose)
-            if rtk_path:
-                clinerules = Path.cwd() / ".clinerules"
-                _inject_rtk_instructions(clinerules, verbose=verbose)
+    # Pre-compute the marker path so the KeyboardInterrupt handler can report
+    # its location even if the interrupt fires before _inject_rtk_instructions
+    # returns (e.g., during the inner _ensure_rtk_binary download).
+    clinerules: Path | None = Path.cwd() / ".clinerules" if not no_rtk else None
+    try:
+        if not no_rtk:
+            if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+                click.echo("  Setting up lean-ctx for Cline...")
+                _setup_lean_ctx_agent("cline", verbose=verbose)
+            else:
+                click.echo("  Setting up rtk for Cline...")
+                rtk_path = _ensure_rtk_binary(verbose=verbose)
+                if rtk_path and clinerules is not None:
+                    _inject_rtk_instructions(clinerules, verbose=verbose)
+    except KeyboardInterrupt:
+        _emit_wrap_interrupted(
+            "cline", clinerules if (clinerules and clinerules.exists()) else None
+        )
+        raise SystemExit(130) from None
 
     if prepare_only:
         return
@@ -2851,6 +2969,29 @@ def continue_dev(
     config file is overridable via --config.
 
     \b
+    Note: Continue's modern config is YAML-first (``.continue/config.yaml``).
+    This helper only writes the JSON variant. Users on the YAML schema should
+    configure ``systemMessage`` through that file by hand.
+
+    \b
+    Per-model handling: Continue overrides top-level ``systemMessage`` with
+    per-model ``systemMessage`` when set, so this command also injects into
+    each ``models[i].systemMessage`` if the ``models`` array is present.
+    Existing non-string ``systemMessage`` values are NEVER overwritten — the
+    command warns loudly and leaves them in place. To opt in, clear the
+    existing value first.
+
+    \b
+    Uninstall: there is no ``headroom unwrap continue`` subcommand. To remove
+    the injected guidance, hand-edit ``.continue/config.json`` and delete
+    everything between ``<!-- headroom:rtk-instructions -->`` and
+    ``<!-- /headroom:rtk-instructions -->`` (inclusive) from every
+    ``systemMessage`` field — both top-level and inside ``models[*]``. If
+    ``lean-ctx`` mode is selected, the lean-ctx agent name ``continue`` may
+    not be recognized by the local lean-ctx binary; a warning is printed in
+    that case and setup is skipped silently.
+
+    \b
     Examples:
         headroom wrap continue                # Start proxy + inject systemMessage
         headroom wrap continue --no-context-tool   # Proxy only
@@ -2859,15 +3000,19 @@ def continue_dev(
     """
     config_file = config_path or (Path.cwd() / ".continue" / "config.json")
 
-    if not no_rtk:
-        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
-            click.echo("  Setting up lean-ctx for Continue...")
-            _setup_lean_ctx_agent("continue", verbose=verbose)
-        else:
-            click.echo("  Setting up rtk for Continue...")
-            rtk_path = _ensure_rtk_binary(verbose=verbose)
-            if rtk_path:
-                _inject_continue_rtk_systemmessage(config_file, verbose=verbose)
+    try:
+        if not no_rtk:
+            if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+                click.echo("  Setting up lean-ctx for Continue...")
+                _setup_lean_ctx_agent("continue", verbose=verbose)
+            else:
+                click.echo("  Setting up rtk for Continue...")
+                rtk_path = _ensure_rtk_binary(verbose=verbose)
+                if rtk_path:
+                    _inject_continue_rtk_systemmessage(config_file, verbose=verbose)
+    except KeyboardInterrupt:
+        _emit_wrap_interrupted("continue", config_file if config_file.exists() else None)
+        raise SystemExit(130) from None
 
     if prepare_only:
         return
@@ -2978,23 +3123,42 @@ def goose(
     extra system context).
 
     \b
+    Uninstall: there is no ``headroom unwrap goose`` subcommand. To remove the
+    injected guidance, hand-edit ``.goosehints`` at the project root and
+    delete everything between ``<!-- headroom:rtk-instructions -->`` and
+    ``<!-- /headroom:rtk-instructions -->`` (inclusive). If ``lean-ctx`` mode
+    is selected, the lean-ctx agent name ``goose`` may not be recognized by
+    the local lean-ctx binary; a warning is printed in that case and setup
+    is skipped silently.
+
+    \b
     Examples:
         headroom wrap goose                          # Start proxy + context tool + goose
         headroom wrap goose -- session               # Start a Goose session
         headroom wrap goose -- --provider anthropic  # Pass args to goose
         headroom wrap goose --no-context-tool        # Skip CLI context-tool setup
     """
-    if not no_rtk:
-        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
-            click.echo("  Setting up lean-ctx for Goose...")
-            _setup_lean_ctx_agent("goose", verbose=verbose)
-        else:
-            click.echo("  Setting up rtk for Goose...")
-            rtk_path = _ensure_rtk_binary(verbose=verbose)
-            if rtk_path:
-                # Goose reads .goosehints from the project root as extra context.
-                goosehints = Path.cwd() / ".goosehints"
-                _inject_rtk_instructions(goosehints, verbose=verbose)
+    # Pre-compute the marker path so the KeyboardInterrupt handler can report
+    # its location even if the interrupt fires before _inject_rtk_instructions
+    # returns (e.g., during the inner _ensure_rtk_binary download).
+    goosehints: Path | None = Path.cwd() / ".goosehints" if not no_rtk else None
+    try:
+        if not no_rtk:
+            if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+                click.echo("  Setting up lean-ctx for Goose...")
+                _setup_lean_ctx_agent("goose", verbose=verbose)
+            else:
+                click.echo("  Setting up rtk for Goose...")
+                rtk_path = _ensure_rtk_binary(verbose=verbose)
+                if rtk_path and goosehints is not None:
+                    # Goose reads .goosehints from the project root as extra
+                    # context.
+                    _inject_rtk_instructions(goosehints, verbose=verbose)
+    except KeyboardInterrupt:
+        _emit_wrap_interrupted(
+            "goose", goosehints if (goosehints and goosehints.exists()) else None
+        )
+        raise SystemExit(130) from None
 
     if prepare_only:
         return
@@ -3088,18 +3252,41 @@ def openhands(
     on-disk OpenHands config is left untouched.
 
     \b
+    The ``OPENHANDS_INSTRUCTIONS`` value injected by this command contains the
+    ``<!-- headroom:rtk-instructions -->`` marker. To uninstall, simply do not
+    set ``OPENHANDS_INSTRUCTIONS`` in the parent shell — this command never
+    writes to disk, so nothing to clean up. If ``lean-ctx`` mode is selected,
+    the lean-ctx agent name ``openhands`` may not be recognized by the local
+    lean-ctx binary; a warning is printed in that case and rtk-style guidance
+    falls through.
+
+    \b
     Examples:
         headroom wrap openhands                # Start proxy + context tool + openhands
         headroom wrap openhands -- --task ...  # Pass args to openhands
         headroom wrap openhands --no-context-tool
     """
-    if not no_rtk:
-        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
-            click.echo("  Setting up lean-ctx for OpenHands...")
-            _setup_lean_ctx_agent("openhands", verbose=verbose)
-        else:
-            click.echo("  Setting up rtk for OpenHands...")
-            _ensure_rtk_binary(verbose=verbose)
+    rtk_path: Path | None = None
+    try:
+        if not no_rtk:
+            if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+                click.echo("  Setting up lean-ctx for OpenHands...")
+                _setup_lean_ctx_agent("openhands", verbose=verbose)
+            else:
+                click.echo("  Setting up rtk for OpenHands...")
+                rtk_path = _ensure_rtk_binary(verbose=verbose)
+                if not rtk_path:
+                    click.echo(
+                        "  Error: rtk install failed; refusing to inject "
+                        "OPENHANDS_INSTRUCTIONS without rtk. Install rtk "
+                        "manually and re-run, or pass --no-context-tool to "
+                        "skip rtk."
+                    )
+                    raise SystemExit(1)
+    except KeyboardInterrupt:
+        # openhands never writes to disk — no marker file to flag.
+        _emit_wrap_interrupted("openhands", None)
+        raise SystemExit(130) from None
 
     if prepare_only:
         return
@@ -3118,14 +3305,15 @@ def openhands(
     env["ANTHROPIC_BASE_URL"] = anthropic_base
     # Also set LLM_BASE_URL for OpenHands' generic LLM provider config.
     env["LLM_BASE_URL"] = openai_base
-    if not no_rtk:
+    if not no_rtk and rtk_path:
         # Inject rtk guidance via env var so OpenHands picks it up as the
-        # session's instruction prefix. Appending instead of overwriting any
-        # pre-existing OPENHANDS_INSTRUCTIONS so user-supplied instructions are
-        # preserved.
+        # session's instruction prefix. Appending instead of overwriting
+        # any pre-existing OPENHANDS_INSTRUCTIONS so user-supplied content
+        # is preserved. The marker check guards against double-injection
+        # when the user inherits an env var that already has the rtk block.
         existing_instructions = env.get("OPENHANDS_INSTRUCTIONS", "")
         if _RTK_MARKER in existing_instructions:
-            # Already injected (re-invocation in the same shell session).
+            # Already injected — pre-existing env var contains marker.
             pass
         elif existing_instructions.strip():
             env["OPENHANDS_INSTRUCTIONS"] = (

--- a/tests/test_cli/test_wrap_cline.py
+++ b/tests/test_cli/test_wrap_cline.py
@@ -1,0 +1,93 @@
+"""Tests for `headroom wrap cline` command (PR-G1, Phase G)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from headroom.cli import wrap as wrap_mod
+from headroom.cli.main import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_wrap_cline_prepare_only_injects_rtk_into_clinerules(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`wrap cline --prepare-only` writes RTK guidance to .clinerules at cwd."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+        result = runner.invoke(main, ["wrap", "cline", "--prepare-only"])
+
+    assert result.exit_code == 0, result.output
+    clinerules = tmp_path / ".clinerules"
+    assert clinerules.exists(), ".clinerules should be created"
+    content = clinerules.read_text()
+    assert wrap_mod._RTK_MARKER in content
+    assert "RTK (Rust Token Killer)" in content
+
+
+def test_wrap_cline_prepare_only_idempotent_no_duplicate_block(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Running wrap cline twice must not duplicate the RTK block."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+        runner.invoke(main, ["wrap", "cline", "--prepare-only"])
+        runner.invoke(main, ["wrap", "cline", "--prepare-only"])
+
+    clinerules = tmp_path / ".clinerules"
+    content = clinerules.read_text()
+    assert content.count(wrap_mod._RTK_MARKER) == 1
+
+
+def test_wrap_cline_no_context_tool_does_not_create_clinerules(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--no-context-tool must not create .clinerules."""
+    monkeypatch.chdir(tmp_path)
+
+    # Patch RTK to fail if accidentally called.
+    with patch.object(wrap_mod, "_ensure_rtk_binary") as ensure:
+        result = runner.invoke(main, ["wrap", "cline", "--prepare-only", "--no-context-tool"])
+
+    assert result.exit_code == 0, result.output
+    assert not (tmp_path / ".clinerules").exists()
+    ensure.assert_not_called()
+
+
+def test_wrap_cline_preserves_existing_clinerules_content(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-existing .clinerules content must be preserved when RTK is appended."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    clinerules = tmp_path / ".clinerules"
+    original = "# Project conventions\n\nAlways use Python 3.12.\n"
+    clinerules.write_text(original)
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+        result = runner.invoke(main, ["wrap", "cline", "--prepare-only"])
+
+    assert result.exit_code == 0, result.output
+    content = clinerules.read_text()
+    assert "Always use Python 3.12." in content
+    assert wrap_mod._RTK_MARKER in content

--- a/tests/test_cli/test_wrap_cline.py
+++ b/tests/test_cli/test_wrap_cline.py
@@ -91,3 +91,37 @@ def test_wrap_cline_preserves_existing_clinerules_content(
     content = clinerules.read_text()
     assert "Always use Python 3.12." in content
     assert wrap_mod._RTK_MARKER in content
+
+
+# ---------------------------------------------------------------------------
+# M4: Ctrl-C during prelude emits a clear "interrupted, marker may be on disk"
+# message and exits non-zero.
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_cline_keyboardinterrupt_during_prelude_emits_clear_message(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ctrl-C between marker injection and proxy startup must signal clearly."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    def raise_kbd_interrupt(*args, **kwargs):  # noqa: ANN002, ANN003
+        # Simulate the user hitting Ctrl-C right after the prelude wrote the
+        # .clinerules marker but before _ensure_proxy returns. We trigger via
+        # _ensure_rtk_binary side-effect so the marker file exists on disk.
+        marker_path = tmp_path / ".clinerules"
+        marker_path.write_text(wrap_mod.RTK_INSTRUCTIONS_BLOCK)
+        raise KeyboardInterrupt
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", side_effect=raise_kbd_interrupt):
+        result = runner.invoke(main, ["wrap", "cline", "--prepare-only"])
+
+    assert result.exit_code == 130
+    assert "interrupted" in result.output.lower()
+    assert "idempotent" in result.output.lower()
+    # marker file is on disk
+    assert (tmp_path / ".clinerules").exists()
+    assert str(tmp_path / ".clinerules") in result.output

--- a/tests/test_cli/test_wrap_continue.py
+++ b/tests/test_cli/test_wrap_continue.py
@@ -1,0 +1,140 @@
+"""Tests for `headroom wrap continue` command (PR-G1, Phase G)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from headroom.cli import wrap as wrap_mod
+from headroom.cli.main import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_inject_continue_rtk_systemmessage_new_file(tmp_path: Path) -> None:
+    """Writing into a non-existent config.json creates parents + sets systemMessage."""
+    config_file = tmp_path / ".continue" / "config.json"
+    assert not config_file.exists()
+
+    assert wrap_mod._inject_continue_rtk_systemmessage(config_file) is True
+
+    data = json.loads(config_file.read_text())
+    assert wrap_mod._RTK_MARKER in data["systemMessage"]
+
+
+def test_inject_continue_rtk_systemmessage_preserves_existing_keys(tmp_path: Path) -> None:
+    """Pre-existing keys like ``models`` are not touched."""
+    config_file = tmp_path / ".continue" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(json.dumps({"models": [{"title": "GPT-4o", "provider": "openai"}]}))
+
+    wrap_mod._inject_continue_rtk_systemmessage(config_file)
+
+    data = json.loads(config_file.read_text())
+    assert data["models"] == [{"title": "GPT-4o", "provider": "openai"}]
+    assert wrap_mod._RTK_MARKER in data["systemMessage"]
+
+
+def test_inject_continue_rtk_systemmessage_appends_to_existing_message(
+    tmp_path: Path,
+) -> None:
+    """Pre-existing systemMessage content is preserved; rtk block is appended."""
+    config_file = tmp_path / ".continue" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    existing_msg = "You are a helpful assistant."
+    config_file.write_text(json.dumps({"systemMessage": existing_msg}))
+
+    wrap_mod._inject_continue_rtk_systemmessage(config_file)
+
+    data = json.loads(config_file.read_text())
+    assert data["systemMessage"].startswith(existing_msg)
+    assert wrap_mod._RTK_MARKER in data["systemMessage"]
+
+
+def test_inject_continue_rtk_systemmessage_idempotent(tmp_path: Path) -> None:
+    """Re-injection must not duplicate the marker."""
+    config_file = tmp_path / ".continue" / "config.json"
+
+    wrap_mod._inject_continue_rtk_systemmessage(config_file)
+    wrap_mod._inject_continue_rtk_systemmessage(config_file)
+
+    data = json.loads(config_file.read_text())
+    assert data["systemMessage"].count(wrap_mod._RTK_MARKER) == 1
+
+
+def test_inject_continue_rtk_systemmessage_refuses_invalid_json(
+    tmp_path: Path,
+) -> None:
+    """Malformed JSON must be left untouched and the helper must return False."""
+    config_file = tmp_path / ".continue" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    malformed = '{ "models": [ this is not valid json'
+    config_file.write_text(malformed)
+
+    result = wrap_mod._inject_continue_rtk_systemmessage(config_file)
+
+    assert result is False
+    assert config_file.read_text() == malformed
+
+
+def test_inject_continue_rtk_systemmessage_refuses_non_object_root(
+    tmp_path: Path,
+) -> None:
+    """A JSON array at the root is not a valid Continue config; leave untouched."""
+    config_file = tmp_path / ".continue" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text("[]")
+
+    result = wrap_mod._inject_continue_rtk_systemmessage(config_file)
+
+    assert result is False
+    assert config_file.read_text() == "[]"
+
+
+def test_wrap_continue_prepare_only_injects_systemmessage(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`wrap continue --prepare-only` injects into ./.continue/config.json by default."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+        result = runner.invoke(main, ["wrap", "continue", "--prepare-only"])
+
+    assert result.exit_code == 0, result.output
+    config_file = tmp_path / ".continue" / "config.json"
+    assert config_file.exists()
+    data = json.loads(config_file.read_text())
+    assert wrap_mod._RTK_MARKER in data["systemMessage"]
+
+
+def test_wrap_continue_respects_custom_config_path(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--config writes to the user-specified path, not the cwd default."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    custom_config = tmp_path / "custom" / "my-continue.json"
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+        result = runner.invoke(
+            main,
+            ["wrap", "continue", "--prepare-only", "--config", str(custom_config)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert custom_config.exists()
+    assert not (tmp_path / ".continue" / "config.json").exists()
+    data = json.loads(custom_config.read_text())
+    assert wrap_mod._RTK_MARKER in data["systemMessage"]

--- a/tests/test_cli/test_wrap_continue.py
+++ b/tests/test_cli/test_wrap_continue.py
@@ -30,7 +30,7 @@ def test_inject_continue_rtk_systemmessage_new_file(tmp_path: Path) -> None:
 
 
 def test_inject_continue_rtk_systemmessage_preserves_existing_keys(tmp_path: Path) -> None:
-    """Pre-existing keys like ``models`` are not touched."""
+    """Pre-existing keys are not touched; per-model entries get systemMessage."""
     config_file = tmp_path / ".continue" / "config.json"
     config_file.parent.mkdir(parents=True)
     config_file.write_text(json.dumps({"models": [{"title": "GPT-4o", "provider": "openai"}]}))
@@ -38,8 +38,14 @@ def test_inject_continue_rtk_systemmessage_preserves_existing_keys(tmp_path: Pat
     wrap_mod._inject_continue_rtk_systemmessage(config_file)
 
     data = json.loads(config_file.read_text())
-    assert data["models"] == [{"title": "GPT-4o", "provider": "openai"}]
+    # Pre-existing fields on the model entry are preserved verbatim.
+    assert data["models"][0]["title"] == "GPT-4o"
+    assert data["models"][0]["provider"] == "openai"
+    # Top-level systemMessage is set.
     assert wrap_mod._RTK_MARKER in data["systemMessage"]
+    # Per-model systemMessage is also populated (Continue overrides top-level
+    # with per-model when set, so we must visit each model).
+    assert wrap_mod._RTK_MARKER in data["models"][0]["systemMessage"]
 
 
 def test_inject_continue_rtk_systemmessage_appends_to_existing_message(
@@ -138,3 +144,173 @@ def test_wrap_continue_respects_custom_config_path(
     assert not (tmp_path / ".continue" / "config.json").exists()
     data = json.loads(custom_config.read_text())
     assert wrap_mod._RTK_MARKER in data["systemMessage"]
+
+
+# ---------------------------------------------------------------------------
+# H1: non-string systemMessage must NOT be silently clobbered.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "non_string_value",
+    [
+        {"role": "system", "content": "You are helpful."},  # dict
+        ["You are helpful.", "Respond in JSON."],  # list
+        42,  # int
+    ],
+    ids=["dict", "list", "int"],
+)
+def test_inject_continue_rtk_systemmessage_refuses_non_string_top_level(
+    tmp_path: Path,
+    non_string_value: object,
+) -> None:
+    """A non-string top-level systemMessage must NOT be overwritten."""
+    config_file = tmp_path / ".continue" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    original_payload = {"systemMessage": non_string_value, "other": "untouched"}
+    config_file.write_text(json.dumps(original_payload))
+    original_bytes = config_file.read_bytes()
+
+    result = wrap_mod._inject_continue_rtk_systemmessage(config_file)
+
+    assert result is False, "must report refusal when user data would be clobbered"
+    # File must be byte-identical to before.
+    assert config_file.read_bytes() == original_bytes
+    data = json.loads(config_file.read_text())
+    assert data["systemMessage"] == non_string_value
+    assert data["other"] == "untouched"
+
+
+@pytest.mark.parametrize(
+    "non_string_value",
+    [
+        {"role": "system", "content": "Per-model system."},
+        ["List", "of", "strings"],
+        7,
+    ],
+    ids=["dict", "list", "int"],
+)
+def test_inject_continue_rtk_systemmessage_refuses_non_string_per_model(
+    tmp_path: Path,
+    non_string_value: object,
+) -> None:
+    """A non-string per-model systemMessage must NOT be overwritten."""
+    config_file = tmp_path / ".continue" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    original_payload = {
+        "models": [
+            {"title": "GPT-4o", "provider": "openai", "systemMessage": non_string_value},
+        ],
+    }
+    config_file.write_text(json.dumps(original_payload))
+
+    result = wrap_mod._inject_continue_rtk_systemmessage(config_file)
+
+    assert result is False, "must report refusal when per-model user data would be clobbered"
+    data = json.loads(config_file.read_text())
+    # The non-string per-model value must be preserved.
+    assert data["models"][0]["systemMessage"] == non_string_value
+
+
+# ---------------------------------------------------------------------------
+# M2: per-model systemMessage handling.
+# ---------------------------------------------------------------------------
+
+
+def test_inject_continue_rtk_systemmessage_visits_each_model(
+    tmp_path: Path,
+) -> None:
+    """Each models[i].systemMessage gets the RTK block."""
+    config_file = tmp_path / ".continue" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {"title": "A", "systemMessage": "user value"},
+                    {"title": "B"},  # no systemMessage yet
+                ],
+            }
+        )
+    )
+
+    assert wrap_mod._inject_continue_rtk_systemmessage(config_file) is True
+
+    data = json.loads(config_file.read_text())
+    # Pre-existing per-model systemMessage is preserved + RTK block appended.
+    assert "user value" in data["models"][0]["systemMessage"]
+    assert wrap_mod._RTK_MARKER in data["models"][0]["systemMessage"]
+    # Model with no systemMessage gets the RTK block fresh.
+    assert wrap_mod._RTK_MARKER in data["models"][1]["systemMessage"]
+    # Top-level also populated.
+    assert wrap_mod._RTK_MARKER in data["systemMessage"]
+
+
+def test_inject_continue_rtk_systemmessage_per_model_idempotent(
+    tmp_path: Path,
+) -> None:
+    """Re-running must not duplicate per-model RTK blocks."""
+    config_file = tmp_path / ".continue" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(
+        json.dumps({"models": [{"title": "A", "systemMessage": "user"}]}),
+    )
+
+    wrap_mod._inject_continue_rtk_systemmessage(config_file)
+    wrap_mod._inject_continue_rtk_systemmessage(config_file)
+
+    data = json.loads(config_file.read_text())
+    assert data["models"][0]["systemMessage"].count(wrap_mod._RTK_MARKER) == 1
+    assert data["systemMessage"].count(wrap_mod._RTK_MARKER) == 1
+
+
+def test_inject_continue_rtk_systemmessage_skips_non_dict_model_entries(
+    tmp_path: Path,
+) -> None:
+    """A models[] entry that isn't a dict must be left untouched."""
+    config_file = tmp_path / ".continue" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(
+        json.dumps({"models": ["just a string entry", {"title": "B"}]}),
+    )
+
+    wrap_mod._inject_continue_rtk_systemmessage(config_file)
+
+    data = json.loads(config_file.read_text())
+    # Non-dict entry preserved verbatim.
+    assert data["models"][0] == "just a string entry"
+    # Dict entry got the RTK block.
+    assert wrap_mod._RTK_MARKER in data["models"][1]["systemMessage"]
+
+
+# ---------------------------------------------------------------------------
+# M4: Ctrl-C during prelude emits a clear message.
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_continue_keyboardinterrupt_during_prelude_emits_clear_message(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ctrl-C between marker injection and proxy start must signal clearly."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    config_file = tmp_path / ".continue" / "config.json"
+
+    def raise_kbd_after_inject(*args, **kwargs):  # noqa: ANN002, ANN003
+        # Simulate the user hitting Ctrl-C right after we wrote config.json
+        # but before the proxy started.
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text('{"systemMessage": "marker block"}')
+        raise KeyboardInterrupt
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", side_effect=raise_kbd_after_inject):
+        result = runner.invoke(main, ["wrap", "continue", "--prepare-only"])
+
+    assert result.exit_code == 130
+    assert "interrupted" in result.output.lower()
+    assert "idempotent" in result.output.lower()
+    assert config_file.exists()
+    assert str(config_file) in result.output

--- a/tests/test_cli/test_wrap_goose.py
+++ b/tests/test_cli/test_wrap_goose.py
@@ -1,0 +1,117 @@
+"""Tests for `headroom wrap goose` command (PR-G1, Phase G)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from headroom.cli import wrap as wrap_mod
+from headroom.cli.main import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_wrap_goose_sets_provider_envs(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OPENAI_BASE_URL, OPENAI_API_BASE, ANTHROPIC_BASE_URL are set on launch."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="goose"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                result = runner.invoke(main, ["wrap", "goose", "--port", "9000", "--", "session"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["OPENAI_BASE_URL"] == "http://127.0.0.1:9000/v1"
+    assert env["OPENAI_API_BASE"] == "http://127.0.0.1:9000/v1"
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9000"
+    assert captured["tool_label"] == "GOOSE"
+    assert captured["agent_type"] == "goose"
+    assert captured["args"] == ("session",)
+
+
+def test_wrap_goose_injects_rtk_into_goosehints(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RTK block must be written to .goosehints at the project root."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+        result = runner.invoke(main, ["wrap", "goose", "--prepare-only"])
+
+    assert result.exit_code == 0, result.output
+    goosehints = tmp_path / ".goosehints"
+    assert goosehints.exists()
+    content = goosehints.read_text()
+    assert wrap_mod._RTK_MARKER in content
+    assert "RTK (Rust Token Killer)" in content
+
+
+def test_wrap_goose_idempotent_no_duplicate_block(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-running prepare-only must not duplicate the .goosehints RTK block."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+        runner.invoke(main, ["wrap", "goose", "--prepare-only"])
+        runner.invoke(main, ["wrap", "goose", "--prepare-only"])
+
+    content = (tmp_path / ".goosehints").read_text()
+    assert content.count(wrap_mod._RTK_MARKER) == 1
+
+
+def test_wrap_goose_missing_binary_errors_clearly(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the goose binary is missing the command must fail with a clear error."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    with patch.object(wrap_mod.shutil, "which", return_value=None):
+        with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+            result = runner.invoke(main, ["wrap", "goose"])
+
+    assert result.exit_code == 1
+    assert "'goose' not found in PATH" in result.output
+
+
+def test_wrap_goose_no_context_tool_skips_goosehints(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--no-context-tool must not create .goosehints."""
+    monkeypatch.chdir(tmp_path)
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary") as ensure:
+        result = runner.invoke(main, ["wrap", "goose", "--prepare-only", "--no-context-tool"])
+
+    assert result.exit_code == 0, result.output
+    assert not (tmp_path / ".goosehints").exists()
+    ensure.assert_not_called()

--- a/tests/test_cli/test_wrap_goose.py
+++ b/tests/test_cli/test_wrap_goose.py
@@ -115,3 +115,34 @@ def test_wrap_goose_no_context_tool_skips_goosehints(
     assert result.exit_code == 0, result.output
     assert not (tmp_path / ".goosehints").exists()
     ensure.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# M4: Ctrl-C during prelude.
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_goose_keyboardinterrupt_during_prelude_emits_clear_message(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ctrl-C between marker injection and proxy start must signal clearly."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    def raise_kbd(*args, **kwargs):  # noqa: ANN002, ANN003
+        # Simulate Ctrl-C after the prelude wrote .goosehints but before the
+        # tool was launched. The marker file exists on disk.
+        marker_path = tmp_path / ".goosehints"
+        marker_path.write_text(wrap_mod.RTK_INSTRUCTIONS_BLOCK)
+        raise KeyboardInterrupt
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", side_effect=raise_kbd):
+        result = runner.invoke(main, ["wrap", "goose", "--prepare-only"])
+
+    assert result.exit_code == 130
+    assert "interrupted" in result.output.lower()
+    assert "idempotent" in result.output.lower()
+    assert (tmp_path / ".goosehints").exists()
+    assert ".goosehints" in result.output

--- a/tests/test_cli/test_wrap_openhands.py
+++ b/tests/test_cli/test_wrap_openhands.py
@@ -1,0 +1,175 @@
+"""Tests for `headroom wrap openhands` command (PR-G1, Phase G)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from headroom.cli import wrap as wrap_mod
+from headroom.cli.main import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_wrap_openhands_sets_provider_envs(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OPENAI_BASE_URL, ANTHROPIC_BASE_URL, LLM_BASE_URL are set on launch."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="openhands"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                result = runner.invoke(
+                    main, ["wrap", "openhands", "--port", "9000", "--", "--task", "demo"]
+                )
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["OPENAI_BASE_URL"] == "http://127.0.0.1:9000/v1"
+    assert env["OPENAI_API_BASE"] == "http://127.0.0.1:9000/v1"
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9000"
+    assert env["LLM_BASE_URL"] == "http://127.0.0.1:9000/v1"
+    assert captured["tool_label"] == "OPENHANDS"
+    assert captured["agent_type"] == "openhands"
+    assert captured["args"] == ("--task", "demo")
+
+
+def test_wrap_openhands_injects_rtk_via_env_var(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OPENHANDS_INSTRUCTIONS env var must contain the RTK block at launch."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.delenv("OPENHANDS_INSTRUCTIONS", raising=False)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="openhands"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                result = runner.invoke(main, ["wrap", "openhands"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    instructions = env.get("OPENHANDS_INSTRUCTIONS", "")
+    assert wrap_mod._RTK_MARKER in instructions
+    assert "RTK (Rust Token Killer)" in instructions
+
+
+def test_wrap_openhands_preserves_existing_openhands_instructions(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-existing OPENHANDS_INSTRUCTIONS env content is preserved, rtk is appended."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.setenv("OPENHANDS_INSTRUCTIONS", "Prefer typed Python.")
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="openhands"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                result = runner.invoke(main, ["wrap", "openhands"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    instructions = env.get("OPENHANDS_INSTRUCTIONS", "")
+    assert "Prefer typed Python." in instructions
+    assert wrap_mod._RTK_MARKER in instructions
+
+
+def test_wrap_openhands_idempotent_already_injected(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If OPENHANDS_INSTRUCTIONS already contains the marker, do not re-append."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    pre_existing = "Prefer typed Python.\n\n" + wrap_mod.RTK_INSTRUCTIONS_BLOCK
+    monkeypatch.setenv("OPENHANDS_INSTRUCTIONS", pre_existing)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="openhands"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                result = runner.invoke(main, ["wrap", "openhands"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    instructions = env.get("OPENHANDS_INSTRUCTIONS", "")
+    assert instructions.count(wrap_mod._RTK_MARKER) == 1
+
+
+def test_wrap_openhands_missing_binary_errors_clearly(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the openhands binary is missing the command must fail with a clear error."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+
+    with patch.object(wrap_mod.shutil, "which", return_value=None):
+        with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+            result = runner.invoke(main, ["wrap", "openhands"])
+
+    assert result.exit_code == 1
+    assert "'openhands' not found in PATH" in result.output
+
+
+def test_wrap_openhands_no_context_tool_does_not_inject(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--no-context-tool must skip OPENHANDS_INSTRUCTIONS injection."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENHANDS_INSTRUCTIONS", raising=False)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="openhands"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary") as ensure:
+                result = runner.invoke(main, ["wrap", "openhands", "--no-context-tool"])
+
+    assert result.exit_code == 0, result.output
+    ensure.assert_not_called()
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "OPENHANDS_INSTRUCTIONS" not in env or env["OPENHANDS_INSTRUCTIONS"] == ""

--- a/tests/test_cli/test_wrap_openhands.py
+++ b/tests/test_cli/test_wrap_openhands.py
@@ -173,3 +173,86 @@ def test_wrap_openhands_no_context_tool_does_not_inject(
     env = captured["env"]
     assert isinstance(env, dict)
     assert "OPENHANDS_INSTRUCTIONS" not in env or env["OPENHANDS_INSTRUCTIONS"] == ""
+
+
+# ---------------------------------------------------------------------------
+# M3: rtk install failure must fail loudly — no silent fallback to env
+# injection without rtk on disk.
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_openhands_rtk_install_failure_aborts_loudly(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If rtk install fails, command must exit non-zero with a clear error."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.delenv("OPENHANDS_INSTRUCTIONS", raising=False)
+
+    launch_called: list[bool] = []
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        launch_called.append(True)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="openhands"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=None):
+                result = runner.invoke(main, ["wrap", "openhands"])
+
+    assert result.exit_code == 1
+    assert "rtk install failed" in result.output
+    assert "--no-context-tool" in result.output
+    # _launch_tool must NOT have been invoked when rtk install fails.
+    assert launch_called == []
+
+
+def test_wrap_openhands_rtk_install_failure_with_no_context_tool_still_launches(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--no-context-tool bypasses rtk entirely — should still launch."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENHANDS_INSTRUCTIONS", raising=False)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="openhands"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=None) as ensure:
+                result = runner.invoke(main, ["wrap", "openhands", "--no-context-tool"])
+
+    assert result.exit_code == 0, result.output
+    # rtk should never have been queried.
+    ensure.assert_not_called()
+    env = captured["env"]
+    assert "OPENHANDS_INSTRUCTIONS" not in env or env["OPENHANDS_INSTRUCTIONS"] == ""
+
+
+# ---------------------------------------------------------------------------
+# M4: Ctrl-C during prelude emits a clear "no on-disk changes" message.
+# openhands never writes to disk (env-var injection only).
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_openhands_keyboardinterrupt_during_prelude_emits_clear_message(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ctrl-C during the prelude must signal cleanly with no on-disk artifact."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.delenv("OPENHANDS_INSTRUCTIONS", raising=False)
+
+    with patch.object(wrap_mod, "_ensure_rtk_binary", side_effect=KeyboardInterrupt):
+        result = runner.invoke(main, ["wrap", "openhands"])
+
+    assert result.exit_code == 130
+    assert "interrupted" in result.output.lower()
+    assert "idempotent" in result.output.lower()


### PR DESCRIPTION
## Summary

Adds `headroom wrap <agent>` subcommands for **cline, continue, goose, openhands** — following the existing claude/codex/aider/copilot/cursor pattern. Each new subcommand:

- Calls `_ensure_rtk_binary()`
- Injects the canonical RTK instructions block into the agent's instruction file
  - cline → `.clinerules`
  - continue → `.continue/config.json` `systemMessage` (top-level **and** per-model `models[*].systemMessage`)
  - goose → `.goosehints`
  - openhands → `OPENHANDS_INSTRUCTIONS` env var
- Spawns the Headroom proxy
- Launches the wrapped CLI with appropriate `*_BASE_URL` env vars

Part of Phase G of the realignment plan (`REALIGNMENT/09-phase-G-rtk-observability.md`).

## Changes (2 commits, recommend squash-merge)

- **c375fa1** — initial implementation (+1139 / −3, 23 new tests)
- **ea1976e** — remediation addressing 1 High + 5 Medium review findings:
  - Refuses to silently clobber a non-string `systemMessage` (loud opt-in instructions)
  - Per-model `systemMessage` handling for Continue's `models[]` array
  - `openhands` now gates on `_ensure_rtk_binary()` like the other 3
  - KeyboardInterrupt handler emits a marker-path retry message
  - Manual-uninstall marker location documented in each new agent's docstring

## Test plan

- 51 wrap tests pass (`pytest tests/test_cli/test_wrap_*.py -x -q`)
- Full `tests/test_cli/` suite: 217 tests pass
- `make ci-precheck` PASSED
- ruff + mypy clean