### PR TITLE
fix(docs): update next.js for GHSA-gx5p-jg67-6x7h

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -17,7 +17,7 @@
 				"fumadocs-ui": "16.7.10",
 				"headroom-ai": "file:../sdk/typescript",
 				"lucide-react": "^1.7.0",
-				"next": "16.2.4",
+				"next": "16.2.7",
 				"react": "^19.2.4",
 				"react-dom": "^19.2.4",
 				"recharts": "^3.8.1",
@@ -40,7 +40,7 @@
 		},
 		"../sdk/typescript": {
 			"name": "headroom-ai",
-			"version": "0.1.0",
+			"version": "0.22.4",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@ai-sdk/anthropic": "^3.0.64",
@@ -52,7 +52,7 @@
 				"openai": "^4.80.0",
 				"tsup": "^8.0.0",
 				"typescript": "^5.5.0",
-				"vitest": "^2.0.0"
+				"vitest": "^4.1.5"
 			},
 			"engines": {
 				"node": ">=18.0.0"
@@ -1202,15 +1202,15 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-			"integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.7.tgz",
+			"integrity": "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==",
 			"license": "MIT"
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-			"integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.7.tgz",
+			"integrity": "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1224,9 +1224,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-			"integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.7.tgz",
+			"integrity": "sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1240,9 +1240,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-			"integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.7.tgz",
+			"integrity": "sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1256,9 +1256,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-			"integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.7.tgz",
+			"integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1272,9 +1272,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-			"integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz",
+			"integrity": "sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1288,9 +1288,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-			"integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.7.tgz",
+			"integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
 			"cpu": [
 				"x64"
 			],
@@ -1304,9 +1304,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-			"integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.7.tgz",
+			"integrity": "sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1320,9 +1320,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-			"integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.7.tgz",
+			"integrity": "sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==",
 			"cpu": [
 				"x64"
 			],
@@ -5410,12 +5410,12 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "16.2.4",
-			"resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-			"integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+			"version": "16.2.7",
+			"resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
+			"integrity": "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "16.2.4",
+				"@next/env": "16.2.7",
 				"@swc/helpers": "0.5.15",
 				"baseline-browser-mapping": "^2.9.19",
 				"caniuse-lite": "^1.0.30001579",
@@ -5429,14 +5429,14 @@
 				"node": ">=20.9.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "16.2.4",
-				"@next/swc-darwin-x64": "16.2.4",
-				"@next/swc-linux-arm64-gnu": "16.2.4",
-				"@next/swc-linux-arm64-musl": "16.2.4",
-				"@next/swc-linux-x64-gnu": "16.2.4",
-				"@next/swc-linux-x64-musl": "16.2.4",
-				"@next/swc-win32-arm64-msvc": "16.2.4",
-				"@next/swc-win32-x64-msvc": "16.2.4",
+				"@next/swc-darwin-arm64": "16.2.7",
+				"@next/swc-darwin-x64": "16.2.7",
+				"@next/swc-linux-arm64-gnu": "16.2.7",
+				"@next/swc-linux-arm64-musl": "16.2.7",
+				"@next/swc-linux-x64-gnu": "16.2.7",
+				"@next/swc-linux-x64-musl": "16.2.7",
+				"@next/swc-win32-arm64-msvc": "16.2.7",
+				"@next/swc-win32-x64-msvc": "16.2.7",
 				"sharp": "^0.34.5"
 			},
 			"peerDependencies": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -33,7 +33,6 @@
 				"@types/react-dom": "^19.2.3",
 				"ai": "^6.0.149",
 				"openai": "^6.33.0",
-				"postcss": "^8.5.10",
 				"tailwindcss": "^4.2.2",
 				"typescript": "^5.9.3"
 			}
@@ -5618,34 +5617,6 @@
 				"react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
 			}
 		},
-		"node_modules/next/node_modules/postcss": {
-			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/postcss"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"nanoid": "^3.3.6",
-				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
-			}
-		},
 		"node_modules/npm-to-yarn": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/npm-to-yarn/-/npm-to-yarn-3.0.1.tgz",
