### PR TITLE
fix: ignore brackets inside JSON strings when splitting mixed content

### DIFF
--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -658,13 +658,38 @@ def _extract_json_block(lines: list[str], start: int) -> tuple[str | None, int]:
     bracket_count = 0
     brace_count = 0
     json_lines = []
+    in_string = False
+    escaped = False
 
     for i in range(start, len(lines)):
         line = lines[i]
         json_lines.append(line)
 
-        bracket_count += line.count("[") - line.count("]")
-        brace_count += line.count("{") - line.count("}")
+        # Count brackets/braces, but ignore any that appear inside a JSON
+        # string literal — a naive line.count() treats e.g. the "]" in
+        # {"path": "a]b"} as a closing bracket and terminates the block
+        # early, splitting one array across multiple sections.
+        for ch in line:
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\":
+                if in_string:
+                    escaped = True
+                continue
+            if ch == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if ch == "[":
+                bracket_count += 1
+            elif ch == "]":
+                bracket_count -= 1
+            elif ch == "{":
+                brace_count += 1
+            elif ch == "}":
+                brace_count -= 1
 
         if bracket_count <= 0 and brace_count <= 0 and json_lines:
             return "\n".join(json_lines), i

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -171,6 +171,66 @@ def test_mixed_content_section_splitting_and_json_extraction() -> None:
     assert _extract_json_block(["{", '"a": 1'], 0) == (None, 0)
 
 
+def test_extract_json_block_ignores_brackets_inside_strings() -> None:
+    """Brackets/braces inside JSON string values must not end the block early.
+
+    Regression: counting raw ``[``/``]``/``{``/``}`` per line treated the
+    ``]`` inside ``{"path": "a]b"}`` as a closing bracket, so the array was
+    truncated mid-way and the remaining rows leaked into later sections.
+    """
+    import json as _json
+
+    lines = [
+        "[",
+        '  {"path": "a]b"},',
+        '  {"path": "c"}',
+        "]",
+    ]
+    block, end_idx = _extract_json_block(lines, 0)
+    assert end_idx == 3
+    assert block is not None
+    parsed = _json.loads(block)
+    assert parsed == [{"path": "a]b"}, {"path": "c"}]
+
+    # Braces inside a string value must likewise be ignored.
+    obj_lines = [
+        "{",
+        '  "msg": "use {curly} and [square]",',
+        '  "n": 1',
+        "}",
+    ]
+    obj_block, obj_end = _extract_json_block(obj_lines, 0)
+    assert obj_end == 3
+    assert obj_block is not None
+    assert _json.loads(obj_block) == {"msg": "use {curly} and [square]", "n": 1}
+
+
+def test_split_into_sections_keeps_json_array_with_bracket_in_string() -> None:
+    """A JSON array embedded in prose stays one JSON section, not fragments.
+
+    With the bracket-in-string bug, the array below split into a truncated
+    JSON section plus a stray ``]`` glued onto the trailing prose.
+    """
+    import json as _json
+
+    content = "\n".join(
+        [
+            "prose line here that is long enough to matter",
+            "[",
+            '  {"path": "a]b"},',
+            '  {"path": "c"}',
+            "]",
+            "trailing prose",
+        ]
+    )
+
+    sections = split_into_sections(content)
+    json_sections = [s for s in sections if s.content_type == ContentType.JSON_ARRAY]
+    assert len(json_sections) == 1
+    parsed = _json.loads(json_sections[0].content)
+    assert parsed == [{"path": "a]b"}, {"path": "c"}]
+
+
 def test_content_router_strategy_and_compress_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     router = ContentRouter(ContentRouterConfig(prefer_code_aware_for_code=False))
 


### PR DESCRIPTION
## Bug

`_extract_json_block()` in `headroom/transforms/content_router.py` finds where a JSON block ends by counting raw bracket/brace characters per line:

```python
bracket_count += line.count("[") - line.count("]")
brace_count  += line.count("{") - line.count("}")
if bracket_count <= 0 and brace_count <= 0 and json_lines:
    return "\n".join(json_lines), i
```

This counts brackets/braces that appear **inside JSON string values**. For example the `]` in `{"path": "a]b"}` is counted as a closing bracket, so the running balance reaches zero before the array actually closes and the block is cut mid-array.

`_extract_json_block` is reached on the live compression path via `ContentRouter.compress()` → `_compress_mixed()` → `split_into_sections()` (used whenever `is_mixed_content()` is true, e.g. a JSON array embedded in prose). The mis-cut fragments one JSON array into several sections: the array is truncated, a non-array fragment (`{"path": "c"}`) gets mislabeled `JSON_ARRAY`, and the stray closing `]` leaks into the following prose section — so the wrong content is routed to the wrong compressor.

## Reproduce (on `main`)

```python
from headroom.transforms.content_router import split_into_sections

content = '''prose line here that is long enough to matter
[
  {"path": "a]b"},
  {"path": "c"}
]
trailing prose'''

for s in split_into_sections(content):
    print(s.content_type.value, repr(s.content))
```

Output on `main` (array fragmented across 4 sections):

```
text       'prose line here that is long enough to matter'
json_array '[\n  {"path": "a]b"},'
json_array '  {"path": "c"}'
text       ']\ntrailing prose'
```

Expected: one `json_array` section containing the full, intact array.

## Fix

Walk the line characters with a small in-string / escape state machine and only count brackets/braces that are **outside** string literals. Smallest change that fixes it; behavior is unchanged for JSON that has no brackets-in-strings (existing `test_mixed_content_section_splitting_and_json_extraction` still passes untouched).

## Regression tests

Two new tests in `tests/test_transforms_content_router.py`:
- `test_extract_json_block_ignores_brackets_inside_strings` — unit-level: `]`/`{`/`}` inside string values don't end the block early.
- `test_split_into_sections_keeps_json_array_with_bracket_in_string` — end-to-end: the embedded array stays one `JSON_ARRAY` section and round-trips through `json.loads`.

Both **fail before** this change and **pass after**. The pure-Python content_router tests pass (19 passed); the one unrelated failure in that file (`test_content_signature_and_detection_helpers`) requires the compiled `headroom._core` extension and fails identically on unmodified `main` in an environment without the Rust wheel built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)