### PR TITLE
fix(learn): decode Unix home dirs whose username contains '.', '-' or '_'

### DIFF
--- a/headroom/learn/plugins/claude.py
+++ b/headroom/learn/plugins/claude.py
@@ -333,15 +333,17 @@ def _decode_project_path(escaped_name: str) -> Path | None:
     if len(parts) < 3:
         return None
 
-    if parts[0] == "Users" and len(parts) > 2:
+    if parts[0] in ("Users", "home") and len(parts) > 2:
+        # Start the greedy decode at the mount root so a home-directory
+        # component containing '.', '-' or '_' (e.g. "first.last", encoded as
+        # "first-last") is matched as a single directory by tokenisation,
+        # instead of being split into "/Users/first/last". Falls back to the
+        # legacy single-token assumption if the rooted walk finds nothing.
+        result = _greedy_path_decode(Path(f"/{parts[0]}"), parts[1:])
+        if result is not None:
+            return result
         base = Path(f"/{parts[0]}/{parts[1]}")
-        remaining = parts[2:]
-        return _greedy_path_decode(base, remaining)
-
-    if parts[0] == "home" and len(parts) > 2:
-        base = Path(f"/{parts[0]}/{parts[1]}")
-        remaining = parts[2:]
-        return _greedy_path_decode(base, remaining)
+        return _greedy_path_decode(base, parts[2:])
 
     return None
 

--- a/tests/test_learn/test_scanner.py
+++ b/tests/test_learn/test_scanner.py
@@ -344,3 +344,37 @@ class TestDecodeProjectPath:
         assert len(projects) == 1
         assert projects[0].name == "work"
         assert str(projects[0].project_path).startswith("C:")
+
+    def test_unix_username_with_dot_stays_single_component(
+        self, users_tmp: Path
+    ) -> None:
+        """Unix home dirs like /Users/first.last must not decode as /Users/first/last.
+
+        Claude Code flattens '.', '-' and '_' to '-' when escaping, so
+        /Users/first.last is stored as ``-Users-first-last-…``. The decoder used
+        to consume only the first token after ``Users`` as the home directory and
+        walk from ``/Users/first`` (which does not exist), so it bailed out and
+        callers fell back to the literal ``/Users/first/last`` — causing writes to
+        fail with ``PermissionError: '/Users/first'``. This is the Unix
+        counterpart of ``test_windows_username_with_dot_stays_single_component``.
+
+        Reproduces only when the test runner's home is itself a dotted/hyphenated
+        name under ``/Users`` (the decoder is rooted at the real ``/Users`` tree);
+        skipped otherwise.
+        """
+        import re
+
+        home = Path.home()
+        if not (str(home).startswith("/Users/") and ("." in home.name or "-" in home.name)):
+            pytest.skip("requires a dotted or hyphenated username under /Users")
+
+        project = users_tmp / "proj"
+        project.mkdir(parents=True)
+
+        # Flatten separators exactly as Claude Code does when escaping a path.
+        encoded = "-" + re.sub(r"[-._/]", "-", str(project)[1:])
+        result = _decode_project_path(encoded)
+
+        assert result == project
+        assert f"/{home.name}/" in str(result)
+        assert f"/{home.name.split('.')[0]}/" not in str(result)


### PR DESCRIPTION
## Problem

`headroom learn --all --apply` fails to write recommendations for every project when the user's home directory name contains a `.` (e.g. macOS/Okta usernames like `first.last`). Each project errors with:

```
Warning: failed to write recommendations for /Users/first/last/...: [Errno 13] Permission denied: '/Users/first'
```

and the decoded path is printed as `/Users/first/last/...` instead of `/Users/first.last/...`.

## Root cause

Claude Code escapes project paths by flattening `/`, `.`, `-` and `_` all to `-`, so `/Users/first.last/proj` is stored as `-Users-first-last-proj`.

`_decode_project_path` consumed only the **first** token after `Users`/`home` as the home directory:

```python
base = Path(f"/{parts[0]}/{parts[1]}")   # -> /Users/first  (does not exist)
return _greedy_path_decode(base, parts[2:])
```

When the username itself spans multiple tokens (`first`, `last`), `/Users/first` doesn't exist, the greedy walk bails, and the caller falls back to the literal `replace("-", "/")` -> `/Users/first/last/...`. Writes then hit `PermissionError: '/Users/first'`.

This is the Unix counterpart of the already-handled Windows case (`test_windows_username_with_dot_stays_single_component`).

## Fix

Start the greedy decode at the mount root (`/Users` or `/home`) and pass the remaining tokens, so the multi-token home component is reconstructed by the existing tokenisation logic (which already handles `.`/`-`/`_` flattening, issues #47 / #159). Legacy single-token behaviour is kept as a fallback.

## Test

Adds `test_unix_username_with_dot_stays_single_component`. The existing `test_flattened_dot_dirname_via_greedy` already fails pre-fix on any machine whose username contains a dot; both pass after the fix. Full `tests/test_learn/test_scanner.py` green (31 passed).