### PR TITLE
fix(openclaw): use published headroom-ai package version

### DIFF
--- a/plugins/openclaw/package-lock.json
+++ b/plugins/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-openclaw",
-  "version": "0.1.1",
+  "version": "0.22.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-openclaw",
-      "version": "0.1.1",
+      "version": "0.22.4",
       "license": "Apache-2.0",
       "dependencies": {
         "headroom-ai": "^0.1.0"

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "headroom-ai": "^0.22.3"
+    "headroom-ai": "^0.1.0"
   },
   "peerDependencies": {
     "openclaw": "*"


### PR DESCRIPTION
## Summary

- Fix the OpenClaw plugin dependency on `headroom-ai` so `npm install` can resolve it from the public npm registry.
- Align `plugins/openclaw/package.json` with the existing lockfile dependency range, which already points to `^0.1.0`.
- Refresh the lockfile package metadata so its top-level version matches `package.json`.

## Root Cause

`plugins/openclaw/package.json` required `headroom-ai@^0.22.3`, but the npm registry currently only publishes `headroom-ai@0.1.0`. This causes fresh installs to fail with `npm ERR! code ETARGET`.

## Verification

From `plugins/openclaw`:

```bash
npm view headroom-ai versions --json
npm install
npm run build
npm run typecheck
npm test
```

Results:

- `npm view headroom-ai versions --json` returns only `0.1.0`.
- `npm install` completes successfully with 0 vulnerabilities.
- `npm run build` succeeds.
- `npm run typecheck` succeeds.
- `npm test` passes: 6 test files, 54 tests.

Closes #535.
