### PR TITLE
fix: update default Gemini model to gemini-flash-latest

### DIFF
--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 _MODEL_DEFAULTS: list[tuple[str, str]] = [
     ("ANTHROPIC_API_KEY", "claude-sonnet-4-6"),
     ("OPENAI_API_KEY", "gpt-4o"),
-    ("GEMINI_API_KEY", "gemini/gemini-2.0-flash"),
+    ("GEMINI_API_KEY", "gemini/gemini-flash-latest"),
 ]
 
 _MAX_DIGEST_TOKENS = 80_000  # Budget for the digest (leave room for prompt + output)
@@ -94,7 +94,7 @@ def _detect_default_model() -> str:
         "No LLM API key found. headroom learn needs one of:\n"
         "  export ANTHROPIC_API_KEY=sk-ant-...   → uses claude-sonnet-4-6\n"
         "  export OPENAI_API_KEY=sk-...          → uses gpt-4o\n"
-        "  export GEMINI_API_KEY=...             → uses gemini-2.0-flash\n"
+        "  export GEMINI_API_KEY=...             → uses gemini-flash-latest (alias — always current)\n"
         "Or set HEADROOM_LEARN_CLI to a coding agent CLI (claude, gemini, codex).\n"
         "Or install one of those CLIs for auto-detection.\n"
         "Or specify a model directly: headroom learn --model <litellm-model-name>"


### PR DESCRIPTION
\`gemini/gemini-2.0-flash\` got deprecated by Google and now returns a 404. If you had \`GEMINI_API_KEY\` set and ran \`headroom learn\`, every project would silently fail with "No actionable patterns found" — which is confusing since it looks like there's just nothing to learn.

Switching to \`gemini/gemini-flash-latest\`, which is Google's maintained alias for the current stable Flash model. Benefit: we won't need to bump this string again when the next generation lands.

Also updated the help text in \`_detect_default_model()\` to match.

Tested \`gemini/gemini-flash-latest\` routing through LiteLLM before landing this.