### PR TITLE
fix(docker): upgrade base images to Python 3.13 / debian13, drop digest pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG PYTHON_VERSION=3.11
-ARG UV_VERSION=0.6.17
-# Pinned 2026-04-15. Update via Dependabot or: docker pull python:3.11-slim
-ARG PYTHON_DIGEST=sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
-# Pinned 2026-04-15. Update via Dependabot or: docker pull gcr.io/distroless/python3-debian13
-ARG DISTROLESS_DIGEST=sha256:ed3a4beb46f8f8baac068743ba1b1f95ea3f793422129cf6dd23967f779b6018
+ARG PYTHON_VERSION=3.13
+ARG UV_VERSION=0.11.16
+# Pinned 2026-05-28. Update via Dependabot or: docker pull python:3.13-slim
+ARG PYTHON_DIGEST=sha256:b04b5d7233d2ad9c379e22ea8927cd1378cd15c60d4ef876c065b25ea8fb3bf3
+# Pinned 2026-05-28. Update via Dependabot or: docker pull gcr.io/distroless/python3-debian13
+ARG DISTROLESS_DIGEST=sha256:a156791331382d183a569c1714a6c5364d5402e622da5618005308c2adcb4a9c
 ARG DISTROLESS_IMAGE=gcr.io/distroless/python3-debian13
 ARG PYTHON_SITE_PACKAGES=/usr/local/lib/python${PYTHON_VERSION}/site-packages
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 ARG PYTHON_VERSION=3.13
 ARG UV_VERSION=0.11.16
-# Pinned 2026-05-28. Update via Dependabot or: docker pull python:3.13-slim
-ARG PYTHON_DIGEST=sha256:b04b5d7233d2ad9c379e22ea8927cd1378cd15c60d4ef876c065b25ea8fb3bf3
-# Pinned 2026-05-28. Update via Dependabot or: docker pull gcr.io/distroless/python3-debian13
-ARG DISTROLESS_DIGEST=sha256:a156791331382d183a569c1714a6c5364d5402e622da5618005308c2adcb4a9c
 ARG DISTROLESS_IMAGE=gcr.io/distroless/python3-debian13
 ARG PYTHON_SITE_PACKAGES=/usr/local/lib/python${PYTHON_VERSION}/site-packages
 
 # ---- Build stage: compile native extensions, build wheel ----
-FROM python:${PYTHON_VERSION}-slim@${PYTHON_DIGEST} AS builder
+FROM python:${PYTHON_VERSION}-slim AS builder
 
 ARG UV_VERSION
 
@@ -65,7 +61,7 @@ RUN cd /tmp && python -c "from headroom._core import DiffCompressor, SmartCrushe
     print(f'build-stage rust core verify OK: {DiffCompressor.__name__}, {SmartCrusher.__name__}')"
 
 # ---- Runtime stage (python-slim): supports root/nonroot via build arg ----
-FROM python:${PYTHON_VERSION}-slim@${PYTHON_DIGEST} AS runtime-slim-base
+FROM python:${PYTHON_VERSION}-slim AS runtime-slim-base
 
 ARG RUNTIME_USER=nonroot
 ARG PYTHON_SITE_PACKAGES
@@ -102,7 +98,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
 ENTRYPOINT ["headroom", "proxy"]
 CMD ["--host", "0.0.0.0", "--port", "8787"]
 
-FROM ${DISTROLESS_IMAGE}@${DISTROLESS_DIGEST} AS runtime-slim
+FROM ${DISTROLESS_IMAGE} AS runtime-slim
 
 ARG RUNTIME_USER=nonroot
 ARG PYTHON_SITE_PACKAGES


### PR DESCRIPTION
## Problem

`ghcr.io/chopratejas/headroom:code-slim` (and all `*-slim` variants) crashed on startup:

```
ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
```

**Root cause:** builder stage used `python:3.11-slim` → installed wheels into `/usr/local/lib/python3.11/site-packages` with `cpython-311` ABI. Distroless runtime (`python3-debian13`) ships Python 3.13, which cannot load `cpython-311` `.so` files. The `PYTHONPATH` workaround only made the module *discoverable* — it couldn't fix the binary ABI mismatch.

Unaffected images (`latest`, `code`, `nonroot`, `code-nonroot`) use `python:3.11-slim` as runtime, so builder/runtime Python matched.

## Fix

- Upgrade builder + `runtime-slim-base` from `python:3.11-slim` → `python:3.13-slim`
- `distroless/python3-debian13` already ships Python 3.13 — now matches
- uv `0.6.17` → `0.11.16`
- Remove digest pins in favour of floating tags (Dependabot / CI pulls latest patches)
- PyO3 `0.22.6` (already in `Cargo.lock`) fully supports Python 3.13

## Verification

Built `runtime-slim` target on linux/amd64 and confirmed:

```
Python 3.13.5
pydantic_core: 2.46.4
Usage: python -m headroom.cli proxy [OPTIONS]   ← --help works
```

Rust core smoke-check also passed inside the build stage:
```
build-stage rust core verify OK: DiffCompressor, SmartCrusher
```