### PR TITLE
fix: correct tiktoken encoding for unknown gpt-4 model snapshots

### DIFF
--- a/headroom/tokenizers/tiktoken_counter.py
+++ b/headroom/tokenizers/tiktoken_counter.py
@@ -97,13 +97,22 @@ def get_encoding_for_model(model: str) -> str:
     if model in MODEL_TO_ENCODING:
         return MODEL_TO_ENCODING[model]
 
-    # Try prefix matching for versioned models
-    for prefix in ["gpt-4o", "gpt-4-turbo", "gpt-4", "gpt-3.5", "o1", "o3"]:
+    # Try prefix matching for versioned models. Ordered most-specific first
+    # so that, e.g., "gpt-4o-*" resolves before "gpt-4-*". Each prefix maps
+    # directly to its encoding: scanning MODEL_TO_ENCODING for the first key
+    # that merely starts with the prefix is order-dependent and wrong — the
+    # "gpt-4" prefix would match the "gpt-4o" dict entry first and return
+    # o200k_base instead of cl100k_base for unknown gpt-4 snapshots.
+    for prefix, encoding in (
+        ("gpt-4o", "o200k_base"),
+        ("gpt-4-turbo", "cl100k_base"),
+        ("gpt-4", "cl100k_base"),
+        ("gpt-3.5", "cl100k_base"),
+        ("o1", "o200k_base"),
+        ("o3", "o200k_base"),
+    ):
         if model.startswith(prefix):
-            # Find any model with this prefix
-            for known_model, encoding in MODEL_TO_ENCODING.items():
-                if known_model.startswith(prefix):
-                    return encoding
+            return encoding
 
     return DEFAULT_ENCODING
 

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -34,6 +34,23 @@ class TestTiktokenCounter:
         assert counter.model == "gpt-4"
         assert counter.encoding_name == "cl100k_base"
 
+    def test_unknown_gpt4_snapshot_uses_cl100k(self):
+        """Unknown gpt-4 (non-o, non-turbo) snapshots must use cl100k_base.
+
+        Regression: the prefix matcher scanned MODEL_TO_ENCODING for the
+        first key starting with the prefix. For prefix "gpt-4" that matched
+        the "gpt-4o" entry first and wrongly returned o200k_base for any
+        gpt-4 snapshot not in the table (e.g. a future dated build).
+        """
+        from headroom.tokenizers.tiktoken_counter import get_encoding_for_model
+
+        assert get_encoding_for_model("gpt-4-2025-01-01") == "cl100k_base"
+        assert get_encoding_for_model("gpt-4-future") == "cl100k_base"
+        # gpt-4o snapshots still resolve to o200k_base (most-specific first).
+        assert get_encoding_for_model("gpt-4o-2099-12-31") == "o200k_base"
+        # gpt-4-turbo snapshots use cl100k_base.
+        assert get_encoding_for_model("gpt-4-turbo-2099") == "cl100k_base"
+
     def test_count_text_empty(self):
         """Test counting empty text."""
         counter = TiktokenCounter()


### PR DESCRIPTION
## Bug

`get_encoding_for_model()` in `headroom/tokenizers/tiktoken_counter.py` resolves unknown/versioned models to a tiktoken encoding via prefix matching. The inner loop scans `MODEL_TO_ENCODING` and returns the encoding of the **first dict key that starts with the matched prefix**:

```python
for prefix in ["gpt-4o", "gpt-4-turbo", "gpt-4", "gpt-3.5", "o1", "o3"]:
    if model.startswith(prefix):
        for known_model, encoding in MODEL_TO_ENCODING.items():
            if known_model.startswith(prefix):
                return encoding
```

The `gpt-4o*` entries are defined **before** the plain `gpt-4*` entries in `MODEL_TO_ENCODING`. So for `prefix == "gpt-4"`, the inner scan matches `"gpt-4o"` first and returns `o200k_base`. The gpt-4 (non-o, non-turbo) family actually uses `cl100k_base`. Any gpt-4 snapshot not already in the table (e.g. a future dated build) therefore gets the **wrong encoding**, so its token counts are computed with the wrong BPE — skewing every downstream context-budget / truncation decision that relies on this counter.

The outer prefix list is intentionally ordered most-specific-first, but the inner dict scan throws that ordering away.

## Reproduce (on `main`)

```python
from headroom.tokenizers.tiktoken_counter import get_encoding_for_model
print(get_encoding_for_model("gpt-4-2025-01-01"))  # -> "o200k_base"  (WRONG)
print(get_encoding_for_model("gpt-4"))             # -> "cl100k_base" (direct hit, correct)
```

`gpt-4-2025-01-01` should map to `cl100k_base` like the rest of the gpt-4 family.

## Fix

Map each prefix directly to its encoding (still ordered most-specific-first). Every model within a given prefix family shares one encoding, so this is deterministic and no longer depends on dict insertion order. Smallest change that fixes it; no behavior change for any model already in the table or for gpt-4o/o1 families.

## Regression test

`tests/test_tokenizers.py::TestTiktokenCounter::test_unknown_gpt4_snapshot_uses_cl100k` asserts unknown `gpt-4` / `gpt-4-turbo` snapshots resolve to `cl100k_base` while `gpt-4o` snapshots stay on `o200k_base`. It **fails before** this change (`o200k_base != cl100k_base`) and **passes after**. Full `tests/test_tokenizers.py` + `tests/test_tokenizer.py` suites pass (39 passed, 14 skipped for optional deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)