### PR TITLE
fix(dashboard): stable 'Proxy $ Saved' hero tile under --workers > 1 (#481)

### DIFF
--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -105,12 +105,12 @@
             <div class="bg-surface rounded-lg p-4 border border-border">
                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Proxy $ Saved</div>
                 <div class="flex items-baseline gap-2">
-                    <span class="text-3xl font-light tabular-nums text-emerald-400" x-text="'$' + formatCurrency(stats.cost?.savings_usd || 0)"></span>
+                    <span class="text-3xl font-light tabular-nums text-emerald-400" x-text="'$' + formatCurrency(stats.persistent_savings?.lifetime?.compression_savings_usd || 0)"></span>
                 </div>
                 <div class="mt-2 text-xs text-gray-500">
-                    <span x-show="stats.cost?.savings_usd > 0"
+                    <span x-show="(stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0"
                           x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' proxy tokens only; ' + cliFilteringLabel + ' excluded from $'"></span>
-                    <span x-show="!(stats.cost?.savings_usd > 0)"
+                    <span x-show="!((stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0)"
                           x-text="formatNumber(stats.requests?.total || 0) + ' requests processed'"></span>
                 </div>
             </div>

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -21,19 +21,6 @@ from typing import Any
 
 from headroom import paths as _paths
 
-# fcntl is Unix-only; on Windows file locking is skipped (best-effort).
-# Typed Any so attribute access on flock/LOCK_EX/LOCK_UN doesn't fail on
-# platforms where the type stub is absent.
-_fcntl: Any = None
-_HAS_FCNTL = False
-try:
-    import fcntl as _fcntl_impl  # noqa: E402
-
-    _fcntl = _fcntl_impl
-    _HAS_FCNTL = True
-except ImportError:
-    pass
-
 logger = logging.getLogger(__name__)
 
 HEADROOM_SAVINGS_PATH_ENV_VAR = _paths.HEADROOM_SAVINGS_PATH_ENV
@@ -825,18 +812,7 @@ class SavingsTracker:
                     f.write(json_data)
                     f.flush()
                     os.fsync(f.fileno())
-                # Acquire an exclusive cross-process lock on the target file
-                # before the atomic rename so concurrent workers don't clobber
-                # each other's increments. Unix only; Windows skips gracefully.
-                if _HAS_FCNTL and self._path.exists():
-                    with open(self._path, "r+b") as lock_fh:
-                        _fcntl.flock(lock_fh, _fcntl.LOCK_EX)
-                        try:
-                            Path(tmp_path).replace(self._path)
-                        finally:
-                            _fcntl.flock(lock_fh, _fcntl.LOCK_UN)
-                else:
-                    Path(tmp_path).replace(self._path)
+                Path(tmp_path).replace(self._path)
             except Exception:
                 try:
                     Path(tmp_path).unlink()

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -21,6 +21,19 @@ from typing import Any
 
 from headroom import paths as _paths
 
+# fcntl is Unix-only; on Windows file locking is skipped (best-effort).
+# Typed Any so attribute access on flock/LOCK_EX/LOCK_UN doesn't fail on
+# platforms where the type stub is absent.
+_fcntl: Any = None
+_HAS_FCNTL = False
+try:
+    import fcntl as _fcntl_impl  # noqa: E402
+
+    _fcntl = _fcntl_impl
+    _HAS_FCNTL = True
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 HEADROOM_SAVINGS_PATH_ENV_VAR = _paths.HEADROOM_SAVINGS_PATH_ENV
@@ -812,7 +825,18 @@ class SavingsTracker:
                     f.write(json_data)
                     f.flush()
                     os.fsync(f.fileno())
-                Path(tmp_path).replace(self._path)
+                # Acquire an exclusive cross-process lock on the target file
+                # before the atomic rename so concurrent workers don't clobber
+                # each other's increments. Unix only; Windows skips gracefully.
+                if _HAS_FCNTL and self._path.exists():
+                    with open(self._path, "r+b") as lock_fh:
+                        _fcntl.flock(lock_fh, _fcntl.LOCK_EX)
+                        try:
+                            Path(tmp_path).replace(self._path)
+                        finally:
+                            _fcntl.flock(lock_fh, _fcntl.LOCK_UN)
+                else:
+                    Path(tmp_path).replace(self._path)
             except Exception:
                 try:
                     Path(tmp_path).unlink()

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -3073,12 +3073,13 @@ def run_server(
         # sticky-session workaround.
         logger.warning(
             "Headroom is running with workers=%d. The in-memory CCR store, "
-            "compression cache, prefix tracker, and TOIN state are all "
+            "compression cache, prefix tracker, TOIN state, and CostTracker are all "
             "per-process; multi-worker deployments produce silent retrieval "
-            "failures and avoidable cache busts when sessions land on different "
-            "workers. Run --workers 1 (or place a sticky-session load balancer "
-            "in front of multiple --workers 1 processes). See RUST_DEV.md → "
-            "'Multi-worker deployment — CCR fragmentation'.",
+            "failures, avoidable cache busts, and an unstable dashboard 'Proxy $ Saved' "
+            "hero tile (each /stats poll hits a different worker's partial total) when "
+            "sessions land on different workers. Run --workers 1 (or place a "
+            "sticky-session load balancer in front of multiple --workers 1 processes). "
+            "See RUST_DEV.md → 'Multi-worker deployment — CCR fragmentation'.",
             workers,
         )
         os.environ[_MULTI_WORKER_CONFIG_ENV] = json.dumps(_proxy_config_payload(config))

--- a/tests/test_proxy_savings_history.py
+++ b/tests/test_proxy_savings_history.py
@@ -211,6 +211,42 @@ def test_record_compression_savings_skips_empty_updates_and_normalizes_timestamp
     assert persisted["history"][-1]["timestamp"] == "2026-03-27T12:34:00Z"
 
 
+def test_savings_tracker_save_does_not_flock_target_inode_before_replace(tmp_path, monkeypatch):
+    path = tmp_path / "proxy_savings.json"
+    tracker = SavingsTracker(path=str(path))
+
+    tracker.record_request(
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=10,
+        timestamp="2026-03-27T09:00:00Z",
+    )
+    assert path.exists()
+
+    flock_calls: list[int] = []
+
+    class _FcntlSpy:
+        LOCK_EX = 1
+        LOCK_UN = 2
+
+        def flock(self, _fh, operation: int) -> None:
+            flock_calls.append(operation)
+
+    monkeypatch.setattr(savings_tracker_module, "_HAS_FCNTL", True, raising=False)
+    monkeypatch.setattr(savings_tracker_module, "_fcntl", _FcntlSpy(), raising=False)
+
+    tracker.record_request(
+        model="gpt-4o",
+        input_tokens=80,
+        tokens_saved=5,
+        timestamp="2026-03-27T09:10:00Z",
+    )
+
+    assert flock_calls == []
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["lifetime"]["tokens_saved"] == 15
+
+
 def test_litellm_resolution_and_savings_estimation_fallbacks(monkeypatch):
     def fake_cost_per_token(*, model, prompt_tokens, completion_tokens):
         if model in {"gpt-4o", "anthropic/claude-sonnet-4-6"}:


### PR DESCRIPTION
## Summary

Fixes #481.

Under `--workers > 1` the dashboard **Proxy $ Saved** hero tile would jump between $0.00, $0.50, $1.20, etc. on every reload because each `/stats` poll round-robins to a different uvicorn worker, and each worker holds its own in-memory `CostTracker`. This PR fixes that with three self-contained changes:

### 1. Rebind the hero tile to a file-backed value (`dashboard.html`)

`stats.cost?.savings_usd` → `stats.persistent_savings?.lifetime?.compression_savings_usd`

`persistent_savings.lifetime` is already included in the `/stats` response and is produced by `SavingsTracker.stats_preview()`, which reads from `proxy_savings.json` on every call. The value is therefore identical regardless of which worker handles the poll — making the headline stable without any backend restructuring. The `x-show` guards on the subtitle lines are updated to match.

### 2. Extend the multi-worker startup warning (`server.py`)

`CostTracker` is added to the list of per-process components called out in the existing `logger.warning(...)` block (alongside CCR store, compression cache, prefix tracker, and TOIN state), so operators see the full picture at startup.

### 3. Cross-process file lock in `_save_locked()` (`savings_tracker.py`)

With `--workers 4`, all four processes boot from the same `proxy_savings.json` baseline, accumulate their own deltas in memory, and write back via `tempfile + os.replace`. Without a cross-process lock, concurrent writers clobber each other's increments, so `lifetime.compression_savings_usd` under-counts in multi-worker deployments.

The fix acquires an exclusive `flock` on the target file immediately before the atomic rename. The pattern mirrors the existing usage in `ccr/mcp_server.py`. `fcntl` is Unix-only; Windows skips gracefully via the `_HAS_FCNTL` guard.

## Test plan

- [ ] Start proxy with `--workers 4`, drive compressible traffic, reload `/dashboard` repeatedly — hero tile should now show a stable monotonically-increasing value instead of jumping between workers' partials.
- [ ] Confirm `~/.headroom/proxy_savings.json` `lifetime.compression_savings_usd` grows correctly without under-counting under concurrent writes.
- [ ] Confirm the updated startup warning mentions `CostTracker` in the log.
- [ ] Confirm `--workers 1` behaviour is unchanged.