### PR TITLE
fix: add encoding='utf-8' to read_text() to fix UnicodeDecodeError on non-UTF-8 locales

### DIFF
--- a/headroom/dashboard/__init__.py
+++ b/headroom/dashboard/__init__.py
@@ -9,4 +9,4 @@ TEMPLATES_DIR = DASHBOARD_DIR / "templates"
 def get_dashboard_html() -> str:
     """Load the dashboard HTML template."""
     template_path = TEMPLATES_DIR / "dashboard.html"
-    return template_path.read_text()
+    return template_path.read_text(encoding='utf-8')


### PR DESCRIPTION
Fixes #533

## Problem
 calls  without specifying encoding. On non-UTF-8 locales (e.g. Korean Windows with cp949), reading a UTF-8 HTML template causes .

## Fix
Added  to the  call so the template is always decoded as UTF-8 regardless of OS locale.

## Verification
