### PR TITLE
fix(release): tag format vX.Y.Z (drop release-please component prefix)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "draft": false,

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1061,6 +1061,19 @@ def test_release_please_config_and_manifest_are_present_and_consistent() -> None
     assert root_pkg["release-type"] == "python"
     assert root_pkg["package-name"] == "headroom-ai"
 
+    # Tag format: existing tags in this repo are `vX.Y.Z`, NOT
+    # `headroom-ai-vX.Y.Z`. release-please's default for manifest
+    # configs prepends the component name; that would produce
+    # `headroom-ai-v0.22.4` and the bot would never find the existing
+    # `v0.22.3` baseline tag. include-component-in-tag MUST be false
+    # to keep tag format consistent with the project's pre-bot tags.
+    assert config.get("include-component-in-tag") is False, (
+        "include-component-in-tag must be false — existing tags are "
+        "`vX.Y.Z`, not `headroom-ai-vX.Y.Z`. Reverting this setting "
+        "would orphan every prior tag and produce a months-long "
+        "changelog because the bot can't find its baseline."
+    )
+
     # extra-files: TypeScript SDK and openclaw plugin package.json
     # files must be in lockstep with pyproject.toml.
     extra_paths = {ef["path"] for ef in root_pkg.get("extra-files", [])}


### PR DESCRIPTION
## Summary

release-please's first run on main (PR #496) tried to ship `headroom-ai-v0.23.0` and computed its changelog from genesis. Two reasons:

1. **Wrong tag prefix.** With manifest configs, release-please defaults to `include-component-in-tag: true`, which prepends the package name. The repo's existing tags are plain `vX.Y.Z`.
2. **Missing baseline tag.** PyPI 0.22.3 had no corresponding git tag — the old release pipeline shipped to PyPI but `create-release` step never tagged the merge commit (PR #490, `9536d6b`, 2026-05-21).

Without a matching baseline tag, the bot walked the entire git history for the changelog.

## Fixes

- **This PR**: adds `"include-component-in-tag": false` to `.release-please-config.json` so the bot uses `vX.Y.Z`. Regression test pinned in `tests/test_release_workflows.py`.
- **Already done out-of-band**: pushed `v0.22.3` tag pointing at `9536d6b` (the merge commit PyPI 0.22.3 came from). Bot now has a clean baseline.
- **After this merges**: close PR #496 to force release-please to regenerate. The new PR will propose `v0.22.4` (PATCH bump from the one `fix(tests):` commit in PR #495) with a one-line changelog.

## Test plan

- [x] `python -m pytest tests/test_release_workflows.py::test_release_please_config_and_manifest_are_present_and_consistent` — passes
- [x] `make ci-precheck` — passes
- [ ] After merge: release-please run produces a clean PR titled `chore(main): release 0.22.4`