### PR TITLE
Document Codex CCM compatibility

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "headroom",
+  "version": "0.22.4",
+  "description": "Headroom context optimization proxy, MCP retrieval tools, and startup hooks for Codex.",
+  "author": {
+    "name": "Headroom Contributors",
+    "url": "https://github.com/chopratejas/headroom"
+  },
+  "homepage": "https://headroom-docs.vercel.app",
+  "repository": "https://github.com/chopratejas/headroom",
+  "license": "Apache-2.0",
+  "keywords": [
+    "codex",
+    "context",
+    "compression",
+    "mcp",
+    "proxy",
+    "headroom",
+    "ccm"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Headroom",
+    "shortDescription": "Context optimization proxy for Codex",
+    "longDescription": "Runs the Headroom local proxy for Codex, exposes MCP compression/retrieve/stats tools, and works alongside Cognitive Context Manager when CCM is used for durable project memory.",
+    "developerName": "Headroom Contributors",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://headroom-docs.vercel.app",
+    "defaultPrompt": [
+      "Use Headroom to inspect compression stats for this Codex session.",
+      "Use Headroom retrieval tools when compressed context markers need expansion.",
+      "Use CCM for project memory and Headroom for proxy compression when both plugins are installed."
+    ],
+    "brandColor": "#10B981"
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "headroom": {
+      "command": "headroom",
+      "args": [
+        "mcp",
+        "serve"
+      ],
+      "cwd": ".",
+      "env": {
+        "HEADROOM_PROXY_URL": "http://127.0.0.1:8787"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -127,13 +127,23 @@ Reproduce: `python -m headroom.evals suite --tier 1` · [Full benchmarks & metho
 | Agent       | `headroom wrap` | Notes                            |
 |-------------|:---------------:|----------------------------------|
 | Claude Code | ●               | `--memory` · `--code-graph`      |
-| Codex       | ●               | shares memory with Claude        |
+| Codex       | ●               | CCM-compatible; proxy + MCP tools |
 | Cursor      | ●               | prints config — paste once       |
 | Aider       | ●               | starts proxy + launches          |
 | Copilot CLI | ●               | starts proxy + launches          |
 | OpenClaw    | ●               | installs as ContextEngine plugin |
 
 Any OpenAI-compatible client works via `headroom proxy`. MCP-native: `headroom mcp install`.
+
+### Codex + Cognitive Context Manager (CCM)
+
+Headroom is compatible with CCM and can run beside it in the same Codex install. A good default split is:
+
+- CCM stays the durable project-memory layer: working context, decisions, open loops, and stale-memory hygiene.
+- Headroom handles the local proxy, request compression, CCR `headroom_compress`/`headroom_retrieve`, and session stats.
+- Both expose MCP tools; use CCM when you need project state and use Headroom when a compressed marker needs expansion or when you want proxy/compression metrics.
+
+This repo includes a Codex plugin skeleton for that pairing: `.codex-plugin/plugin.json`, `.mcp.json`, `hooks/hooks.json`, and `skills/headroom/SKILL.md`. Install `headroom-ai[all]` so the `headroom` command is on `PATH`, enable the plugin in Codex, and keep CCM installed as the default project memory provider.
 
 ## When to use · When to skip
 

--- a/headroom/ccr/mcp_server.py
+++ b/headroom/ccr/mcp_server.py
@@ -86,6 +86,14 @@ _READ_ENABLED = os.environ.get("HEADROOM_MCP_READ", "off").lower().strip() in (
 DEFAULT_PROXY_URL = os.environ.get("HEADROOM_PROXY_URL", "http://127.0.0.1:8787")
 
 
+def _token_savings_percent(input_tokens: int, output_tokens: int) -> float:
+    """Return savings percent from token counts, clamped at zero for expansions."""
+    if input_tokens <= 0:
+        return 0.0
+    tokens_saved = max(0, input_tokens - output_tokens)
+    return round((tokens_saved / input_tokens) * 100, 1)
+
+
 def _format_session_summary(summary: dict[str, Any], local_stats: dict[str, Any]) -> str:
     """Format the proxy summary + local MCP stats into clean readable text."""
     lines: list[str] = []
@@ -259,9 +267,7 @@ class SessionStats:
             "type": "compress",
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
-            "savings_percent": round((1 - output_tokens / input_tokens) * 100, 1)
-            if input_tokens > 0
-            else 0,
+            "savings_percent": _token_savings_percent(input_tokens, output_tokens),
             "strategy": strategy,
             "timestamp": time.time(),
         }
@@ -387,9 +393,7 @@ class HeadroomMCPServer:
         )
         self._stats.record_compression(input_tokens, output_tokens, strategy)
 
-        savings_pct = (
-            round((1 - result.compression_ratio) * 100, 1) if result.compression_ratio < 1.0 else 0
-        )
+        savings_pct = _token_savings_percent(input_tokens, output_tokens)
 
         return {
             "compressed": compressed_content,

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,31 @@
+{
+  "description": "Headroom Codex hooks - keep the persistent local proxy available for Codex sessions.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd /tmp && headroom init hook ensure --profile init-user --marker headroom-codex-plugin",
+            "timeout": 30,
+            "statusMessage": "Starting Headroom proxy"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd /tmp && headroom init hook ensure --profile init-user --marker headroom-codex-plugin",
+            "timeout": 30,
+            "statusMessage": "Checking Headroom proxy"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/headroom/SKILL.md
+++ b/skills/headroom/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: headroom
+description: Use when working with the local Headroom Codex integration, proxy health, MCP compression/retrieve tools, persistent runtime profile, or Headroom configuration.
+---
+
+# Headroom For Codex
+
+Headroom should be installed so the `headroom` command is available on `PATH` and configured for Codex through the persistent `init-user` profile on port `8787`.
+
+Use Headroom alongside Cognitive Context Manager. CCM remains the default project-memory and working-context system; Headroom handles local proxy routing, compression, CCR retrieve tools, and proxy/session stats.
+
+Useful checks:
+
+```bash
+headroom install status --profile init-user
+curl -fsS http://127.0.0.1:8787/readyz
+curl -fsS http://127.0.0.1:8787/health
+```
+
+If the proxy is stopped, start it with:
+
+```bash
+cd /tmp && headroom install agent ensure --profile init-user
+```
+
+Avoid running the Headroom CLI from a source checkout when starting the proxy unless the checkout has a compiled `headroom._core`; otherwise Python may import the checkout instead of the installed wheel. A neutral cwd such as `/tmp` uses the installed package with the Rust extension.

--- a/tests/test_ccr_mcp_server.py
+++ b/tests/test_ccr_mcp_server.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import sys
+from types import ModuleType, SimpleNamespace
 
 from headroom.ccr import mcp_server
 
@@ -22,3 +24,46 @@ def test_shared_stats_work_without_fcntl(monkeypatch, tmp_path) -> None:
 
     events = mcp_server._read_shared_events(window_seconds=60)
     assert events == [{"type": "compress", "timestamp": 1000.0, "pid": 4242}]
+
+
+def test_token_savings_percent_uses_saved_tokens() -> None:
+    assert mcp_server._token_savings_percent(100, 25) == 75.0
+    assert mcp_server._token_savings_percent(67, 67) == 0.0
+    assert mcp_server._token_savings_percent(10, 12) == 0.0
+    assert mcp_server._token_savings_percent(0, 0) == 0.0
+
+
+def test_mcp_compress_reports_savings_from_token_counts(monkeypatch) -> None:
+    fake_compress_module = ModuleType("headroom.compress")
+
+    def fake_compress(messages, model):
+        assert messages == [{"role": "tool", "content": "original"}]
+        assert model == "claude-sonnet-4-5-20250929"
+        return SimpleNamespace(
+            messages=[{"role": "tool", "content": "compressed"}],
+            tokens_before=67,
+            tokens_after=67,
+            transforms_applied=["fake"],
+            compression_ratio=0.0,
+        )
+
+    fake_compress_module.compress = fake_compress
+    monkeypatch.setitem(sys.modules, "headroom.compress", fake_compress_module)
+
+    class DummyStore:
+        def store(self, **kwargs):
+            self.kwargs = kwargs
+            return "dummyhash"
+
+    class DummyStats:
+        def record_compression(self, *args):
+            self.args = args
+
+    server = mcp_server.HeadroomMCPServer.__new__(mcp_server.HeadroomMCPServer)
+    server._local_store = DummyStore()
+    server._stats = DummyStats()
+
+    result = mcp_server.HeadroomMCPServer._compress_content(server, "original")
+
+    assert result["tokens_saved"] == 0
+    assert result["savings_percent"] == 0.0


### PR DESCRIPTION
Summary
- Add a Codex plugin skeleton for Headroom MCP tools, hooks, and the Headroom skill.
- Document how Headroom runs alongside Cognitive Context Manager: CCM owns durable project memory; Headroom owns proxy compression, CCR retrieval, and stats.
- Fix MCP savings_percent reporting to use token-count savings and clamp expansions to 0%.

Validation
- uv run --extra dev pytest tests/test_ccr_mcp_server.py
- uv run python /Users/matt/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/matt/Documents/Headroom
- jq validation for .codex-plugin/plugin.json, .mcp.json, hooks/hooks.json
- Headroom install status plus /readyz and /health checks on init-user profile
- Headroom MCP compress/retrieve smoke test

Note
- Direct push to chopratejas/headroom:main was rejected with 403 for mefree2098, so this branch was pushed to the fork for review.