### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/wiki/getting-started.md
+++ b/wiki/getting-started.md
@@ -11,13 +11,13 @@ This guide will help you get up and running with Headroom in under 5 minutes.
 pip install headroom
 
 # With proxy server
-pip install headroom[proxy]
+pip install 'headroom[proxy]'
 
 # With semantic relevance (for smarter compression)
-pip install headroom[relevance]
+pip install 'headroom[relevance]'
 
 # Everything
-pip install headroom[all]
+pip install 'headroom[all]'
 ```
 
 **TypeScript / Node.js:**

--- a/wiki/macos-deployment.md
+++ b/wiki/macos-deployment.md
@@ -23,7 +23,7 @@ This is ideal for local development environments where you want "set and forget"
 
 ```bash
 # Install with proxy support
-pip install headroom-ai[proxy]
+pip install 'headroom-ai[proxy]'
 
 # Verify installation
 headroom proxy --help


### PR DESCRIPTION
## Summary
        - Quote `pip install` examples that include extras.

        ## Why
        - Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

        ## Scope
        - Files changed:
        - `wiki/getting-started.md`
- `wiki/macos-deployment.md`
        - This does not change dependencies or runtime behavior.

        ## Testing
        - `git diff --check`

        ## Maintainer Fit
        - Small install-command correctness fix.
        - Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`