### PR TITLE
ci(docker): push :dev image tags on every main-branch commit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: Docker
 
 on:
+  push:
+    branches: [main]
   workflow_call:
     inputs:
       version:
@@ -166,6 +168,31 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/digests"
           touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
 
+      # Smoke-test the built image before recording its digest. If the
+      # Python ABI is wrong (e.g. builder Python 3.11 vs distroless
+      # Python 3.13) pydantic_core._pydantic_core fails to dlopen and
+      # the import raises ModuleNotFoundError. Catching it here prevents
+      # a broken digest from reaching the manifest merge job and being
+      # tagged and published. Both python-slim and distroless variants
+      # expose python3 in PATH and honour the image's PYTHONPATH env.
+      - name: Smoke-test image (pydantic_core + headroom._core)
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
+          PLATFORM: ${{ matrix.arch.platform }}
+        run: |
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --entrypoint python3 \
+            "${IMAGE}@${DIGEST}" \
+            -c "
+          import pydantic_core
+          from headroom._core import DiffCompressor, SmartCrusher
+          print('smoke-test OK: pydantic_core', pydantic_core.__version__,
+                '| DiffCompressor', DiffCompressor.__name__,
+                '| SmartCrusher', SmartCrusher.__name__)
+          "
+
       - name: Upload digest marker
         uses: actions/upload-artifact@v7
         with:
@@ -255,6 +282,7 @@ jobs:
           tags: |
             type=ref,event=branch,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
             type=ref,event=pr,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name != 'release' }},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
+            type=raw,value=dev,enable=${{ inputs.enable_ref_tags != 'false' && github.event_name == 'push' }},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }},suffix=${{ matrix.variant.name != '' && format('-{0}', matrix.variant.name) || '' }}
             type=raw,value=${{ steps.version.outputs.version }}-${{ steps.short-sha.outputs.sha }},enable=${{ steps.version.outputs.version != '' && matrix.variant.name == '' }}
             type=raw,value=${{ steps.version.outputs.version }}-${{ matrix.variant.name }}-${{ steps.short-sha.outputs.sha }},enable=${{ steps.version.outputs.version != '' && matrix.variant.name != '' }}


### PR DESCRIPTION
## Summary

- Adds `push: branches: [main]` trigger to `docker.yml` so every merge to main builds and tags all image variants.
- Inserts a `type=raw,value=dev` tag rule in the `docker-manifest` metadata step, producing `:dev` + `:dev-<variant>` tags for all 8 variants.
- Adds a smoke-test step (after digest extraction, before upload) that runs the built image with `python3` and imports `pydantic_core` + `headroom._core` to catch Python ABI mismatches before a broken digest can reach the manifest merge job.

## Tags produced on every `main` push

| Variant | Tag |
|---|---|
| root | `:dev` |
| nonroot | `:dev-nonroot` |
| code | `:dev-code` |
| code-nonroot | `:dev-code-nonroot` |
| slim | `:dev-slim` |
| slim-nonroot | `:dev-slim-nonroot` |
| code-slim | `:dev-code-slim` |
| code-slim-nonroot | `:dev-code-slim-nonroot` |

## Guard logic

```
enable=${{ inputs.enable_ref_tags != 'false' && github.event_name == 'push' }}
```

- **Push to main** → `'' != 'false'` = true AND `push == push` = true → `:dev` fires
- **Release** (`workflow_call` with `enable_ref_tags: false`) → `'false' != 'false'` = false → skips
- **PR dry-run** (same `workflow_call` path) → skips

`promote-latest` runs but its re-tag step self-skips (no version set on push events) — no `:latest` churn.

## Test plan

- [ ] Merge to main; confirm all 8 `:dev-*` tags appear in GHCR
- [ ] Trigger a release; confirm `:dev-*` tags are NOT overwritten or re-emitted
- [ ] Confirm `actionlint` passes: `actionlint .github/workflows/docker.yml`

Closes #530