@@ -5771,7 +5742,6 @@
 			"version": "8.5.10",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
 			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -25,7 +25,7 @@
 			},
 			"devDependencies": {
 				"@ai-sdk/openai": "^3.0.51",
-				"@anthropic-ai/sdk": "^0.82.0",
+				"@anthropic-ai/sdk": "^0.91.1",
 				"@tailwindcss/postcss": "^4.2.2",
 				"@types/mdx": "^2.0.13",
 				"@types/node": "^25.5.0",
@@ -156,9 +156,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.82.0",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
-			"integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -641,18 +641,24 @@
 			"license": "MIT"
 		},
 		"node_modules/@formatjs/fast-memoize": {
-			"version": "3.1.1",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.5.tgz",
+			"integrity": "sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A==",
 			"license": "MIT"
 		},
 		"node_modules/@formatjs/intl-localematcher": {
-			"version": "0.8.2",
+			"version": "0.8.9",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.9.tgz",
+			"integrity": "sha512-GmB0F/gYh4Hdl4rLWjgDsgT+x4pB54fkJeRh8kAZ4XFzKeCK8dGs+SBJWXO42QZtOUni+IDWKNuCw6wiL4lTvw==",
 			"license": "MIT",
 			"dependencies": {
-				"@formatjs/fast-memoize": "3.1.1"
+				"@formatjs/fast-memoize": "3.1.5"
 			}
 		},
 		"node_modules/@fumadocs/tailwind": {
 			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@fumadocs/tailwind/-/tailwind-0.0.3.tgz",
+			"integrity": "sha512-/FWcggMz9BhoX+13xBoZLX+XX9mYvJ50dkTqy3IfocJqua65ExcsKfxwKH8hgTO3vA5KnWv4+4jU7LaW2AjAmQ==",
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^7.1.1"
@@ -2138,33 +2144,78 @@
 			}
 		},
 		"node_modules/@shikijs/engine-javascript": {
-			"version": "4.0.2",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.1.0.tgz",
+			"integrity": "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.0.2",
+				"@shikijs/types": "4.1.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
-				"oniguruma-to-es": "^4.3.4"
+				"oniguruma-to-es": "^4.3.6"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/engine-javascript/node_modules/@shikijs/types": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
 			},
 			"engines": {
 				"node": ">=20"
 			}
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "4.0.2",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.1.0.tgz",
+			"integrity": "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.0.2",
+				"@shikijs/types": "4.1.0",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			},
 			"engines": {
 				"node": ">=20"
 			}
 		},
-		"node_modules/@shikijs/langs": {
-			"version": "4.0.2",
+		"node_modules/@shikijs/engine-oniguruma/node_modules/@shikijs/types": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.0.2"
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.1.0.tgz",
+			"integrity": "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/langs/node_modules/@shikijs/types": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
 			},
 			"engines": {
 				"node": ">=20"
@@ -2183,13 +2234,15 @@
 			}
 		},
 		"node_modules/@shikijs/rehype": {
-			"version": "4.0.2",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-4.1.0.tgz",
+			"integrity": "sha512-HQwltCcO2/UiFz44/8whyji4rP1VghLu++MgvQn+lQA8/gvuycGkay8DH8o8VAOvLBDKGOkBEw7cC1Cm33GObQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.0.2",
+				"@shikijs/types": "4.1.0",
 				"@types/hast": "^3.0.4",
 				"hast-util-to-string": "^3.0.1",
-				"shiki": "4.0.2",
+				"shiki": "4.1.0",
 				"unified": "^11.0.5",
 				"unist-util-visit": "^5.1.0"
 			},
