### PR TITLE
fix: make headroom.proxy import lazy so CLI works without [proxy] extra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: sync-plugin-versions
         name: Sync plugin versions
-        entry: python scripts/sync-plugin-versions.py
+        entry: python3 scripts/sync-plugin-versions.py
         language: system
         pass_filenames: false
         always_run: true

--- a/headroom/proxy/__init__.py
+++ b/headroom/proxy/__init__.py
@@ -14,6 +14,27 @@ Usage:
     Set base URL in Cursor settings to http://localhost:8787
 """
 
-from .server import create_app, run_server
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .server import create_app, run_server
 
 __all__ = ["create_app", "run_server"]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose the server entry points (PEP 562).
+
+    ``headroom.proxy.server`` pulls in ``fastapi`` and the rest of the proxy
+    stack, which only ship with the ``[proxy]`` extra. Importing it eagerly
+    here broke ``headroom --help`` (and every other CLI command) for base
+    installs without that extra, because ``headroom.cli.proxy`` only needs the
+    dependency-free ``headroom.proxy.modes`` module. Deferring the import keeps
+    ``from headroom.proxy import create_app`` working while no longer requiring
+    ``fastapi`` just to import this package. See issue #441.
+    """
+    if name in ("create_app", "run_server"):
+        from . import server
+
+        return getattr(server, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_package_init_lazy.py
+++ b/tests/test_package_init_lazy.py
@@ -6,9 +6,12 @@ import json
 import subprocess
 import sys
 import textwrap
+import types
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 import headroom._version as version_module
 
@@ -146,6 +149,33 @@ def test_proxy_package_exports_remain_accessible() -> None:
     )
 
     assert result.stdout.strip() == "ok"
+
+
+def test_proxy_lazy_getattr_uses_server_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    import headroom.proxy as proxy
+
+    fake_server = types.ModuleType("headroom.proxy.server")
+
+    def create_app() -> object:
+        return object()
+
+    def run_server() -> None:
+        return None
+
+    fake_server.create_app = create_app  # type: ignore[attr-defined]
+    fake_server.run_server = run_server  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "headroom.proxy.server", fake_server)
+    monkeypatch.delattr(proxy, "server", raising=False)
+
+    assert proxy.__getattr__("create_app") is create_app
+    assert proxy.__getattr__("run_server") is run_server
+
+
+def test_proxy_lazy_getattr_rejects_unknown_attribute() -> None:
+    import headroom.proxy as proxy
+
+    with pytest.raises(AttributeError, match="does_not_exist"):
+        proxy.__getattr__("does_not_exist")
 
 
 def test_proxy_server_import_skips_litellm_backend() -> None:

--- a/tests/test_package_init_lazy.py
+++ b/tests/test_package_init_lazy.py
@@ -74,6 +74,80 @@ def test_version_prefers_source_tree_release_history() -> None:
     package_version.assert_not_called()
 
 
+def test_proxy_package_import_stays_lazy() -> None:
+    """Importing ``headroom.proxy`` must not pull in the fastapi-backed server.
+
+    Regression for issue #441: the eager ``from .server import ...`` in
+    ``headroom/proxy/__init__.py`` made ``headroom --help`` crash with
+    ``ModuleNotFoundError: No module named 'fastapi'`` on base installs without
+    the ``[proxy]`` extra, because loading ``headroom.cli.proxy`` imports the
+    dependency-free ``headroom.proxy.modes`` and that triggers the package
+    ``__init__``.
+    """
+    script = textwrap.dedent(
+        """
+        import json
+        import sys
+
+        import headroom.proxy
+        import headroom.proxy.modes  # what the CLI actually needs
+
+        print(json.dumps({
+            "server_loaded": "headroom.proxy.server" in sys.modules,
+            "fastapi_loaded": "fastapi" in sys.modules,
+        }))
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    data = json.loads(result.stdout.strip())
+    assert data["server_loaded"] is False
+    assert data["fastapi_loaded"] is False
+
+
+def test_proxy_package_exports_remain_accessible() -> None:
+    """The lazy ``__getattr__`` must still expose ``create_app``/``run_server``."""
+    script = textwrap.dedent(
+        """
+        import sys
+
+        import headroom.proxy
+
+        create_app = headroom.proxy.create_app
+        run_server = headroom.proxy.run_server
+        assert callable(create_app)
+        assert callable(run_server)
+        # Accessing the exports must have loaded the server module on demand.
+        assert "headroom.proxy.server" in sys.modules
+
+        # Unknown attributes still raise AttributeError.
+        try:
+            headroom.proxy.does_not_exist
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError("expected AttributeError for unknown attribute")
+
+        print("ok")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == "ok"
+
+
 def test_proxy_server_import_skips_litellm_backend() -> None:
     script = textwrap.dedent(
         """


### PR DESCRIPTION
## What

Make importing the `headroom.proxy` package lazy so it no longer eagerly pulls in `fastapi`.

- `headroom/proxy/__init__.py`: replace the eager `from .server import create_app, run_server` with a PEP 562 `__getattr__` that imports `headroom.proxy.server` only when `create_app`/`run_server` are actually accessed.
- `.pre-commit-config.yaml`: use `python3` instead of `python` for the `sync-plugin-versions` hook so it runs on machines (e.g. Homebrew) where only `python3` is on `PATH`.
- `tests/test_package_init_lazy.py`: add regression tests asserting that importing `headroom.proxy` does not load `headroom.proxy.server`/`fastapi`, and that the lazy exports still resolve.

## Why

Fixes #441.

On a base install (`pip install headroom-ai`, i.e. **without** the `[proxy]` extra), `fastapi` is not present. Any CLI invocation — even `headroom --help` — crashed with:

```
ModuleNotFoundError: No module named 'fastapi'
```

Root cause is an import chain that only needs the dependency-free `headroom.proxy.modes` module but transitively dragged in the whole proxy server:

```
headroom/cli/proxy.py
  → from headroom.proxy.modes import ...        # only this is needed
    → headroom/proxy/__init__.py
      → from .server import create_app, ...      # eager, unnecessary
        → headroom/proxy/server.py
          → from headroom.providers.proxy_routes import register_provider_routes
            → from fastapi import FastAPI, ...    # boom: fastapi is [proxy]-only
```

`fastapi` lives in `[project.optional-dependencies].proxy`, not the core deps, so this path is broken for every base install. No code actually imports `create_app`/`run_server` from the package root (`from headroom.proxy.server import ...` is used everywhere), so the eager re-export was pure liability. The lazy `__getattr__` preserves `from headroom.proxy import create_app` for backwards compatibility while removing the hard `fastapi` requirement just to import the package.

## How to test

```bash
# Reproduce (before this change), in an env without the [proxy] extra:
pip install headroom-ai
headroom --help          # ModuleNotFoundError: No module named 'fastapi'

# After this change, the CLI loads without fastapi installed.

# Regression tests:
pytest tests/test_package_init_lazy.py -q
```

## Breaking changes

None. `from headroom.proxy import create_app` / `run_server` still work (resolved lazily on first access).
