### PR TITLE
Leverage /backend-api/models for Codex to pull models instead of fixed list

### DIFF
--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -204,6 +204,13 @@ def _selected_context_tool() -> str:
         "Env: HEADROOM_ANTHROPIC_PRE_UPSTREAM_MEMORY_CONTEXT_TIMEOUT_SECONDS."
     ),
 )
+@click.option(
+    "--log-level",
+    type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
+    default=None,
+    envvar="HEADROOM_LOG_LEVEL",
+    help="Set Headroom proxy file log level. Env: HEADROOM_LOG_LEVEL.",
+)
 @click.option("--log-file", default=None, help="Path to JSONL log file")
 @click.option(
     "--log-messages",
@@ -454,6 +461,7 @@ def proxy(
     anthropic_pre_upstream_concurrency: int | None,
     anthropic_pre_upstream_acquire_timeout_seconds: float | None,
     anthropic_pre_upstream_memory_context_timeout_seconds: float | None,
+    log_level: str | None,
     log_file: str | None,
     log_messages: bool,
     codex_wire_debug: bool,
@@ -505,6 +513,9 @@ def proxy(
         OPENAI_BASE_URL=http://localhost:8787/v1 your-app
     """
     # Import here to avoid slow startup
+    if log_level:
+        os.environ["HEADROOM_LOG_LEVEL"] = log_level.upper()
+
     try:
         from headroom.proxy.server import ProxyConfig, run_server
     except ImportError as e:

--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -204,13 +204,6 @@ def _selected_context_tool() -> str:
         "Env: HEADROOM_ANTHROPIC_PRE_UPSTREAM_MEMORY_CONTEXT_TIMEOUT_SECONDS."
     ),
 )
-@click.option(
-    "--log-level",
-    type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
-    default=None,
-    envvar="HEADROOM_LOG_LEVEL",
-    help="Set Headroom proxy file log level. Env: HEADROOM_LOG_LEVEL.",
-)
 @click.option("--log-file", default=None, help="Path to JSONL log file")
 @click.option(
     "--log-messages",
@@ -461,7 +454,6 @@ def proxy(
     anthropic_pre_upstream_concurrency: int | None,
     anthropic_pre_upstream_acquire_timeout_seconds: float | None,
     anthropic_pre_upstream_memory_context_timeout_seconds: float | None,
-    log_level: str | None,
     log_file: str | None,
     log_messages: bool,
     codex_wire_debug: bool,
@@ -513,9 +505,6 @@ def proxy(
         OPENAI_BASE_URL=http://localhost:8787/v1 your-app
     """
     # Import here to avoid slow startup
-    if log_level:
-        os.environ["HEADROOM_LOG_LEVEL"] = log_level.upper()
-
     try:
         from headroom.proxy.server import ProxyConfig, run_server
     except ImportError as e:

--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
-from typing import Any, cast
+import os
+import time
+from typing import Any, TypedDict, cast
+from urllib.parse import quote
 
 from fastapi import FastAPI, Request, WebSocket
 from fastapi.responses import Response
@@ -12,6 +16,15 @@ from fastapi.responses import Response
 from headroom.proxy.handlers.openai import _resolve_codex_routing_headers
 
 logger = logging.getLogger("headroom.proxy.routes")
+
+_CODEX_MODELS_CACHE: dict[tuple[str, str], tuple[float, tuple[str, ...]]] = {}
+
+
+class OpenAIModelItem(TypedDict):
+    id: str
+    object: str
+    created: int
+    owned_by: str
 
 
 def _api_target(proxy: Any, provider_name: str) -> str:
@@ -51,8 +64,9 @@ def _select_passthrough_base_url(proxy: Any, headers: dict[str, str]) -> str:
 # bearer tokens (issue #478). Codex polls `/v1/models` every few seconds
 # to populate its model-picker UI, so the 403 storm is noisy and breaks
 # refresh. The fix: when Codex hits `/v1/models` under ChatGPT auth,
-# synthesize an OpenAI-compatible response from the known-supported
-# Codex/ChatGPT model set instead of forwarding to a 403.
+# fetch the Codex-specific registry first and synthesize an
+# OpenAI-compatible response from its slugs. If that registry is
+# unavailable, fall back to the known-supported static set.
 #
 # The list mirrors what Codex itself ships in its built-in model
 # registry (the same models its provider config exposes); it's the
@@ -68,22 +82,44 @@ _CHATGPT_AUTH_CODEX_MODELS: tuple[str, ...] = (
 )
 
 
-def _synthetic_models_list_response() -> Response:
-    """OpenAI-compatible `/v1/models` payload for Codex ChatGPT auth."""
-    import json
+def _codex_client_version(requested_client_version: str | None = None) -> str:
+    if requested_client_version:
+        return requested_client_version
+    return os.getenv("HEADROOM_CODEX_CLIENT_VERSION", "0.130.0")
 
+
+def _codex_models_cache_ttl_seconds() -> float:
+    raw_value = os.getenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "300")
+    try:
+        return max(0.0, float(raw_value))
+    except ValueError:
+        logger.warning(
+            "Invalid HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS=%r; disabling Codex models cache",
+            raw_value,
+        )
+        return 0.0
+
+
+def _openai_model_item(model_id: str) -> OpenAIModelItem:
+    return {
+        "id": model_id,
+        "object": "model",
+        "created": 0,
+        "owned_by": "openai",
+    }
+
+
+def _models_list_response(model_ids: tuple[str, ...], *, source: str) -> Response:
     payload = {
         "object": "list",
-        "data": [
-            {
-                "id": model_id,
-                "object": "model",
-                "created": 0,
-                "owned_by": "openai",
-            }
-            for model_id in _CHATGPT_AUTH_CODEX_MODELS
-        ],
+        "data": [_openai_model_item(model_id) for model_id in model_ids],
     }
+    logger.debug(
+        "Returning Codex model metadata response source=%s model_ids=%s payload=%s",
+        source,
+        list(model_ids),
+        payload,
+    )
     return Response(
         content=json.dumps(payload),
         status_code=200,
@@ -91,10 +127,13 @@ def _synthetic_models_list_response() -> Response:
     )
 
 
+def _synthetic_models_list_response() -> Response:
+    """OpenAI-compatible `/v1/models` payload for Codex ChatGPT auth."""
+    return _models_list_response(_CHATGPT_AUTH_CODEX_MODELS, source="static_fallback")
+
+
 def _synthetic_model_get_response(model_id: str) -> Response:
     """OpenAI-compatible `/v1/models/{id}` payload."""
-    import json
-
     if model_id not in _CHATGPT_AUTH_CODEX_MODELS:
         return Response(
             content=json.dumps(
@@ -110,15 +149,132 @@ def _synthetic_model_get_response(model_id: str) -> Response:
             headers={"content-type": "application/json"},
         )
     return Response(
+        content=json.dumps(_openai_model_item(model_id)),
+        status_code=200,
+        headers={"content-type": "application/json"},
+    )
+
+
+def _normalize_codex_registry_headers(headers: dict[str, str]) -> tuple[dict[str, str], str]:
+    upstream_headers = dict(headers)
+    upstream_headers.pop("host", None)
+    account_id = (
+        upstream_headers.get("chatgpt-account-id")
+        or upstream_headers.get("ChatGPT-Account-ID")
+        or ""
+    )
+    if account_id:
+        upstream_headers["chatgpt-account-id"] = account_id
+        upstream_headers.pop("ChatGPT-Account-ID", None)
+    upstream_headers["accept"] = "application/json"
+    upstream_headers.pop("Accept", None)
+    return upstream_headers, account_id
+
+
+async def _fetch_chatgpt_codex_model_ids(
+    proxy: Any,
+    headers: dict[str, str],
+    requested_client_version: str | None,
+) -> tuple[str, ...] | None:
+    client_version = _codex_client_version(requested_client_version)
+    upstream_headers, account_id = _normalize_codex_registry_headers(headers)
+    cache_key = (account_id, client_version)
+    cache_ttl = _codex_models_cache_ttl_seconds()
+    now = time.monotonic()
+    cached = _CODEX_MODELS_CACHE.get(cache_key)
+    if cached is not None:
+        cached_at, cached_model_ids = cached
+        if cache_ttl > 0 and now - cached_at < cache_ttl:
+            logger.debug(
+                "Using cached Codex model IDs from upstream model registry: %s",
+                list(cached_model_ids),
+            )
+            return cached_model_ids
+        _CODEX_MODELS_CACHE.pop(cache_key, None)
+
+    url = (
+        "https://chatgpt.com/backend-api/codex/models"
+        f"?client_version={quote(client_version, safe='')}"
+    )
+    try:
+        assert proxy.http_client is not None
+        resp = await proxy.http_client.get(
+            url,
+            headers=upstream_headers,
+            timeout=15.0,
+        )
+        if resp.status_code >= 400:
+            logger.warning(
+                "Codex model registry fetch failed: HTTP %s: %s",
+                resp.status_code,
+                resp.text[:300],
+            )
+            return None
+
+        data = resp.json()
+        models_raw = data.get("models") if isinstance(data, dict) else None
+        if not isinstance(models_raw, list):
+            logger.warning("Codex model registry response did not contain models[]")
+            return None
+
+        model_ids = tuple(
+            slug
+            for entry in models_raw
+            if isinstance(entry, dict)
+            for slug in (entry.get("slug"),)
+            if isinstance(slug, str) and slug
+        )
+        if not model_ids:
+            logger.warning("Codex model registry returned no model slugs")
+            return None
+
+        if cache_ttl > 0:
+            _CODEX_MODELS_CACHE[cache_key] = (now, model_ids)
+        logger.info("Fetched %d Codex models from upstream model registry", len(model_ids))
+        logger.debug("Fetched Codex model IDs from upstream model registry: %s", list(model_ids))
+        return model_ids
+    except Exception:
+        logger.exception("Codex model registry fetch failed")
+        return None
+
+
+async def _fetch_chatgpt_codex_models_response(
+    proxy: Any,
+    headers: dict[str, str],
+    requested_client_version: str | None,
+) -> Response | None:
+    model_ids = await _fetch_chatgpt_codex_model_ids(proxy, headers, requested_client_version)
+    if model_ids is None:
+        return None
+    return _models_list_response(model_ids, source="upstream_registry")
+
+
+async def _fetch_chatgpt_codex_model_get_response(
+    proxy: Any,
+    headers: dict[str, str],
+    model_id: str,
+    requested_client_version: str | None,
+) -> Response | None:
+    model_ids = await _fetch_chatgpt_codex_model_ids(proxy, headers, requested_client_version)
+    if model_ids is None:
+        return None
+    if model_id in model_ids:
+        return Response(
+            content=json.dumps(_openai_model_item(model_id)),
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+    return Response(
         content=json.dumps(
             {
-                "id": model_id,
-                "object": "model",
-                "created": 0,
-                "owned_by": "openai",
+                "error": {
+                    "message": f"Model {model_id!r} not available under ChatGPT auth",
+                    "type": "invalid_request_error",
+                    "code": "model_not_found",
+                }
             }
         ),
-        status_code=200,
+        status_code=404,
         headers={"content-type": "application/json"},
     )
 
@@ -134,13 +290,28 @@ async def _handle_chatgpt_model_metadata(
     if not is_chatgpt_auth:
         return None
 
-    # Short-circuit `/backend-api/models[/{id}]` — chatgpt.com returns
-    # 403 here for OAuth tokens; synthesize a Codex-compatible response
-    # locally so the model-picker refresh succeeds (issue #478).
+    # Avoid generic `/backend-api/models[/{id}]`, which returns 403 for
+    # OAuth tokens, but prefer the Codex-specific registry when available.
+    requested_client_version = request.query_params.get("client_version")
     if upstream_path == "/backend-api/models":
+        upstream_response = await _fetch_chatgpt_codex_models_response(
+            proxy,
+            headers,
+            requested_client_version,
+        )
+        if upstream_response is not None:
+            return upstream_response
         return _synthetic_models_list_response()
     if upstream_path.startswith("/backend-api/models/"):
         model_id = upstream_path[len("/backend-api/models/") :]
+        upstream_response = await _fetch_chatgpt_codex_model_get_response(
+            proxy,
+            headers,
+            model_id,
+            requested_client_version,
+        )
+        if upstream_response is not None:
+            return upstream_response
         return _synthetic_model_get_response(model_id)
 
     url = f"https://chatgpt.com{upstream_path}"

--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 from urllib.parse import quote
 
 from fastapi import FastAPI, Request, WebSocket
@@ -15,13 +14,6 @@ from fastapi.responses import Response
 from headroom.proxy.handlers.openai import _resolve_codex_routing_headers
 
 logger = logging.getLogger("headroom.proxy.routes")
-
-
-class OpenAIModelItem(TypedDict):
-    id: str
-    object: str
-    created: int
-    owned_by: str
 
 
 def _api_target(proxy: Any, provider_name: str) -> str:
@@ -82,22 +74,21 @@ _CHATGPT_AUTH_CODEX_MODELS: tuple[str, ...] = (
 def _codex_client_version(requested_client_version: str | None = None) -> str:
     if requested_client_version:
         return requested_client_version
-    return os.getenv("HEADROOM_CODEX_CLIENT_VERSION", "0.130.0")
+    return "0.130.0"
 
 
-def _openai_model_item(model_id: str) -> OpenAIModelItem:
-    return {
-        "id": model_id,
-        "object": "model",
-        "created": 0,
-        "owned_by": "openai",
-    }
-
-
-def _models_list_response(model_ids: tuple[str, ...], *, source: str) -> Response:
+def _models_list_response(model_ids: tuple[str, ...]) -> Response:
     payload = {
         "object": "list",
-        "data": [_openai_model_item(model_id) for model_id in model_ids],
+        "data": [
+            {
+                "id": model_id,
+                "object": "model",
+                "created": 0,
+                "owned_by": "openai",
+            }
+            for model_id in model_ids
+        ],
     }
     return Response(
         content=json.dumps(payload),
@@ -108,7 +99,7 @@ def _models_list_response(model_ids: tuple[str, ...], *, source: str) -> Respons
 
 def _synthetic_models_list_response() -> Response:
     """OpenAI-compatible `/v1/models` payload for Codex ChatGPT auth."""
-    return _models_list_response(_CHATGPT_AUTH_CODEX_MODELS, source="static_fallback")
+    return _models_list_response(_CHATGPT_AUTH_CODEX_MODELS)
 
 
 def _synthetic_model_get_response(model_id: str) -> Response:
@@ -128,13 +119,20 @@ def _synthetic_model_get_response(model_id: str) -> Response:
             headers={"content-type": "application/json"},
         )
     return Response(
-        content=json.dumps(_openai_model_item(model_id)),
+        content=json.dumps(
+            {
+                "id": model_id,
+                "object": "model",
+                "created": 0,
+                "owned_by": "openai",
+            }
+        ),
         status_code=200,
         headers={"content-type": "application/json"},
     )
 
 
-def _normalize_codex_registry_headers(headers: dict[str, str]) -> tuple[dict[str, str], str]:
+def _normalize_codex_registry_headers(headers: dict[str, str]) -> dict[str, str]:
     upstream_headers = dict(headers)
     upstream_headers.pop("host", None)
     account_id = (
@@ -147,7 +145,7 @@ def _normalize_codex_registry_headers(headers: dict[str, str]) -> tuple[dict[str
         upstream_headers.pop("ChatGPT-Account-ID", None)
     upstream_headers["accept"] = "application/json"
     upstream_headers.pop("Accept", None)
-    return upstream_headers, account_id
+    return upstream_headers
 
 
 async def _fetch_chatgpt_codex_model_ids(
@@ -156,7 +154,7 @@ async def _fetch_chatgpt_codex_model_ids(
     requested_client_version: str | None,
 ) -> tuple[str, ...] | None:
     client_version = _codex_client_version(requested_client_version)
-    upstream_headers, _account_id = _normalize_codex_registry_headers(headers)
+    upstream_headers = _normalize_codex_registry_headers(headers)
     url = (
         "https://chatgpt.com/backend-api/codex/models"
         f"?client_version={quote(client_version, safe='')}"
@@ -209,7 +207,7 @@ async def _fetch_chatgpt_codex_models_response(
     model_ids = await _fetch_chatgpt_codex_model_ids(proxy, headers, requested_client_version)
     if model_ids is None:
         return None
-    return _models_list_response(model_ids, source="upstream_registry")
+    return _models_list_response(model_ids)
 
 
 async def _fetch_chatgpt_codex_model_get_response(
@@ -223,7 +221,14 @@ async def _fetch_chatgpt_codex_model_get_response(
         return None
     if model_id in model_ids:
         return Response(
-            content=json.dumps(_openai_model_item(model_id)),
+            content=json.dumps(
+                {
+                    "id": model_id,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "openai",
+                }
+            ),
             status_code=200,
             headers={"content-type": "application/json"},
         )

--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -72,12 +72,14 @@ _CHATGPT_AUTH_CODEX_MODELS: tuple[str, ...] = (
 
 
 def _codex_client_version(requested_client_version: str | None = None) -> str:
+    """Return the Codex client version to use for model-registry requests."""
     if requested_client_version:
         return requested_client_version
     return "0.130.0"
 
 
 def _models_list_response(model_ids: tuple[str, ...]) -> Response:
+    """Build an OpenAI-compatible model-list response for Codex metadata callers."""
     payload = {
         "object": "list",
         "data": [
@@ -133,6 +135,7 @@ def _synthetic_model_get_response(model_id: str) -> Response:
 
 
 def _normalize_codex_registry_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Prepare inbound ChatGPT auth headers for the Codex model registry."""
     upstream_headers = dict(headers)
     upstream_headers.pop("host", None)
     account_id = (
@@ -153,6 +156,7 @@ async def _fetch_chatgpt_codex_model_ids(
     headers: dict[str, str],
     requested_client_version: str | None,
 ) -> tuple[str, ...] | None:
+    """Fetch Codex model slugs from ChatGPT, returning None when fallback should apply."""
     client_version = _codex_client_version(requested_client_version)
     upstream_headers = _normalize_codex_registry_headers(headers)
     url = (
@@ -204,6 +208,7 @@ async def _fetch_chatgpt_codex_models_response(
     headers: dict[str, str],
     requested_client_version: str | None,
 ) -> Response | None:
+    """Build a dynamic `/v1/models` response from the Codex registry when available."""
     model_ids = await _fetch_chatgpt_codex_model_ids(proxy, headers, requested_client_version)
     if model_ids is None:
         return None
@@ -216,6 +221,7 @@ async def _fetch_chatgpt_codex_model_get_response(
     model_id: str,
     requested_client_version: str | None,
 ) -> Response | None:
+    """Build a dynamic `/v1/models/{id}` response from the Codex registry when available."""
     model_ids = await _fetch_chatgpt_codex_model_ids(proxy, headers, requested_client_version)
     if model_ids is None:
         return None

--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -114,12 +114,6 @@ def _models_list_response(model_ids: tuple[str, ...], *, source: str) -> Respons
         "object": "list",
         "data": [_openai_model_item(model_id) for model_id in model_ids],
     }
-    logger.debug(
-        "Returning Codex model metadata response source=%s model_ids=%s payload=%s",
-        source,
-        list(model_ids),
-        payload,
-    )
     return Response(
         content=json.dumps(payload),
         status_code=200,

--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import time
 from typing import Any, TypedDict, cast
 from urllib.parse import quote
 
@@ -16,8 +15,6 @@ from fastapi.responses import Response
 from headroom.proxy.handlers.openai import _resolve_codex_routing_headers
 
 logger = logging.getLogger("headroom.proxy.routes")
-
-_CODEX_MODELS_CACHE: dict[tuple[str, str], tuple[float, tuple[str, ...]]] = {}
 
 
 class OpenAIModelItem(TypedDict):
@@ -86,18 +83,6 @@ def _codex_client_version(requested_client_version: str | None = None) -> str:
     if requested_client_version:
         return requested_client_version
     return os.getenv("HEADROOM_CODEX_CLIENT_VERSION", "0.130.0")
-
-
-def _codex_models_cache_ttl_seconds() -> float:
-    raw_value = os.getenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "300")
-    try:
-        return max(0.0, float(raw_value))
-    except ValueError:
-        logger.warning(
-            "Invalid HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS=%r; disabling Codex models cache",
-            raw_value,
-        )
-        return 0.0
 
 
 def _openai_model_item(model_id: str) -> OpenAIModelItem:
@@ -171,21 +156,7 @@ async def _fetch_chatgpt_codex_model_ids(
     requested_client_version: str | None,
 ) -> tuple[str, ...] | None:
     client_version = _codex_client_version(requested_client_version)
-    upstream_headers, account_id = _normalize_codex_registry_headers(headers)
-    cache_key = (account_id, client_version)
-    cache_ttl = _codex_models_cache_ttl_seconds()
-    now = time.monotonic()
-    cached = _CODEX_MODELS_CACHE.get(cache_key)
-    if cached is not None:
-        cached_at, cached_model_ids = cached
-        if cache_ttl > 0 and now - cached_at < cache_ttl:
-            logger.debug(
-                "Using cached Codex model IDs from upstream model registry: %s",
-                list(cached_model_ids),
-            )
-            return cached_model_ids
-        _CODEX_MODELS_CACHE.pop(cache_key, None)
-
+    upstream_headers, _account_id = _normalize_codex_registry_headers(headers)
     url = (
         "https://chatgpt.com/backend-api/codex/models"
         f"?client_version={quote(client_version, safe='')}"
@@ -222,8 +193,6 @@ async def _fetch_chatgpt_codex_model_ids(
             logger.warning("Codex model registry returned no model slugs")
             return None
 
-        if cache_ttl > 0:
-            _CODEX_MODELS_CACHE[cache_key] = (now, model_ids)
         logger.info("Fetched %d Codex models from upstream model registry", len(model_ids))
         logger.debug("Fetched Codex model IDs from upstream model registry: %s", list(model_ids))
         return model_ids

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -910,6 +910,14 @@ def _headroom_log_dir() -> Path:
     return _paths.log_dir()
 
 
+def _file_log_level() -> int:
+    raw_level = os.environ.get("HEADROOM_LOG_LEVEL", "INFO").strip().upper()
+    level = getattr(logging, raw_level, None)
+    if isinstance(level, int):
+        return level
+    return logging.INFO
+
+
 def _setup_file_logging() -> None:
     """Add a RotatingFileHandler to the headroom root logger.
 
@@ -929,7 +937,8 @@ def _setup_file_logging() -> None:
             backupCount=5,
             encoding="utf-8",
         )
-        handler.setLevel(logging.INFO)
+        log_level = _file_log_level()
+        handler.setLevel(log_level)
         handler.setFormatter(
             logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         )
@@ -937,6 +946,7 @@ def _setup_file_logging() -> None:
         # Disable propagation to root to avoid duplicate writes when
         # wrap.py redirects stderr to the same log file.
         headroom_logger = logging.getLogger("headroom")
+        headroom_logger.setLevel(log_level)
         if not any(isinstance(h, RotatingFileHandler) for h in headroom_logger.handlers):
             headroom_logger.addHandler(handler)
         headroom_logger.propagate = False

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -910,14 +910,6 @@ def _headroom_log_dir() -> Path:
     return _paths.log_dir()
 
 
-def _file_log_level() -> int:
-    raw_level = os.environ.get("HEADROOM_LOG_LEVEL", "INFO").strip().upper()
-    level = getattr(logging, raw_level, None)
-    if isinstance(level, int):
-        return level
-    return logging.INFO
-
-
 def _setup_file_logging() -> None:
     """Add a RotatingFileHandler to the headroom root logger.
 
@@ -937,8 +929,7 @@ def _setup_file_logging() -> None:
             backupCount=5,
             encoding="utf-8",
         )
-        log_level = _file_log_level()
-        handler.setLevel(log_level)
+        handler.setLevel(logging.INFO)
         handler.setFormatter(
             logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         )
@@ -946,7 +937,7 @@ def _setup_file_logging() -> None:
         # Disable propagation to root to avoid duplicate writes when
         # wrap.py redirects stderr to the same log file.
         headroom_logger = logging.getLogger("headroom")
-        headroom_logger.setLevel(log_level)
+        headroom_logger.setLevel(logging.INFO)
         if not any(isinstance(h, RotatingFileHandler) for h in headroom_logger.handlers):
             headroom_logger.addHandler(handler)
         headroom_logger.propagate = False

--- a/tests/test_provider_proxy_routes.py
+++ b/tests/test_provider_proxy_routes.py
@@ -339,14 +339,126 @@ def test_gemini_batch_embed_contents_passthrough_uses_gemini_target(monkeypatch)
     ]
 
 
-def test_v1_models_returns_synthetic_list_under_chatgpt_auth() -> None:
+def test_v1_models_fetches_codex_registry_under_chatgpt_auth(monkeypatch) -> None:
+    monkeypatch.setenv("HEADROOM_CODEX_CLIENT_VERSION", "0.130.0")
+    monkeypatch.setenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "0")
+    proxy_routes = importlib.import_module("headroom.providers.proxy_routes")
+    debug_messages: list[tuple[str, tuple[object, ...]]] = []
+    monkeypatch.setattr(
+        proxy_routes.logger,
+        "debug",
+        lambda message, *args: debug_messages.append((message, args)),
+    )
+
+    class FakeAsyncClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, dict[str, str]]] = []
+
+        async def get(self, url, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls.append(("GET", url, dict(kwargs.get("headers", {}))))
+            return httpx.Response(
+                200,
+                json={
+                    "models": [
+                        {"slug": "gpt-5.5"},
+                        {"slug": "gpt-5.3-codex-spark"},
+                    ]
+                },
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    with TestClient(_app()) as client:
+        fake_http_client = FakeAsyncClient()
+        client.app.state.proxy.http_client = fake_http_client
+        response = client.get(
+            "/v1/models?client_version=0.135.0",
+            headers={
+                "authorization": "Bearer eyJ-chatgpt-oauth-token",
+                "chatgpt-account-id": "test-account",
+                "originator": "Codex Desktop",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        "object": "list",
+        "data": [
+            {
+                "id": "gpt-5.5",
+                "object": "model",
+                "created": 0,
+                "owned_by": "openai",
+            },
+            {
+                "id": "gpt-5.3-codex-spark",
+                "object": "model",
+                "created": 0,
+                "owned_by": "openai",
+            },
+        ],
+    }
+    assert len(fake_http_client.calls) == 1
+    method, url, headers = fake_http_client.calls[0]
+    assert method == "GET"
+    assert url == "https://chatgpt.com/backend-api/codex/models?client_version=0.135.0"
+    assert headers["authorization"] == "Bearer eyJ-chatgpt-oauth-token"
+    assert headers["chatgpt-account-id"] == "test-account"
+    assert headers["originator"] == "Codex Desktop"
+    assert headers["accept"] == "application/json"
+    assert "Accept" not in headers
+    assert debug_messages == [
+        (
+            "Fetched Codex model IDs from upstream model registry: %s",
+            (["gpt-5.5", "gpt-5.3-codex-spark"],),
+        ),
+        (
+            "Returning Codex model metadata response source=%s model_ids=%s payload=%s",
+            (
+                "upstream_registry",
+                ["gpt-5.5", "gpt-5.3-codex-spark"],
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "gpt-5.5",
+                            "object": "model",
+                            "created": 0,
+                            "owned_by": "openai",
+                        },
+                        {
+                            "id": "gpt-5.3-codex-spark",
+                            "object": "model",
+                            "created": 0,
+                            "owned_by": "openai",
+                        },
+                    ],
+                },
+            ),
+        ),
+    ]
+
+
+def test_v1_models_falls_back_to_synthetic_list_under_chatgpt_auth(monkeypatch) -> None:
     """Issue #478: under Codex ChatGPT-subscription OAuth, the proxy
     must NOT forward `/v1/models` to chatgpt.com/backend-api/models
-    (which returns 403). Synthesize an OpenAI-compatible response with
-    the known-supported Codex/ChatGPT model set instead, so Codex's
-    model-picker refresh succeeds.
+    (which returns 403). If the Codex-specific registry also fails,
+    synthesize an OpenAI-compatible response with the known-supported
+    Codex/ChatGPT model set instead, so Codex's model-picker refresh succeeds.
     """
+    monkeypatch.setenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "0")
+
+    class FakeAsyncClient:
+        async def get(self, url, **kwargs):  # type: ignore[no-untyped-def]
+            return httpx.Response(403, json={"error": "forbidden"})
+
+        async def aclose(self) -> None:
+            return None
+
     with TestClient(_app()) as client:
+        client.app.state.proxy.http_client = FakeAsyncClient()
         # ChatGPT auth detected via Bearer + ChatGPT account header
         # (mirrors what Codex Desktop sends).
         response = client.get(
@@ -370,13 +482,32 @@ def test_v1_models_returns_synthetic_list_under_chatgpt_auth() -> None:
         assert entry["owned_by"] == "openai"
 
 
-def test_v1_models_get_single_synthetic_under_chatgpt_auth() -> None:
+def test_v1_models_get_single_dynamic_under_chatgpt_auth(monkeypatch) -> None:
     """The single-model variant (`/v1/models/{id}`) is also called by
-    Codex for some flows. Must return a synthetic OpenAI-compatible
-    payload for known models, 404 for unknown."""
+    Codex for some flows. It should use the Codex registry first so
+    dynamically exposed model slugs validate consistently."""
+    monkeypatch.setenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "300")
+    importlib.import_module("headroom.providers.proxy_routes")._CODEX_MODELS_CACHE.clear()
+
+    class FakeAsyncClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def get(self, url, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls += 1
+            return httpx.Response(
+                200,
+                json={"models": [{"slug": "gpt-5.5"}, {"slug": "gpt-5.3-codex-spark"}]},
+            )
+
+        async def aclose(self) -> None:
+            return None
+
     with TestClient(_app()) as client:
+        fake_http_client = FakeAsyncClient()
+        client.app.state.proxy.http_client = fake_http_client
         ok = client.get(
-            "/v1/models/gpt-5.5",
+            "/v1/models/gpt-5.3-codex-spark",
             headers={
                 "authorization": "Bearer eyJ-chatgpt-oauth-token",
                 "chatgpt-account-id": "test-account",
@@ -391,12 +522,13 @@ def test_v1_models_get_single_synthetic_under_chatgpt_auth() -> None:
         )
     assert ok.status_code == 200
     assert ok.json() == {
-        "id": "gpt-5.5",
+        "id": "gpt-5.3-codex-spark",
         "object": "model",
         "created": 0,
         "owned_by": "openai",
     }
     assert unknown.status_code == 404
+    assert fake_http_client.calls == 1
 
 
 def test_v1_models_still_forwards_under_non_chatgpt_auth() -> None:

--- a/tests/test_provider_proxy_routes.py
+++ b/tests/test_provider_proxy_routes.py
@@ -340,7 +340,6 @@ def test_gemini_batch_embed_contents_passthrough_uses_gemini_target(monkeypatch)
 
 
 def test_v1_models_fetches_codex_registry_under_chatgpt_auth(monkeypatch) -> None:
-    monkeypatch.setenv("HEADROOM_CODEX_CLIENT_VERSION", "0.130.0")
     proxy_routes = importlib.import_module("headroom.providers.proxy_routes")
     debug_messages: list[tuple[str, tuple[object, ...]]] = []
     monkeypatch.setattr(

--- a/tests/test_provider_proxy_routes.py
+++ b/tests/test_provider_proxy_routes.py
@@ -341,7 +341,6 @@ def test_gemini_batch_embed_contents_passthrough_uses_gemini_target(monkeypatch)
 
 def test_v1_models_fetches_codex_registry_under_chatgpt_auth(monkeypatch) -> None:
     monkeypatch.setenv("HEADROOM_CODEX_CLIENT_VERSION", "0.130.0")
-    monkeypatch.setenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "0")
     proxy_routes = importlib.import_module("headroom.providers.proxy_routes")
     debug_messages: list[tuple[str, tuple[object, ...]]] = []
     monkeypatch.setattr(
@@ -424,8 +423,6 @@ def test_v1_models_falls_back_to_synthetic_list_under_chatgpt_auth(monkeypatch) 
     synthesize an OpenAI-compatible response with the known-supported
     Codex/ChatGPT model set instead, so Codex's model-picker refresh succeeds.
     """
-    monkeypatch.setenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "0")
-
     class FakeAsyncClient:
         async def get(self, url, **kwargs):  # type: ignore[no-untyped-def]
             return httpx.Response(403, json={"error": "forbidden"})
@@ -458,13 +455,10 @@ def test_v1_models_falls_back_to_synthetic_list_under_chatgpt_auth(monkeypatch) 
         assert entry["owned_by"] == "openai"
 
 
-def test_v1_models_get_single_dynamic_under_chatgpt_auth(monkeypatch) -> None:
+def test_v1_models_get_single_dynamic_under_chatgpt_auth() -> None:
     """The single-model variant (`/v1/models/{id}`) is also called by
     Codex for some flows. It should use the Codex registry first so
     dynamically exposed model slugs validate consistently."""
-    monkeypatch.setenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "300")
-    importlib.import_module("headroom.providers.proxy_routes")._CODEX_MODELS_CACHE.clear()
-
     class FakeAsyncClient:
         def __init__(self) -> None:
             self.calls = 0
@@ -504,7 +498,7 @@ def test_v1_models_get_single_dynamic_under_chatgpt_auth(monkeypatch) -> None:
         "owned_by": "openai",
     }
     assert unknown.status_code == 404
-    assert fake_http_client.calls == 1
+    assert fake_http_client.calls == 2
 
 
 def test_v1_models_still_forwards_under_non_chatgpt_auth() -> None:

--- a/tests/test_provider_proxy_routes.py
+++ b/tests/test_provider_proxy_routes.py
@@ -414,30 +414,6 @@ def test_v1_models_fetches_codex_registry_under_chatgpt_auth(monkeypatch) -> Non
             "Fetched Codex model IDs from upstream model registry: %s",
             (["gpt-5.5", "gpt-5.3-codex-spark"],),
         ),
-        (
-            "Returning Codex model metadata response source=%s model_ids=%s payload=%s",
-            (
-                "upstream_registry",
-                ["gpt-5.5", "gpt-5.3-codex-spark"],
-                {
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "gpt-5.5",
-                            "object": "model",
-                            "created": 0,
-                            "owned_by": "openai",
-                        },
-                        {
-                            "id": "gpt-5.3-codex-spark",
-                            "object": "model",
-                            "created": 0,
-                            "owned_by": "openai",
-                        },
-                    ],
-                },
-            ),
-        ),
     ]
 
 

--- a/tests/test_proxy_codex_route_aliases.py
+++ b/tests/test_proxy_codex_route_aliases.py
@@ -159,25 +159,26 @@ def test_codex_responses_subpath_passthrough_derives_chatgpt_routing_from_jwt(pa
     assert headers["ChatGPT-Account-ID"] == "acct-from-jwt"
 
 
-def test_codex_model_metadata_synthesises_response_for_chatgpt_auth():
+def test_codex_model_metadata_fetches_codex_registry_for_chatgpt_auth(monkeypatch):
     """Issue #478: under Codex ChatGPT-subscription OAuth, the proxy
     must NOT forward `/v1/models[/{id}]` to chatgpt.com/backend-api —
-    that endpoint returns 403 to OAuth tokens, breaking Codex's model
-    refresh. Headroom synthesises an OpenAI-compatible payload locally
-    so the picker UI populates correctly.
-
-    The earlier version of this test asserted the buggy forward
-    behaviour; flipped here to lock the synthetic-response contract
-    so the bug can't return.
+    that endpoint returns 403 to OAuth tokens. Instead, Headroom should
+    fetch the Codex-specific model registry and synthesize an
+    OpenAI-compatible payload from its slugs.
     """
+    monkeypatch.setenv("HEADROOM_CODEX_CLIENT_VERSION", "0.130.0")
+    monkeypatch.setenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "0")
 
     class FakeAsyncClient:
         def __init__(self):
             self.calls: list[tuple[str, str, dict[str, str]]] = []
 
-        async def request(self, method, url, **kwargs):  # type: ignore[no-untyped-def]
-            self.calls.append((method, url, dict(kwargs.get("headers", {}))))
-            return httpx.Response(200, json={"method": method, "url": url})
+        async def get(self, url, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls.append(("GET", url, dict(kwargs.get("headers", {}))))
+            return httpx.Response(
+                200,
+                json={"models": [{"slug": "gpt-5.5"}, {"slug": "gpt-5.3-codex-spark"}]},
+            )
 
         async def aclose(self):
             return None
@@ -204,14 +205,19 @@ def test_codex_model_metadata_synthesises_response_for_chatgpt_auth():
             headers={"Authorization": f"Bearer {token}"},
         )
         unknown_response = client.get(
-            "/v1/models/gpt-5.3-codex?client_version=0.130.0",
+            "/v1/models/gpt-99-future?client_version=0.130.0",
             headers={"Authorization": f"Bearer {token}"},
         )
 
-    # No upstream call must be made — the response is synthesised locally.
-    assert fake_http_client.calls == [], (
-        f"Expected zero upstream calls; got {fake_http_client.calls}"
-    )
+    assert len(fake_http_client.calls) == 3
+    for method, url, headers in fake_http_client.calls:
+        assert method == "GET"
+        assert url == "https://chatgpt.com/backend-api/codex/models?client_version=0.130.0"
+        assert headers["authorization"] == f"Bearer {token}"
+        assert headers["chatgpt-account-id"] == "acct-from-jwt"
+        assert headers["accept"] == "application/json"
+        assert "ChatGPT-Account-ID" not in headers
+        assert "Accept" not in headers
 
     # List endpoint returns a non-empty OpenAI-compatible list.
     assert list_response.status_code == 200
@@ -219,7 +225,10 @@ def test_codex_model_metadata_synthesises_response_for_chatgpt_auth():
     assert list_payload["object"] == "list"
     assert isinstance(list_payload["data"], list)
     assert len(list_payload["data"]) > 0
-    assert "gpt-5.5" in {entry["id"] for entry in list_payload["data"]}
+    assert {entry["id"] for entry in list_payload["data"]} == {
+        "gpt-5.5",
+        "gpt-5.3-codex-spark",
+    }
 
     # Single-model GET returns a model object when known.
     assert known_response.status_code == 200
@@ -231,6 +240,5 @@ def test_codex_model_metadata_synthesises_response_for_chatgpt_auth():
         "owned_by": "openai",
     }
 
-    # Unknown model variants 404 — the synthetic set is bounded to the
-    # ChatGPT-auth-supported list.
+    # Unknown model variants 404 against the dynamic registry.
     assert unknown_response.status_code == 404

--- a/tests/test_proxy_codex_route_aliases.py
+++ b/tests/test_proxy_codex_route_aliases.py
@@ -166,7 +166,6 @@ def test_codex_model_metadata_fetches_codex_registry_for_chatgpt_auth(monkeypatc
     fetch the Codex-specific model registry and synthesize an
     OpenAI-compatible payload from its slugs.
     """
-    monkeypatch.setenv("HEADROOM_CODEX_CLIENT_VERSION", "0.130.0")
 
     class FakeAsyncClient:
         def __init__(self):

--- a/tests/test_proxy_codex_route_aliases.py
+++ b/tests/test_proxy_codex_route_aliases.py
@@ -167,7 +167,6 @@ def test_codex_model_metadata_fetches_codex_registry_for_chatgpt_auth(monkeypatc
     OpenAI-compatible payload from its slugs.
     """
     monkeypatch.setenv("HEADROOM_CODEX_CLIENT_VERSION", "0.130.0")
-    monkeypatch.setenv("HEADROOM_CODEX_MODELS_CACHE_TTL_SECONDS", "0")
 
     class FakeAsyncClient:
         def __init__(self):


### PR DESCRIPTION
## Description

#480 resolved issue #478 by returning a fixed list of ChatGPT models for Codex. This PR changes that by calling the back-end API with OAUTH.


Fixes #478 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Updated proxy_routes.py to call OpenAI API for retrieving models, still falls-back to static list on failure. 

## Testing

Describe the tests you ran to verify your changes:

- [X] Unit tests pass (`pytest`)
- [X] Linting passes (`ruff check .`)
- [X] Type checking passes (`mypy headroom`)
- [X] New tests added for new functionality
- [X] Manual testing performed

## Test Output

```
================================================================= test session starts =================================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0 -- /Users/ehendrix/Documents/headroom/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/ehendrix/Documents/headroom
configfile: pyproject.toml
plugins: anyio-4.12.1, langsmith-0.6.5, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 12 items                                                                                                                                    

tests/test_provider_proxy_routes.py::test_provider_passthrough_routes_forward_expected_targets PASSED                                           [  8%]
tests/test_provider_proxy_routes.py::test_proxy_route_helpers_prefer_legacy_targets_and_gemini_passthrough PASSED                               [ 16%]
tests/test_provider_proxy_routes.py::test_provider_specific_routes_delegate_to_expected_proxy_handlers PASSED                                   [ 25%]
tests/test_provider_proxy_routes.py::test_openai_response_websocket_aliases_delegate_to_openai_ws_handler PASSED                                [ 33%]
tests/test_provider_proxy_routes.py::test_openai_response_subpath_passthrough_returns_502_on_http_failure PASSED                                [ 41%]
tests/test_provider_proxy_routes.py::test_openai_response_subpath_passthrough_uses_openai_target PASSED                                         [ 50%]
tests/test_provider_proxy_routes.py::test_openai_response_subpath_aliases_and_chatgpt_auth_use_expected_targets PASSED                          [ 58%]
tests/test_provider_proxy_routes.py::test_gemini_batch_embed_contents_passthrough_uses_gemini_target PASSED                                     [ 66%]
tests/test_provider_proxy_routes.py::test_v1_models_fetches_codex_registry_under_chatgpt_auth PASSED                                            [ 75%]
tests/test_provider_proxy_routes.py::test_v1_models_falls_back_to_synthetic_list_under_chatgpt_auth PASSED                                      [ 83%]
tests/test_provider_proxy_routes.py::test_v1_models_get_single_dynamic_under_chatgpt_auth PASSED                                                [ 91%]
tests/test_provider_proxy_routes.py::test_v1_models_still_forwards_under_non_chatgpt_auth PASSED                                                [100%]

================================================================= 12 passed in 0.88s ==================================================================
```

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.
