### PR TITLE
fix(learn): finish gemini-flash-latest default model sweep

### DIFF
--- a/headroom/cli/learn.py
+++ b/headroom/cli/learn.py
@@ -87,7 +87,7 @@ Use 'auto' (default) to scan all detected agents."""
     "--model",
     type=str,
     default=None,
-    help="LLM model for analysis (e.g., claude-sonnet-4-6, gpt-4o, gemini/gemini-2.0-flash). "
+    help="LLM model for analysis (e.g., claude-sonnet-4-6, gpt-4o, gemini/gemini-flash-latest). "
     "Auto-detected from API keys if not specified.",
 )
 @click.option(

--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 _MODEL_DEFAULTS: list[tuple[str, str]] = [
     ("ANTHROPIC_API_KEY", "claude-sonnet-4-6"),
     ("OPENAI_API_KEY", "gpt-4o"),
-    ("GEMINI_API_KEY", "gemini/gemini-2.0-flash"),
+    ("GEMINI_API_KEY", "gemini/gemini-flash-latest"),
 ]
 
 _MAX_DIGEST_TOKENS = 80_000  # Budget for the digest (leave room for prompt + output)
@@ -94,7 +94,7 @@ def _detect_default_model() -> str:
         "No LLM API key found. headroom learn needs one of:\n"
         "  export ANTHROPIC_API_KEY=sk-ant-...   → uses claude-sonnet-4-6\n"
         "  export OPENAI_API_KEY=sk-...          → uses gpt-4o\n"
-        "  export GEMINI_API_KEY=...             → uses gemini-2.0-flash\n"
+        "  export GEMINI_API_KEY=...             → uses gemini-flash-latest\n"
         "Or set HEADROOM_LEARN_CLI to a coding agent CLI (claude, gemini, codex).\n"
         "Or install one of those CLIs for auto-detection.\n"
         "Or specify a model directly: headroom learn --model <litellm-model-name>"

--- a/tests/test_learn/test_analyzer.py
+++ b/tests/test_learn/test_analyzer.py
@@ -466,7 +466,7 @@ class TestDetectDefaultModel:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.setenv("GEMINI_API_KEY", "test")
-        assert _detect_default_model() == "gemini/gemini-2.0-flash"
+        assert _detect_default_model() == "gemini/gemini-flash-latest"
 
     def test_anthropic_preferred_over_openai(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")


### PR DESCRIPTION
## Summary

Completes the `gemini/gemini-2.0-flash` → `gemini/gemini-flash-latest` migration for `headroom learn` that #532 started in `analyzer.py`. Google deprecated `gemini-2.0-flash`; users with `GEMINI_API_KEY` set hit 404s and see "No actionable patterns found" with no obvious cause.

This PR updates the remaining user-facing references so the CLI help, runtime default, and tests all agree.

## Problem

PR #532 fixes `_MODEL_DEFAULTS` in `headroom/learn/analyzer.py`, but two call sites still advertise the retired model:

```python
# headroom/cli/learn.py — --model help text
help="... gemini/gemini-2.0-flash). "

# tests/test_learn/test_analyzer.py
assert _detect_default_model() == "gemini/gemini-2.0-flash"
```

Users reading `--help` or maintainers running CI would still see the old default.

## Solution

- Switch `_MODEL_DEFAULTS` and the `_detect_default_model()` setup message to `gemini/gemini-flash-latest` (same change as #532).
- Update `headroom learn --model` help example to match.
- Update `TestDetectDefaultModel::test_gemini_key` assertion.

`gemini-flash-latest` is Google's maintained alias for the current stable Flash model, so we should not need to bump this string again when the next generation lands.

## Out of scope

- Proxy/integration tests that intentionally call `gemini-2.0-flash` API endpoints — those models may still work via direct API routes.
- Agno integration docs (`docs/content/docs/agno.mdx`) — separate integration surface, not the learn default.

## Test plan

- [ ] `pytest tests/test_learn/test_analyzer.py::TestDetectDefaultModel -q`
- [ ] `ruff check headroom/learn/analyzer.py headroom/cli/learn.py`
- [ ] CI to confirm the rest.

## Related

- #532 — prior PR that updated `analyzer.py` only

Made with [Cursor](https://cursor.com)