@@ -2197,22 +2250,95 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/@shikijs/themes": {
-			"version": "4.0.2",
+		"node_modules/@shikijs/rehype/node_modules/@shikijs/types": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.0.2"
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.1.0.tgz",
+			"integrity": "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/themes/node_modules/@shikijs/types": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
 			},
 			"engines": {
 				"node": ">=20"
 			}
 		},
 		"node_modules/@shikijs/transformers": {
-			"version": "4.0.2",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.1.0.tgz",
+			"integrity": "sha512-YbuOcAA3kwqKDU9YSt00dtFLrY5lBXjKU3dWaMATyEyPSqBm9Jqblk/uVICxz7lcjwAHzYaEvIiMWX3mTpogkA==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/core": "4.0.2",
-				"@shikijs/types": "4.0.2"
+				"@shikijs/core": "4.1.0",
+				"@shikijs/types": "4.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/transformers/node_modules/@shikijs/core": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
+			"integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/primitive": "4.1.0",
+				"@shikijs/types": "4.1.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/transformers/node_modules/@shikijs/primitive": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
+			"integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.1.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
 			},
 			"engines": {
 				"node": ">=20"
@@ -2915,9 +3041,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -3046,6 +3172,8 @@
 		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
@@ -3487,11 +3615,13 @@
 			}
 		},
 		"node_modules/framer-motion": {
-			"version": "12.38.0",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+			"integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
 			"license": "MIT",
 			"dependencies": {
-				"motion-dom": "^12.38.0",
-				"motion-utils": "^12.36.0",
+				"motion-dom": "^12.40.0",
+				"motion-utils": "^12.39.0",
 				"tslib": "^2.4.0"
 			},
 			"peerDependencies": {
@@ -3513,6 +3643,8 @@
 		},
 		"node_modules/fumadocs-core": {
 			"version": "16.7.10",
+			"resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-16.7.10.tgz",
+			"integrity": "sha512-ltAQO+CgCkGUUef33vGXZBj1SNzIRq9SpmZzOIEnXL1+nBZGHiRlSuRK0xqcAtvFwvCOVQN5GNhWmahNoqXo4g==",
 			"license": "MIT",
 			"dependencies": {
 				"@formatjs/intl-localematcher": "^0.8.2",
@@ -3750,6 +3882,8 @@
 		},
 		"node_modules/fumadocs-ui": {
 			"version": "16.7.10",
+			"resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-16.7.10.tgz",
+			"integrity": "sha512-QJD007wuavYgjh057Q6KgTS8tNPV060QpaitEJxxaUAzJRHEDRnRal1eHpCF5hEYgaM1Ah8DuLlYIDE9HwTt6A==",
 			"license": "MIT",
 			"dependencies": {
 				"@fumadocs/tailwind": "0.0.3",
@@ -3961,6 +4095,8 @@
 		},
 		"node_modules/hast-util-to-string": {
 			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+			"integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0"
@@ -4010,6 +4146,8 @@
 		},
 		"node_modules/image-size": {
 			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+			"integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
 			"license": "MIT",
 			"bin": {
 				"image-size": "bin/image-size.js"
@@ -4392,7 +4530,9 @@
 			}
 		},
 		"node_modules/lucide-react": {
-			"version": "1.7.0",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+			"integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
 			"license": "ISC",
 			"peerDependencies": {
 				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -5348,10 +5488,12 @@
 			}
 		},
 		"node_modules/motion": {
-			"version": "12.38.0",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
+			"integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
 			"license": "MIT",
 			"dependencies": {
-				"framer-motion": "^12.38.0",
+				"framer-motion": "^12.40.0",
 				"tslib": "^2.4.0"
 			},
 			"peerDependencies": {
@@ -5372,14 +5514,18 @@
 			}
 		},
 		"node_modules/motion-dom": {
-			"version": "12.38.0",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+			"integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
 			"license": "MIT",
 			"dependencies": {
-				"motion-utils": "^12.36.0"
+				"motion-utils": "^12.39.0"
 			}
 		},
 		"node_modules/motion-utils": {
-			"version": "12.36.0",
+			"version": "12.39.0",
+			"resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+			"integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
 			"license": "MIT"
 		},
 		"node_modules/ms": {
@@ -5404,6 +5550,8 @@
 		},
 		"node_modules/negotiator": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -5472,6 +5620,8 @@
 		},
 		"node_modules/next/node_modules/postcss": {
 			"version": "8.4.31",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5498,6 +5648,8 @@
 		},
 		"node_modules/npm-to-yarn": {
 			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/npm-to-yarn/-/npm-to-yarn-3.0.1.tgz",
+			"integrity": "sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==",
 			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5507,14 +5659,18 @@
 			}
 		},
 		"node_modules/oniguruma-parser": {
-			"version": "0.12.1",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+			"integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
 			"license": "MIT"
 		},
 		"node_modules/oniguruma-to-es": {
-			"version": "4.3.5",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+			"integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
 			"license": "MIT",
 			"dependencies": {
-				"oniguruma-parser": "^0.12.1",
+				"oniguruma-parser": "^0.12.2",
 				"regex": "^6.1.0",
 				"regex-recursion": "^6.0.2"
 			}
@@ -5580,6 +5736,8 @@
 		},
 		"node_modules/path-to-regexp": {
 			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -5640,6 +5798,8 @@
 		},
 		"node_modules/postcss-selector-parser": {
 			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -5695,7 +5855,9 @@
 			"peer": true
 		},
 		"node_modules/react-medium-image-zoom": {
-			"version": "5.4.3",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/react-medium-image-zoom/-/react-medium-image-zoom-5.4.5.tgz",
+			"integrity": "sha512-58QSIRK6X3uw2fSTejJRnH0JuKTZl7ZJYX+sAMaYx4YTEm33gsNdnP5RuQSCnBiAvisQeErqZWAT31bR89WB6g==",
 			"funding": [
 				{
 					"type": "github",
@@ -5911,6 +6073,8 @@
 		},
 		"node_modules/regex": {
 			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
 			"license": "MIT",
 			"dependencies": {
 				"regex-utilities": "^2.3.0"
@@ -5918,6 +6082,8 @@
 		},
 		"node_modules/regex-recursion": {
 			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
 			"license": "MIT",
 			"dependencies": {
 				"regex-utilities": "^2.3.0"
@@ -5925,6 +6091,8 @@
 		},
 		"node_modules/regex-utilities": {
 			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
 			"license": "MIT"
 		},
 		"node_modules/rehype-raw": {
@@ -6115,15 +6283,60 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "4.0.2",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
+			"integrity": "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/core": "4.0.2",
-				"@shikijs/engine-javascript": "4.0.2",
-				"@shikijs/engine-oniguruma": "4.0.2",
-				"@shikijs/langs": "4.0.2",
-				"@shikijs/themes": "4.0.2",
-				"@shikijs/types": "4.0.2",
+				"@shikijs/core": "4.1.0",
+				"@shikijs/engine-javascript": "4.1.0",
+				"@shikijs/engine-oniguruma": "4.1.0",
+				"@shikijs/langs": "4.1.0",
+				"@shikijs/themes": "4.1.0",
+				"@shikijs/types": "4.1.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/shiki/node_modules/@shikijs/core": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
+			"integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/primitive": "4.1.0",
+				"@shikijs/types": "4.1.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/shiki/node_modules/@shikijs/primitive": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
+			"integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.1.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/shiki/node_modules/@shikijs/types": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+			"license": "MIT",
+			"dependencies": {
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4"
 			},
@@ -6201,7 +6414,9 @@
 			}
 		},
 		"node_modules/tailwind-merge": {
-			"version": "3.5.0",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+			"integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -6239,11 +6454,13 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -6461,6 +6678,8 @@
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
 		},
 		"node_modules/vfile": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,7 @@
 		"fumadocs-ui": "16.7.10",
 		"headroom-ai": "file:../sdk/typescript",
 		"lucide-react": "^1.7.0",
-		"next": "16.2.4",
+		"next": "16.2.7",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
 		"recharts": "^3.8.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
 	},
 	"devDependencies": {
 		"@ai-sdk/openai": "^3.0.51",
-		"@anthropic-ai/sdk": "^0.82.0",
+		"@anthropic-ai/sdk": "^0.91.1",
 		"@tailwindcss/postcss": "^4.2.2",
 		"@types/mdx": "^2.0.13",
 		"@types/node": "^25.5.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,6 +24,9 @@
 		"recharts": "^3.8.1",
 		"tailwind-merge": "^3.5.0"
 	},
+	"overrides": {
+	  "postcss": "8.5.10"
+	},
 	"devDependencies": {
 		"@ai-sdk/openai": "^3.0.51",
 		"@anthropic-ai/sdk": "^0.91.1",
@@ -34,8 +37,7 @@
 		"@types/react-dom": "^19.2.3",
 		"ai": "^6.0.149",
 		"openai": "^6.33.0",
-		"postcss": "^8.5.10",
-		"tailwindcss": "^4.2.2",
+"tailwindcss": "^4.2.2",
 		"typescript": "^5.9.3"
 	}
 }


### PR DESCRIPTION
Fixes docs dependency advisory CVE-2026-44580 / GHSA-gx5p-jg67-6x7h.

VIPER hash: a783378608ec0242

Changes:
- Updated docs/package.json next dependency from 16.2.4 to 16.2.7 (npm latest).
- Regenerated docs/package-lock.json.

Verification:
- `npm view next version` -> `16.2.7`
- `node -p "require('./package.json').dependencies.next"` -> `16.2.7`
- `node -p "require('./package-lock.json').packages[''].dependencies.next"` -> `16.2.7`
- `node -p "require('./package-lock.json').packages['node_modules/next'].version"` -> `16.2.7`
- `npm ls next` -> all docs Next.js entries resolve to `next@16.2.7`.
- `grep -RIn --exclude='package-lock.json' --exclude-dir='node_modules' 'beforeInteractive' docs || true` -> no matches.
- `npm run types:check` -> failed on pre-existing/missing docs alias modules such as `@/lib/source`, `@/lib/layout.shared`, `@/lib/shared`, `@/lib/cn`, `@/lib/telemetry`; route types generated successfully before TypeScript errors.
- `npm run build` -> failed on the same missing alias modules; Next.js 16.2.7 build started, then Turbopack reported module-not-found errors.

Diff stat:
```text
docs/package-lock.json | 84 +++++++++++++++++++++++++-------------------------
docs/package.json      |  2 +-
2 files changed, 43 insertions(+), 43 deletions(-)
```

Limitations:
- Validation failures appear unrelated to the dependency update and are due to missing docs source modules in the checked-out tree.
- `npm install` reported 8 moderate npm audit findings outside this targeted Next.js update.
