### PR TITLE
feat(copilot): GitHub Copilot subscription mode through Headroom

### DIFF
--- a/.github/ISSUE_TEMPLATE/copilot-subscription-test-report.md
+++ b/.github/ISSUE_TEMPLATE/copilot-subscription-test-report.md
@@ -1,0 +1,54 @@
+---
+name: Copilot Subscription Test Report
+about: Report results of testing `headroom wrap copilot --subscription` on Linux/Windows/macOS
+title: '[COPILOT-SUB] <OS> test report'
+labels: copilot-subscription, testing
+assignees: ''
+---
+
+<!--
+Thanks for helping verify Copilot subscription mode across platforms!
+See TESTING-copilot-subscription.md for the step-by-step flows.
+Redact your actual token everywhere.
+-->
+
+## Environment
+
+- **OS + version**: (e.g., Ubuntu 24.04, Windows 11 23H2, macOS 14.5)
+- **Architecture**: (x86_64 / arm64)
+- **How you installed headroom**: (pipx/pip `--pre` wheel · Docker install.sh/ps1 · built from source)
+- **headroom version**: (`headroom --version`)
+- **Copilot CLI version**: (`copilot --version`)
+- **Was plain `copilot` logged in before the test?**: yes / no
+
+## Result
+
+- **Command run**:
+  ```
+  headroom wrap copilot --subscription -- --model gpt-4o -p "Reply with exactly: HEADROOM_OK"
+  ```
+- **Did it print `HEADROOM_OK`?**: yes / no
+- **Worked WITHOUT `GITHUB_COPILOT_TOKEN` (auto-discovery)?**: yes / no / didn't try
+- **Worked WITH `GITHUB_COPILOT_TOKEN` set?**: yes / no / didn't try
+
+## Error output (if any)
+
+```
+paste any error here
+```
+
+## Token storage schema (only if auto-discovery failed)
+
+Helps us fix auto-discovery. **Redact the secret value.**
+
+- Linux: `secret-tool search --all 2>/dev/null | sed -E 's/^secret = .*/secret = <redacted>/'`
+- Windows: `cmd /c "cmdkey /list"` (paste the Copilot-related `Target:` line)
+- macOS (reference): service `copilot-cli`
+
+```
+paste the attribute / Target lines here (secret redacted)
+```
+
+## Anything else
+
+(logs from `~/.headroom/logs/proxy.log`, surprises, etc.)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ Reproduce: `python -m headroom.evals suite --tier 1` · [Full benchmarks & metho
 
 Any OpenAI-compatible client works via `headroom proxy`. MCP-native: `headroom mcp install`.
 
+### GitHub Copilot CLI subscription mode
+
+Headroom can route GitHub Copilot CLI subscription traffic through the local proxy:
+
+```bash
+headroom wrap copilot --subscription -- --model gpt-4o
+```
+
+This lets Headroom intercept OpenAI-compatible Copilot CLI requests and apply the same proxy compression pipeline before forwarding to GitHub Copilot's hosted API. The wrapper resolves the account-specific Copilot API endpoint and prints it as `COPILOT_PROVIDER_API_URL=...` during launch.
+
+Platform support note: macOS auth reuse via Copilot CLI Keychain storage has been smoke-tested. Windows Credential Manager, Linux Secret Service / `secret-tool`, and Docker/CI token-injection paths are implemented or planned as auth-discovery paths, but still need real OS validation before they should be considered fully vetted. For Docker and CI, prefer passing an explicit `GITHUB_COPILOT_TOKEN` or `GITHUB_COPILOT_GITHUB_TOKEN` rather than relying on host keychain access.
+
 ## When to use · When to skip
 
 **Great fit if you…**

--- a/TESTING-copilot-subscription.md
+++ b/TESTING-copilot-subscription.md
@@ -1,0 +1,122 @@
+# Testing: GitHub Copilot subscription mode (`headroom wrap copilot --subscription`)
+
+This is an **experimental** feature and we need help verifying it on **Linux and
+Windows**. It already works on macOS; the cross-platform gap is small and
+specific (see [Status](#status)). If you have a GitHub Copilot subscription and
+10 minutes, please run one of the flows below and
+[file a report](https://github.com/chopratejas/headroom/issues/new?template=copilot-subscription-test-report.md).
+
+> ⚠️ This is experimental, and it reads your Copilot login token + routes your
+> Copilot CLI traffic through a local Headroom proxy. Only run it if you're
+> comfortable with that. The branch is open for inspection.
+
+## What it does (and what "subscription" means here)
+
+Normally `headroom wrap copilot` is **BYOK** — you bring an Anthropic/OpenAI API
+key and pay that vendor. `--subscription` is different: it lets you use the
+**Copilot seat you already pay GitHub for**, with **no separate API key**, while
+still routing through Headroom so your context gets compressed.
+
+Mechanically: the Copilot CLI's only interposition hook is its provider-override
+(the "BYOK transport"), so Headroom uses that knob but supplies **your
+subscription token** and points back at **GitHub's own Copilot API**. So the CLI
+may print "BYOK" and require an explicit `--model`, but you are **not** paying a
+third party — it's your subscription, just compressed. (Proof it's working: the
+proxy forwards to `https://api.*.githubcopilot.com` with your token.)
+
+## Status
+
+| Platform | Mechanism (compress + forward) | Token **auto-discovery** from the OS secret store |
+|----------|:---:|:---:|
+| macOS (Keychain) | ✅ verified | ✅ verified (`copilot-cli`) |
+| Linux (`secret-tool`/libsecret) | ✅ expected | ❓ **needs testing** |
+| Windows (Credential Manager) | ✅ expected | ❓ **needs testing** |
+| Any OS via `GITHUB_COPILOT_TOKEN` env var | ✅ verified by tests | n/a (bypasses discovery) |
+
+The two things we want to learn:
+1. **Does it work end to end on your OS?**
+2. **Does it find your Copilot token automatically**, or do you have to set
+   `GITHUB_COPILOT_TOKEN`? If it can't find it, we need the **storage schema**
+   (see each flow) so we can fix auto-discovery.
+
+## Prerequisites (all platforms)
+
+1. A **GitHub Copilot subscription**.
+2. The **GitHub Copilot CLI**: `npm install -g @github/copilot`
+3. **Log in once**: run `copilot`, complete the device-code login in your
+   browser, then type `/exit`.
+
+---
+
+## Linux — the flow we most need (tests auto-discovery)
+
+Auto-discovery only works with a **host-native** install (a container can't read
+your host secret store). Linux has prebuilt wheels, so:
+
+```bash
+pipx install --pip-args='--pre' headroom-ai     # or: pip install --pre headroom-ai
+# (no separate API key needed — that's the point)
+headroom wrap copilot --subscription -- --model gpt-4o -p "Reply with exactly: HEADROOM_OK"
+```
+
+- **If it prints `HEADROOM_OK`** → auto-discovery works on your Linux. 🎉 Report success.
+- **If it errors with "no reusable bearer token"** → discovery missed your token. Please grab the **schema** so we can fix it (redact the secret), then confirm the mechanism works via the env var:
+  ```bash
+  secret-tool search --all 2>/dev/null | sed -E 's/^secret = .*/secret = <redacted>/'
+  # then retry, supplying the token explicitly:
+  GITHUB_COPILOT_TOKEN='<your-token>' headroom wrap copilot --subscription -- --model gpt-4o -p "Reply with: HEADROOM_OK"
+  ```
+  Report the `attribute.*` lines from `secret-tool` and whether the env-var retry worked.
+
+---
+
+## Windows
+
+There is **no native Windows wheel yet**, so pick one:
+
+**A. Mechanism test (easiest — Docker Desktop or WSL2):**
+```powershell
+$env:HEADROOM_DOCKER_IMAGE = "ghcr.io/chopratejas/headroom:<branch-tag>"   # ask the maintainer for the tag
+# run the Docker-native installer (scripts/install.ps1), then:
+$env:GITHUB_COPILOT_TOKEN = "<your-token>"
+headroom wrap copilot --subscription -- --model gpt-4o -p "Reply with: HEADROOM_OK"
+```
+Report whether it prints `HEADROOM_OK`.
+
+**B. Native auto-discovery schema (even without a working install):** after
+`copilot` login, tell us where Windows stored the token:
+```cmd
+cmd /c "cmdkey /list"
+```
+Report the `Target:` line that looks Copilot-related (it shows the target name,
+not the secret). That single fact lets us make native Windows discovery work.
+
+> Native Windows auto-discovery becomes fully testable once we add a Windows
+> wheel to the build matrix — tracked separately.
+
+---
+
+## macOS (already proven — a second data point still helps)
+
+```bash
+pipx install --pip-args='--pre' headroom-ai
+headroom wrap copilot --subscription -- --model gpt-4o -p "Reply with exactly: HEADROOM_OK"
+```
+Schema, for reference: Keychain generic password, service `copilot-cli`
+(`security find-generic-password -s copilot-cli -w`).
+
+---
+
+## What to report
+
+Please open a
+[Copilot subscription test report](https://github.com/chopratejas/headroom/issues/new?template=copilot-subscription-test-report.md)
+with:
+
+- **OS + version** and **how you installed** (pipx/pip wheel, Docker, source).
+- Was plain `copilot` logged in?
+- Did `wrap copilot --subscription` print **`HEADROOM_OK`**? Paste any error.
+- Did it work **without** setting `GITHUB_COPILOT_TOKEN` (auto-discovery), or
+  only **with** it?
+- The **storage schema** if discovery failed (`secret-tool search --all` /
+  `cmdkey /list`), with the secret redacted.

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -37,7 +37,6 @@ if sys.platform == "win32" and hasattr(sys.stdout, "buffer"):
 import click
 
 from headroom._version import __version__ as _HEADROOM_VERSION
-from headroom.copilot_auth import DEFAULT_API_URL as COPILOT_API_URL
 from headroom.copilot_auth import (
     has_oauth_auth,
     resolve_client_bearer_token,
@@ -162,6 +161,7 @@ def _start_proxy(
     anyllm_provider: str | None = None,
     region: str | None = None,
     openai_api_url: str | None = None,
+    copilot_api_token: str | None = None,
 ) -> subprocess.Popen:
     """Start Headroom proxy as a background subprocess.
 
@@ -217,6 +217,12 @@ def _start_proxy(
         proxy_env.setdefault("HEADROOM_STACK", f"wrap_{agent_type}")
     if openai_api_url:
         proxy_env["OPENAI_TARGET_API_URL"] = openai_api_url
+    # Pin the wrapper-validated Copilot token for this proxy instance only.
+    # Injected into the subprocess env here (not the parent's os.environ) so it
+    # never leaks into shared state. The proxy's CopilotTokenProvider honours
+    # GITHUB_COPILOT_API_TOKEN directly, making upstream auth deterministic.
+    if copilot_api_token:
+        proxy_env["GITHUB_COPILOT_API_TOKEN"] = copilot_api_token
 
     proc = subprocess.Popen(
         cmd,
@@ -1600,6 +1606,7 @@ def _ensure_proxy(
     anyllm_provider: str | None = None,
     region: str | None = None,
     openai_api_url: str | None = None,
+    copilot_api_token: str | None = None,
 ) -> subprocess.Popen | None:
     """Start or verify proxy. Returns process handle if we started it."""
     helpers = _live_wrap_module()
@@ -1700,8 +1707,7 @@ def _ensure_proxy(
                 if missing:
                     needs_restart = True
                     flags_str = ", ".join(
-                        f if f.startswith("--") else f"--{f.replace('_', '-')}"
-                        for f in missing
+                        f if f.startswith("--") else f"--{f.replace('_', '-')}" for f in missing
                     )
                     click.echo(f"  Proxy on port {port} is missing: {flags_str}")
                     click.echo("  Restarting proxy with upgraded configuration...")
@@ -1748,6 +1754,7 @@ def _ensure_proxy(
                     anyllm_provider=anyllm_provider,
                     region=region,
                     openai_api_url=openai_api_url,
+                    copilot_api_token=copilot_api_token,
                 ),
             )
             click.echo(f"  Proxy ready on http://127.0.0.1:{port}")
@@ -1823,6 +1830,7 @@ def _launch_tool(
     anyllm_provider: str | None = None,
     region: str | None = None,
     openai_api_url: str | None = None,
+    copilot_api_token: str | None = None,
 ) -> None:
     """Common logic: start proxy, launch tool, clean up."""
     proxy_holder: list[subprocess.Popen | None] = [None]
@@ -1849,6 +1857,7 @@ def _launch_tool(
             anyllm_provider=anyllm_provider,
             region=region,
             openai_api_url=openai_api_url,
+            copilot_api_token=copilot_api_token,
         )
 
         if code_graph:
@@ -2481,6 +2490,7 @@ def copilot(
 
     env = os.environ.copy()
     openai_api_url: str | None = None
+    copilot_proxy_token: str | None = None
     if _should_use_copilot_oauth(
         backend=effective_backend,
         provider_type=provider_type,
@@ -2504,6 +2514,16 @@ def copilot(
         env["COPILOT_PROVIDER_BEARER_TOKEN"] = client_bearer
         env["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] = "false"
         env.pop("COPILOT_PROVIDER_API_KEY", None)
+        # Hand the exact token we resolved (and, for --subscription, validated
+        # against GitHub) to the proxy explicitly via copilot_proxy_token below.
+        # The proxy pins it as GITHUB_COPILOT_API_TOKEN, so upstream auth is
+        # deterministic instead of the proxy re-running unvalidated discovery
+        # (read_cached_oauth_token returns the *first* candidate, which may not
+        # be the one the wrapper approved → environment-dependent 401s). Passing
+        # it as a launch argument — rather than mutating this process's global
+        # os.environ — keeps the token off shared state and out of unrelated
+        # code paths.
+        copilot_proxy_token = client_bearer
         env_vars_display = [
             "COPILOT_PROVIDER_TYPE=openai",
             f"COPILOT_PROVIDER_BASE_URL=http://127.0.0.1:{port}/v1",
@@ -2518,9 +2538,6 @@ def copilot(
         env["GITHUB_COPILOT_API_URL"] = openai_api_url
         env["OPENAI_TARGET_API_URL"] = openai_api_url
         env_vars_display.append(f"COPILOT_PROVIDER_API_URL={openai_api_url}")
-        os.environ["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] = "false"
-        os.environ["GITHUB_COPILOT_API_URL"] = openai_api_url
-        os.environ["OPENAI_TARGET_API_URL"] = openai_api_url
     else:
         env, env_vars_display = _build_copilot_launch_env(
             port=port,
@@ -2563,6 +2580,7 @@ def copilot(
         anyllm_provider=anyllm_provider,
         region=region,
         openai_api_url=openai_api_url,
+        copilot_api_token=copilot_proxy_token,
     )
 
 

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -38,7 +38,12 @@ import click
 
 from headroom._version import __version__ as _HEADROOM_VERSION
 from headroom.copilot_auth import DEFAULT_API_URL as COPILOT_API_URL
-from headroom.copilot_auth import has_oauth_auth, resolve_client_bearer_token
+from headroom.copilot_auth import (
+    has_oauth_auth,
+    resolve_client_bearer_token,
+    resolve_copilot_api_url,
+    resolve_subscription_bearer_token,
+)
 from headroom.providers.aider import build_launch_env as _build_aider_launch_env
 from headroom.providers.claude import proxy_base_url as _claude_proxy_base_url
 from headroom.providers.codex import build_launch_env as _build_codex_launch_env
@@ -210,6 +215,8 @@ def _start_proxy(
     if agent_type != "unknown":
         proxy_env["HEADROOM_AGENT_TYPE"] = agent_type
         proxy_env.setdefault("HEADROOM_STACK", f"wrap_{agent_type}")
+    if openai_api_url:
+        proxy_env["OPENAI_TARGET_API_URL"] = openai_api_url
 
     proc = subprocess.Popen(
         cmd,
@@ -1343,6 +1350,16 @@ def _proxy_active_session_count(payload: dict[str, Any] | None) -> int:
     return max(counts, default=0)
 
 
+def _normalize_proxy_api_url(url: object) -> str | None:
+    """Normalize configured upstream URLs for running-proxy comparisons."""
+    if not isinstance(url, str):
+        return None
+    normalized = url.strip().rstrip("/")
+    if normalized.endswith("/v1"):
+        normalized = normalized[:-3]
+    return normalized or None
+
+
 def _proxy_version(payload: dict[str, Any] | None) -> str | None:
     """Return the running proxy version when it exposes one."""
     if payload is None:
@@ -1554,8 +1571,11 @@ def _should_use_copilot_oauth(
     backend: str | None,
     provider_type: str,
     env: dict[str, str],
+    force_subscription: bool = False,
 ) -> bool:
     """Prefer a reusable Copilot OAuth session when the requested routing supports it."""
+    if force_subscription:
+        return True
     if env.get("COPILOT_PROVIDER_API_KEY") or env.get("COPILOT_PROVIDER_BEARER_TOKEN"):
         return False
     if provider_type == "anthropic":
@@ -1669,10 +1689,20 @@ def _ensure_proxy(
                     missing.append("learn")
                 if code_graph and not running_config.get("code_graph"):
                     missing.append("code_graph")
+                if openai_api_url:
+                    running_openai_url = _normalize_proxy_api_url(
+                        running_config.get("openai_api_url")
+                    )
+                    requested_openai_url = _normalize_proxy_api_url(openai_api_url)
+                    if running_openai_url != requested_openai_url:
+                        missing.append("openai-api-url")
 
                 if missing:
                     needs_restart = True
-                    flags_str = ", ".join(f"--{f.replace('_', '-')}" for f in missing)
+                    flags_str = ", ".join(
+                        f if f.startswith("--") else f"--{f.replace('_', '-')}"
+                        for f in missing
+                    )
                     click.echo(f"  Proxy on port {port} is missing: {flags_str}")
                     click.echo("  Restarting proxy with upgraded configuration...")
 
@@ -2360,6 +2390,14 @@ def unwrap_claude(
     default=None,
     help="OpenAI-compatible Copilot wire API. Defaults to 'completions' when provider-type resolves to openai.",
 )
+@click.option(
+    "--subscription",
+    is_flag=True,
+    help=(
+        "Experimental: route GitHub-authenticated Copilot CLI traffic through Headroom "
+        "without requiring a provider API key."
+    ),
+)
 @click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
 @click.argument("copilot_args", nargs=-1, type=click.UNPROCESSED)
@@ -2372,6 +2410,7 @@ def copilot(
     region: str | None,
     provider_type: str,
     wire_api: str | None,
+    subscription: bool,
     memory: bool,
     verbose: bool,
     copilot_args: tuple[str, ...],
@@ -2389,6 +2428,7 @@ def copilot(
         headroom wrap copilot -- --model claude-sonnet-4-20250514
         headroom wrap copilot --backend anyllm --anyllm-provider groq -- --model gpt-4o
         headroom wrap copilot --provider-type openai --wire-api responses -- --model gpt-5.4
+        headroom wrap copilot --subscription -- --model gpt-4.1
         headroom wrap copilot --no-context-tool -- --prompt "explain this file"
     """
     copilot_bin = shutil.which("copilot")
@@ -2416,6 +2456,17 @@ def copilot(
         wire_api=wire_api,
         backend=effective_backend,
     )
+    if subscription:
+        if effective_backend not in (None, "", "anthropic"):
+            raise click.ClickException(
+                "--subscription routes to GitHub Copilot's hosted API and cannot be combined "
+                "with translated backends such as anyllm or litellm-*."
+            )
+        if provider_type == "anthropic":
+            raise click.ClickException(
+                "--subscription uses Copilot's OpenAI-compatible hosted API path; "
+                "do not combine it with --provider-type anthropic."
+            )
 
     if not no_rtk:
         if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
@@ -2434,11 +2485,16 @@ def copilot(
         backend=effective_backend,
         provider_type=provider_type,
         env=env,
+        force_subscription=subscription,
     ):
-        client_bearer = resolve_client_bearer_token()
+        client_bearer = (
+            resolve_subscription_bearer_token() if subscription else resolve_client_bearer_token()
+        )
         if not client_bearer:
             raise click.ClickException(
-                "GitHub Copilot auth was detected but no reusable bearer token could be resolved."
+                "GitHub Copilot subscription mode requires a reusable GitHub/Copilot bearer "
+                "token, but none could be resolved. Run `copilot auth login` first, or set "
+                "GITHUB_COPILOT_TOKEN / GITHUB_COPILOT_GITHUB_TOKEN."
             )
 
         effective_wire_api = wire_api or "completions"
@@ -2446,14 +2502,25 @@ def copilot(
         env["COPILOT_PROVIDER_BASE_URL"] = f"http://127.0.0.1:{port}/v1"
         env["COPILOT_PROVIDER_WIRE_API"] = effective_wire_api
         env["COPILOT_PROVIDER_BEARER_TOKEN"] = client_bearer
+        env["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] = "false"
         env.pop("COPILOT_PROVIDER_API_KEY", None)
         env_vars_display = [
             "COPILOT_PROVIDER_TYPE=openai",
             f"COPILOT_PROVIDER_BASE_URL=http://127.0.0.1:{port}/v1",
             f"COPILOT_PROVIDER_WIRE_API={effective_wire_api}",
-            "COPILOT_AUTH_MODE=github-oauth",
+            (
+                "COPILOT_AUTH_MODE=github-subscription-experimental"
+                if subscription
+                else "COPILOT_AUTH_MODE=github-oauth"
+            ),
         ]
-        openai_api_url = COPILOT_API_URL
+        openai_api_url = resolve_copilot_api_url(client_bearer)
+        env["GITHUB_COPILOT_API_URL"] = openai_api_url
+        env["OPENAI_TARGET_API_URL"] = openai_api_url
+        env_vars_display.append(f"COPILOT_PROVIDER_API_URL={openai_api_url}")
+        os.environ["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] = "false"
+        os.environ["GITHUB_COPILOT_API_URL"] = openai_api_url
+        os.environ["OPENAI_TARGET_API_URL"] = openai_api_url
     else:
         env, env_vars_display = _build_copilot_launch_env(
             port=port,
@@ -2475,7 +2542,7 @@ def copilot(
             )
             raise SystemExit(1)
 
-    if not _copilot_model_configured(copilot_args, env):
+    if not subscription and not _copilot_model_configured(copilot_args, env):
         click.echo(
             "  Note: Copilot BYOK requires a model. Pass `--model <name>` "
             "or set `COPILOT_MODEL` / `COPILOT_PROVIDER_MODEL_ID`."

--- a/headroom/copilot_auth.py
+++ b/headroom/copilot_auth.py
@@ -18,10 +18,14 @@ from urllib import error as urllib_error
 from urllib import request as urllib_request
 from urllib.parse import urlparse
 
+from headroom.copilot_linux_secret import read_copilot_oauth_token as read_linux_secret_token
+from headroom.copilot_macos_keychain import read_copilot_oauth_token as read_macos_keychain_token
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_API_URL = "https://api.githubcopilot.com"
 DEFAULT_TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
+DEFAULT_USER_INFO_URL = "https://api.github.com/copilot_internal/user"
 DEFAULT_GITHUB_HOST = "github.com"
 _TOKEN_EXPIRY_BUFFER_S = 60
 _DEFAULT_EDITOR_VERSION = "vscode/1.104.1"
@@ -31,11 +35,14 @@ _API_TOKEN_ENV_VARS = (
     "GITHUB_COPILOT_API_TOKEN",
     "COPILOT_PROVIDER_BEARER_TOKEN",
 )
-_OAUTH_TOKEN_ENV_VARS = (
+_COPILOT_OAUTH_TOKEN_ENV_VARS = (
     "GITHUB_COPILOT_GITHUB_TOKEN",
     "GITHUB_COPILOT_TOKEN",
-    "GITHUB_TOKEN",
     "COPILOT_GITHUB_TOKEN",
+)
+_GENERIC_GITHUB_TOKEN_ENV_VARS = (
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
 )
 _OAUTH_TOKEN_KEYS = (
     "oauth_token",
@@ -62,12 +69,26 @@ class CopilotAPIToken:
         return time.time() < (self.expires_at - _TOKEN_EXPIRY_BUFFER_S)
 
 
+@dataclass(frozen=True)
+class CopilotTokenCandidate:
+    """A discovered reusable token plus enough metadata to reason about trust."""
+
+    token: str
+    source: str
+    confidence: str
+    validate_for_subscription: bool = True
+
+
 def _github_host() -> str:
     return (os.environ.get("GITHUB_COPILOT_HOST") or DEFAULT_GITHUB_HOST).strip().lower()
 
 
 def _token_exchange_url() -> str:
     return os.environ.get("GITHUB_COPILOT_TOKEN_EXCHANGE_URL", DEFAULT_TOKEN_EXCHANGE_URL).strip()
+
+
+def _user_info_url() -> str:
+    return os.environ.get("GITHUB_COPILOT_USER_INFO_URL", DEFAULT_USER_INFO_URL).strip()
 
 
 def _should_exchange_oauth_token() -> bool:
@@ -117,6 +138,18 @@ def _read_gh_cli_oauth_token() -> str | None:
 
     token = result.stdout.strip()
     return token or None
+
+
+def _read_macos_keychain_oauth_token() -> str | None:
+    """Best-effort Copilot CLI token lookup from macOS Keychain."""
+
+    return read_macos_keychain_token(host=_github_host())
+
+
+def _read_linux_secret_oauth_token() -> str | None:
+    """Best-effort Copilot CLI token lookup from Linux Secret Service."""
+
+    return read_linux_secret_token(host=_github_host())
 
 
 def _read_windows_copilot_cli_oauth_token() -> str | None:
@@ -262,19 +295,87 @@ def _iter_file_entries(payload: Any) -> list[tuple[str, dict[str, Any]]]:
 def read_cached_oauth_token() -> str | None:
     """Return a GitHub OAuth token for Copilot, if one is available."""
 
-    for env_var in _OAUTH_TOKEN_ENV_VARS:
+    for candidate in iter_oauth_token_candidates():
+        return candidate.token
+    return None
+
+
+def iter_oauth_token_candidates() -> list[CopilotTokenCandidate]:
+    """Return reusable token candidates in safest-first discovery order."""
+
+    candidates: list[CopilotTokenCandidate] = []
+
+    for env_var in _COPILOT_OAUTH_TOKEN_ENV_VARS:
         token = os.environ.get(env_var, "").strip()
         if token:
-            return token
+            candidates.append(
+                CopilotTokenCandidate(
+                    token=token,
+                    source=f"env:{env_var}",
+                    confidence="explicit",
+                )
+            )
 
     windows_copilot_token = _read_windows_copilot_cli_oauth_token()
     if windows_copilot_token:
-        return windows_copilot_token
+        candidates.append(
+            CopilotTokenCandidate(
+                token=windows_copilot_token,
+                source="windows-credential-manager:copilot-cli",
+                confidence="high",
+            )
+        )
+
+    macos_copilot_token = _read_macos_keychain_oauth_token()
+    if macos_copilot_token:
+        candidates.append(
+            CopilotTokenCandidate(
+                token=macos_copilot_token,
+                source="macos-keychain:copilot-cli",
+                confidence="high",
+            )
+        )
+
+    linux_copilot_token = _read_linux_secret_oauth_token()
+    if linux_copilot_token:
+        candidates.append(
+            CopilotTokenCandidate(
+                token=linux_copilot_token,
+                source="linux-secret-service:copilot-cli",
+                confidence="high",
+            )
+        )
+
+    candidates.extend(_read_file_oauth_token_candidates())
+
+    for env_var in _GENERIC_GITHUB_TOKEN_ENV_VARS:
+        token = os.environ.get(env_var, "").strip()
+        if token:
+            candidates.append(
+                CopilotTokenCandidate(
+                    token=token,
+                    source=f"env:{env_var}",
+                    confidence="generic-github",
+                )
+            )
 
     gh_token = _read_gh_cli_oauth_token()
     if gh_token:
-        return gh_token
+        candidates.append(
+            CopilotTokenCandidate(
+                token=gh_token,
+                source="gh-cli",
+                confidence="generic-github",
+            )
+        )
 
+    return _dedupe_token_candidates(candidates)
+
+
+def _read_file_oauth_token_candidates() -> list[CopilotTokenCandidate]:
+    """Return token candidates from Copilot/GitHub credential files."""
+
+    candidates: list[CopilotTokenCandidate] = []
     host = _github_host()
     for path in _resolve_token_file_paths():
         try:
@@ -290,9 +391,28 @@ def read_cached_oauth_token() -> str | None:
                 continue
             cached_token = _extract_oauth_token(entry)
             if cached_token:
-                return cached_token
+                candidates.append(
+                    CopilotTokenCandidate(
+                        token=cached_token,
+                        source=f"file:{path}",
+                        confidence="medium",
+                    )
+                )
 
-    return None
+    return candidates
+
+
+def _dedupe_token_candidates(
+    candidates: list[CopilotTokenCandidate],
+) -> list[CopilotTokenCandidate]:
+    seen: set[str] = set()
+    deduped: list[CopilotTokenCandidate] = []
+    for candidate in candidates:
+        if candidate.token in seen:
+            continue
+        seen.add(candidate.token)
+        deduped.append(candidate)
+    return deduped
 
 
 def resolve_client_bearer_token() -> str | None:
@@ -303,6 +423,28 @@ def resolve_client_bearer_token() -> str | None:
         if token:
             return token
     return read_cached_oauth_token()
+
+
+def resolve_subscription_bearer_token() -> str | None:
+    """Return the first discovered token that GitHub accepts for Copilot subscription APIs."""
+
+    for env_var in _API_TOKEN_ENV_VARS:
+        token = os.environ.get(env_var, "").strip()
+        if token and _fetch_copilot_user_info(token) is not None:
+            return token
+
+    for candidate in iter_oauth_token_candidates():
+        if not candidate.validate_for_subscription:
+            continue
+        if _fetch_copilot_user_info(candidate.token) is not None:
+            logger.debug(
+                "Using Copilot subscription token from %s (%s)",
+                candidate.source,
+                candidate.confidence,
+            )
+            return candidate.token
+
+    return None
 
 
 def has_oauth_auth() -> bool:
@@ -329,6 +471,46 @@ def build_copilot_upstream_url(base_url: str, path: str) -> str:
     if is_copilot_api_url(normalized_base) and normalized_path.startswith("/v1/"):
         normalized_path = normalized_path[3:]
     return f"{normalized_base}{normalized_path}"
+
+
+def resolve_copilot_api_url(oauth_token: str | None = None) -> str:
+    """Return the Copilot API endpoint advertised for the current OAuth token."""
+
+    token = (oauth_token or read_cached_oauth_token() or "").strip()
+    if not token:
+        return os.environ.get("GITHUB_COPILOT_API_URL", DEFAULT_API_URL).strip() or DEFAULT_API_URL
+
+    payload = _fetch_copilot_user_info(token)
+    if payload is None:
+        return os.environ.get("GITHUB_COPILOT_API_URL", DEFAULT_API_URL).strip() or DEFAULT_API_URL
+
+    endpoints = payload.get("endpoints") if isinstance(payload, dict) else None
+    api_url = endpoints.get("api") if isinstance(endpoints, dict) else None
+    if isinstance(api_url, str) and api_url.strip():
+        return api_url.strip()
+    return os.environ.get("GITHUB_COPILOT_API_URL", DEFAULT_API_URL).strip() or DEFAULT_API_URL
+
+
+def _fetch_copilot_user_info(token: str) -> dict[str, Any] | None:
+    """Fetch Copilot account metadata for a reusable OAuth-style token."""
+
+    token = token.strip()
+    if not token:
+        return None
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    request = urllib_request.Request(_user_info_url(), headers=headers, method="GET")
+    try:
+        with urllib_request.urlopen(request, timeout=10.0) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:
+        logger.debug("Unable to resolve Copilot API URL from user info: %s", exc)
+        return None
+
+    return payload if isinstance(payload, dict) else None
 
 
 class CopilotTokenProvider:
@@ -377,7 +559,7 @@ class CopilotTokenProvider:
 
     async def _exchange_token(self, oauth_token: str) -> CopilotAPIToken:
         headers = {
-            "Authorization": f"token {oauth_token}",
+            "Authorization": f"Bearer {oauth_token}",
             "Accept": "application/json",
             "Editor-Version": os.environ.get(
                 "GITHUB_COPILOT_EDITOR_VERSION", _DEFAULT_EDITOR_VERSION

--- a/headroom/copilot_linux_secret.py
+++ b/headroom/copilot_linux_secret.py
@@ -1,0 +1,106 @@
+"""Linux secret-service lookup helpers for GitHub Copilot CLI auth."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def read_copilot_oauth_token(*, host: str = "github.com") -> str | None:
+    """Return a Copilot CLI OAuth token from Linux Secret Service, if available."""
+
+    if not sys.platform.startswith("linux"):
+        return None
+
+    secret_tool = os.environ.get("GITHUB_COPILOT_SECRET_TOOL", "secret-tool").strip()
+    if not secret_tool:
+        return None
+
+    normalized_host = host.strip().lower() or "github.com"
+    login = _read_copilot_config_login()
+    for command in _candidate_secret_tool_commands(secret_tool, normalized_host, login):
+        token = _run_secret_tool_lookup(command)
+        if token:
+            return token
+
+    return None
+
+
+def _read_copilot_config_login() -> str | None:
+    path = Path(os.environ.get("COPILOT_HOME", str(Path.home() / ".copilot"))) / "config.json"
+    try:
+        lines = [
+            line
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("//")
+        ]
+        payload = json.loads("\n".join(lines))
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    user = payload.get("lastLoggedInUser")
+    if not isinstance(user, dict):
+        return None
+    login = user.get("login")
+    return login.strip() if isinstance(login, str) and login.strip() else None
+
+
+def _candidate_secret_tool_commands(
+    secret_tool: str,
+    host: str,
+    login: str | None,
+) -> list[list[str]]:
+    commands: list[list[str]] = []
+    accounts = [
+        value
+        for value in (
+            f"https://{host}:{login}" if login else None,
+            f"{host}:{login}" if login else None,
+            login,
+            f"https://{host}",
+            host,
+        )
+        if value
+    ]
+    service_names = ("copilot-cli", "GitHub Copilot CLI", "github-copilot", "copilot")
+
+    for service in service_names:
+        commands.append([secret_tool, "lookup", "service", service])
+        commands.append([secret_tool, "lookup", "application", service])
+        for account in accounts:
+            commands.append([secret_tool, "lookup", "service", service, "account", account])
+            commands.append([secret_tool, "lookup", "application", service, "account", account])
+            commands.append([secret_tool, "lookup", "service", service, "username", account])
+
+    return commands
+
+
+def _run_secret_tool_lookup(command: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=5,
+        )
+    except OSError as exc:
+        logger.debug("Unable to invoke secret-tool for Copilot auth discovery: %s", exc)
+        return None
+    except subprocess.TimeoutExpired:
+        logger.debug("secret-tool lookup timed out for Copilot auth")
+        return None
+
+    if result.returncode != 0:
+        return None
+    token = result.stdout.strip()
+    return token or None

--- a/headroom/copilot_macos_keychain.py
+++ b/headroom/copilot_macos_keychain.py
@@ -1,0 +1,124 @@
+"""macOS Keychain lookup helpers for GitHub Copilot CLI auth."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def read_copilot_oauth_token(*, host: str = "github.com") -> str | None:
+    """Return a Copilot CLI OAuth token from macOS Keychain, if available."""
+
+    if sys.platform != "darwin":
+        return None
+
+    normalized_host = host.strip().lower() or "github.com"
+    login = _read_copilot_config_login()
+    services = _split_env_list("GITHUB_COPILOT_KEYCHAIN_SERVICE") or [
+        "GitHub Copilot",
+        "GitHub Copilot CLI",
+        "github-copilot",
+        "copilot",
+        "copilot-cli",
+        "GitHub CLI",
+        "github.com",
+        f"https://{normalized_host}",
+        normalized_host,
+    ]
+    accounts = _split_env_list("GITHUB_COPILOT_KEYCHAIN_ACCOUNT") or [
+        value
+        for value in (
+            f"https://{normalized_host}:{login}" if login else None,
+            f"{normalized_host}:{login}" if login else None,
+            login,
+            os.environ.get("USER"),
+            os.environ.get("USERNAME"),
+            normalized_host,
+            f"https://{normalized_host}",
+        )
+        if value
+    ]
+
+    for command in _candidate_security_commands(normalized_host, services, accounts):
+        token = _run_security_lookup(command)
+        if token:
+            return token
+
+    return None
+
+
+def _read_copilot_config_login() -> str | None:
+    """Return the last logged-in Copilot CLI username from ~/.copilot/config.json."""
+
+    path = Path(os.environ.get("COPILOT_HOME", str(Path.home() / ".copilot"))) / "config.json"
+    try:
+        lines = [
+            line
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("//")
+        ]
+        payload = json.loads("\n".join(lines))
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    user = payload.get("lastLoggedInUser")
+    if not isinstance(user, dict):
+        return None
+    login = user.get("login")
+    return login.strip() if isinstance(login, str) and login.strip() else None
+
+
+def _split_env_list(name: str) -> list[str]:
+    return [part.strip() for part in os.environ.get(name, "").split(",") if part.strip()]
+
+
+def _candidate_security_commands(
+    host: str,
+    services: list[str],
+    accounts: list[str],
+) -> list[list[str]]:
+    commands: list[list[str]] = []
+    for service in services:
+        commands.append(["security", "find-generic-password", "-s", service, "-w"])
+        for account in accounts:
+            commands.append(
+                ["security", "find-generic-password", "-s", service, "-a", account, "-w"]
+            )
+    for server in (host, f"https://{host}"):
+        commands.append(["security", "find-internet-password", "-s", server, "-w"])
+        for account in accounts:
+            commands.append(
+                ["security", "find-internet-password", "-s", server, "-a", account, "-w"]
+            )
+    return commands
+
+
+def _run_security_lookup(command: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=5,
+        )
+    except OSError as exc:
+        logger.debug("Unable to invoke macOS Keychain lookup for Copilot auth: %s", exc)
+        return None
+    except subprocess.TimeoutExpired:
+        logger.debug("macOS Keychain lookup timed out for Copilot auth")
+        return None
+
+    if result.returncode != 0:
+        return None
+    token = result.stdout.strip()
+    return token or None

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -1666,6 +1666,10 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                 "memory": config.memory_enabled,
                 "learn": config.traffic_learning_enabled,
                 "code_graph": config.code_graph_watcher,
+                "anthropic_api_url": config.anthropic_api_url,
+                "openai_api_url": config.openai_api_url,
+                "gemini_api_url": config.gemini_api_url,
+                "cloudcode_api_url": config.cloudcode_api_url,
                 "pid": os.getpid(),
             }
         return payload

--- a/tests/test_cli/test_wrap_copilot.py
+++ b/tests/test_cli/test_wrap_copilot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 import sys
 import types
 from pathlib import Path
@@ -253,6 +254,59 @@ def test_wrap_copilot_subscription_uses_github_auth_without_provider_key(
     assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "gho-existing"
     assert "COPILOT_PROVIDER_API_KEY" not in env
     assert captured["openai_api_url"] == DEFAULT_API_URL
+
+
+def test_wrap_copilot_subscription_pins_validated_token_for_proxy(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--subscription` must hand the *validated* token to the proxy.
+
+    The proxy honours ``GITHUB_COPILOT_API_TOKEN``; the wrapper passes the
+    resolved token as the ``copilot_api_token`` launch argument so the proxy
+    pins exactly it (rather than re-discovering a possibly different,
+    unvalidated token). The token rides the launch arg, never the child env or
+    the parent's global ``os.environ``. This guards the deterministic handoff.
+    """
+    _wrap_cli, main = wrap_modules
+    for var in ("COPILOT_PROVIDER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    business_api = "https://api.business.githubcopilot.com"
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    with (
+        patch("headroom.cli.wrap.shutil.which", return_value="copilot"),
+        patch(
+            "headroom.cli.wrap.resolve_subscription_bearer_token",
+            return_value="gho-validated",
+        ),
+        patch("headroom.cli.wrap.resolve_copilot_api_url", return_value=business_api),
+        patch("headroom.cli.wrap.has_oauth_auth", return_value=False),
+        patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool),
+    ):
+        result = runner.invoke(main, ["wrap", "copilot", "--subscription", "--no-rtk"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    # The validated token is handed to the proxy as an explicit launch
+    # argument — not via the child env, not via the parent's os.environ.
+    assert captured["copilot_api_token"] == "gho-validated"
+    assert "GITHUB_COPILOT_API_TOKEN" not in env
+    assert os.environ.get("GITHUB_COPILOT_API_TOKEN") is None
+    assert env["COPILOT_PROVIDER_TYPE"] == "openai"
+    assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "gho-validated"
+    assert env["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] == "false"
+    assert env["OPENAI_TARGET_API_URL"] == business_api
+    assert captured["openai_api_url"] == business_api
+    assert "COPILOT_PROVIDER_API_KEY" not in env
+    # The secret must never be echoed to the terminal.
+    assert "gho-validated" not in result.output
 
 
 def test_wrap_copilot_subscription_requires_reusable_auth(

--- a/tests/test_cli/test_wrap_copilot.py
+++ b/tests/test_cli/test_wrap_copilot.py
@@ -212,8 +212,92 @@ def test_wrap_copilot_prefers_existing_oauth_session(
     assert env["COPILOT_PROVIDER_BASE_URL"] == "http://127.0.0.1:8787/v1"
     assert env["COPILOT_PROVIDER_WIRE_API"] == "completions"
     assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "gho-existing"
+    assert env["GITHUB_COPILOT_API_URL"] == DEFAULT_API_URL
+    assert env["OPENAI_TARGET_API_URL"] == DEFAULT_API_URL
     assert "COPILOT_PROVIDER_API_KEY" not in env
     assert captured["openai_api_url"] == DEFAULT_API_URL
+    assert f"COPILOT_PROVIDER_API_URL={DEFAULT_API_URL}" in captured["env_vars_display"]
+
+
+def test_wrap_copilot_subscription_uses_github_auth_without_provider_key(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wrap_cli, main = wrap_modules
+    for var in ("COPILOT_PROVIDER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with (
+        patch("headroom.cli.wrap.shutil.which", return_value="copilot"),
+        patch("headroom.cli.wrap.resolve_subscription_bearer_token", return_value="gho-existing"),
+        patch("headroom.cli.wrap.has_oauth_auth", return_value=False),
+        patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool),
+    ):
+        result = runner.invoke(
+            main,
+            ["wrap", "copilot", "--subscription", "--no-rtk"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Copilot BYOK requires a model" not in result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["COPILOT_PROVIDER_TYPE"] == "openai"
+    assert env["COPILOT_PROVIDER_BASE_URL"] == "http://127.0.0.1:8787/v1"
+    assert env["COPILOT_PROVIDER_WIRE_API"] == "completions"
+    assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "gho-existing"
+    assert "COPILOT_PROVIDER_API_KEY" not in env
+    assert captured["openai_api_url"] == DEFAULT_API_URL
+
+
+def test_wrap_copilot_subscription_requires_reusable_auth(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+) -> None:
+    _wrap_cli, main = wrap_modules
+    with (
+        patch("headroom.cli.wrap.shutil.which", return_value="copilot"),
+        patch("headroom.cli.wrap.resolve_subscription_bearer_token", return_value=None),
+    ):
+        result = runner.invoke(main, ["wrap", "copilot", "--subscription", "--no-rtk"])
+
+    assert result.exit_code != 0
+    assert "subscription mode requires a reusable GitHub/Copilot bearer token" in result.output
+
+
+def test_wrap_copilot_subscription_rejects_translated_backend(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+) -> None:
+    _wrap_cli, main = wrap_modules
+    with patch("headroom.cli.wrap.shutil.which", return_value="copilot"):
+        result = runner.invoke(
+            main,
+            ["wrap", "copilot", "--subscription", "--backend", "anyllm", "--no-rtk"],
+        )
+
+    assert result.exit_code != 0
+    assert "cannot be combined with translated backends" in result.output
+
+
+def test_wrap_copilot_subscription_rejects_anthropic_provider_type(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+) -> None:
+    _wrap_cli, main = wrap_modules
+    with patch("headroom.cli.wrap.shutil.which", return_value="copilot"):
+        result = runner.invoke(
+            main,
+            ["wrap", "copilot", "--subscription", "--provider-type", "anthropic", "--no-rtk"],
+        )
+
+    assert result.exit_code != 0
+    assert "do not combine it with --provider-type anthropic" in result.output
 
 
 def test_wrap_copilot_translated_backend_still_requires_byok(

--- a/tests/test_cli/test_wrap_persistent.py
+++ b/tests/test_cli/test_wrap_persistent.py
@@ -206,6 +206,46 @@ def test_ensure_proxy_restarts_idle_stale_ephemeral_proxy(monkeypatch) -> None:
     assert calls[1][0] == "start"
 
 
+def test_ensure_proxy_restarts_ephemeral_proxy_for_openai_api_url_mismatch(monkeypatch) -> None:
+    calls: list[object] = []
+    health = {
+        "version": wrap_cli._HEADROOM_VERSION,
+        "runtime": {"websocket_sessions": {"active_sessions": 0, "active_relay_tasks": 0}},
+        "config": {
+            "pid": "12345",
+            "memory": False,
+            "learn": False,
+            "code_graph": False,
+            "openai_api_url": "https://api.githubcopilot.com",
+        },
+    }
+
+    monkeypatch.setattr(wrap_cli, "_find_persistent_manifest", lambda port: None)
+    monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: len(calls) == 0)
+    monkeypatch.setattr(wrap_cli, "_query_proxy_health", lambda port: health)
+    monkeypatch.setattr(
+        wrap_cli,
+        "_kill_proxy_by_pid",
+        lambda pid, port: calls.append(("kill", pid, port)) or True,
+    )
+    monkeypatch.setattr(
+        wrap_cli,
+        "_start_proxy",
+        lambda *args, **kwargs: calls.append(("start", args, kwargs)),
+    )
+
+    result = wrap_cli._ensure_proxy(
+        8787,
+        False,
+        openai_api_url="https://api.individual.githubcopilot.com",
+    )
+
+    assert result is None
+    assert calls[0] == ("kill", 12345, 8787)
+    assert calls[1][0] == "start"
+    assert calls[1][2]["openai_api_url"] == "https://api.individual.githubcopilot.com"
+
+
 def test_ensure_proxy_leaves_active_stale_ephemeral_proxy_running(monkeypatch) -> None:
     health = {
         "version": "0.0.1",

--- a/tests/test_codex_ws_compression_scheduler.py
+++ b/tests/test_codex_ws_compression_scheduler.py
@@ -245,7 +245,9 @@ def test_concurrent_compression_has_no_semaphore_tail() -> None:
       (≈27×) or (b) OS-level scheduler noise (≈2–3×). 4× sits
       comfortably between the two — catches the bug, tolerates
       hardware. (First iteration tried 5× with mixed sizes, which
-      let size-variance push CI ratios to 7.4×.)
+      let size-variance push CI ratios to 7.4×.) The ratio is only
+      enforced once p99 clears a scheduler-noise floor — on very fast
+      runners p50 rounds to 0ms and the ratio becomes pure jitter.
 
     Marked ``slow`` so a normal ``pytest`` run can skip it via
     ``-m 'not slow'``. CI matrix runs all marks.
@@ -300,9 +302,20 @@ def test_concurrent_compression_has_no_semaphore_tail() -> None:
 
     assert not errors, f"Got {len(errors)} errors; first: {errors[0].error}"
     ratio = p99 / max(p50, 1)
-    assert ratio < 4.0, (
+    # The p99/p50 ratio only signals contention when the tail is also
+    # *absolutely* large. On a fast/quiet runner p50 rounds toward 0ms, so the
+    # ratio collapses to "p99 in ms" and a few milliseconds of ordinary
+    # scheduler jitter reads as a spurious multiple (e.g. p50=0ms, p99=5ms →
+    # ~5×) that has nothing to do with the semaphore. The deleted semaphore
+    # produced a tail of *tens* of milliseconds (and ~27×); a healthy run keeps
+    # p99 in the single-digit-ms range regardless of ratio. So only treat a high
+    # ratio as a regression once p99 clears a scheduler-noise floor.
+    SEMAPHORE_TAIL_FLOOR_MS = 25.0
+    assert ratio < 4.0 or p99 < SEMAPHORE_TAIL_FLOOR_MS, (
         f"p99/p50 ratio is {ratio:.1f}× (p50={p50:.0f}ms, p99={p99:.0f}ms). "
-        f"Expected < 4× on uniform-size workload — a higher ratio means "
-        f"the semaphore-induced contention tail is back. Pre-fix baseline "
-        f"ratio on this same workload shape was ~27× regardless of CPU speed."
+        f"Expected < 4× on uniform-size workload once p99 clears the "
+        f"{SEMAPHORE_TAIL_FLOOR_MS:.0f}ms noise floor — a high ratio with a large "
+        f"absolute tail means the semaphore-induced contention tail is back. "
+        f"Pre-fix baseline ratio on this same workload shape was ~27× regardless "
+        f"of CPU speed."
     )

--- a/tests/test_copilot_auth.py
+++ b/tests/test_copilot_auth.py
@@ -75,9 +75,11 @@ def test_resolve_subscription_bearer_token_skips_invalid_generic_token(
     monkeypatch.setattr(
         copilot_auth,
         "_fetch_copilot_user_info",
-        lambda token: {"endpoints": {"api": "https://api.individual.githubcopilot.com"}}
-        if token == "gho-copilot"
-        else None,
+        lambda token: (
+            {"endpoints": {"api": "https://api.individual.githubcopilot.com"}}
+            if token == "gho-copilot"
+            else None
+        ),
     )
 
     assert copilot_auth.resolve_subscription_bearer_token() == "gho-copilot"

--- a/tests/test_copilot_auth.py
+++ b/tests/test_copilot_auth.py
@@ -17,6 +17,72 @@ def test_read_cached_oauth_token_prefers_env(monkeypatch: pytest.MonkeyPatch) ->
     assert copilot_auth.read_cached_oauth_token() == "gho-env"
 
 
+def test_read_cached_oauth_token_prefers_copilot_cli_before_generic_github_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp-generic")
+    monkeypatch.setattr(copilot_auth, "_read_windows_copilot_cli_oauth_token", lambda: None)
+    monkeypatch.setattr(copilot_auth, "_read_macos_keychain_oauth_token", lambda: "gho-keychain")
+    monkeypatch.setattr(copilot_auth, "_read_gh_cli_oauth_token", lambda: None)
+
+    assert copilot_auth.read_cached_oauth_token() == "gho-keychain"
+
+
+def test_iter_oauth_token_candidates_preserves_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp-generic")
+    monkeypatch.setattr(copilot_auth, "_read_windows_copilot_cli_oauth_token", lambda: None)
+    monkeypatch.setattr(copilot_auth, "_read_macos_keychain_oauth_token", lambda: "gho-keychain")
+    monkeypatch.setattr(copilot_auth, "_read_file_oauth_token_candidates", lambda: [])
+    monkeypatch.setattr(copilot_auth, "_read_gh_cli_oauth_token", lambda: None)
+
+    candidates = copilot_auth.iter_oauth_token_candidates()
+
+    assert [(candidate.source, candidate.token) for candidate in candidates] == [
+        ("macos-keychain:copilot-cli", "gho-keychain"),
+        ("env:GITHUB_TOKEN", "ghp-generic"),
+    ]
+
+
+def test_resolve_subscription_bearer_token_skips_invalid_generic_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_COPILOT_API_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_PROVIDER_BEARER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        copilot_auth,
+        "iter_oauth_token_candidates",
+        lambda: [
+            copilot_auth.CopilotTokenCandidate(
+                token="ghp-generic",
+                source="env:GITHUB_TOKEN",
+                confidence="generic-github",
+            ),
+            copilot_auth.CopilotTokenCandidate(
+                token="gho-copilot",
+                source="macos-keychain:copilot-cli",
+                confidence="high",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        copilot_auth,
+        "_fetch_copilot_user_info",
+        lambda token: {"endpoints": {"api": "https://api.individual.githubcopilot.com"}}
+        if token == "gho-copilot"
+        else None,
+    )
+
+    assert copilot_auth.resolve_subscription_bearer_token() == "gho-copilot"
+
+
 def test_should_exchange_oauth_token_supports_truthy_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -59,6 +125,7 @@ def test_read_cached_oauth_token_falls_back_to_gh_cli(monkeypatch: pytest.Monkey
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
     monkeypatch.setattr(copilot_auth, "_read_windows_copilot_cli_oauth_token", lambda: None)
+    monkeypatch.setattr(copilot_auth, "_read_macos_keychain_oauth_token", lambda: None)
     monkeypatch.setattr(copilot_auth, "_read_gh_cli_oauth_token", lambda: "gho-gh-cli")
 
     assert copilot_auth.read_cached_oauth_token() == "gho-gh-cli"
@@ -79,6 +146,35 @@ def test_read_cached_oauth_token_prefers_copilot_cli_windows_token(
     assert copilot_auth.read_cached_oauth_token() == "gho-copilot"
 
 
+def test_read_cached_oauth_token_prefers_macos_keychain_before_gh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(copilot_auth, "_read_windows_copilot_cli_oauth_token", lambda: None)
+    monkeypatch.setattr(copilot_auth, "_read_macos_keychain_oauth_token", lambda: "gho-keychain")
+    monkeypatch.setattr(copilot_auth, "_read_gh_cli_oauth_token", lambda: "gho-gh-cli")
+
+    assert copilot_auth.read_cached_oauth_token() == "gho-keychain"
+
+
+def test_read_macos_keychain_oauth_token_uses_security(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_read(*, host: str) -> str:
+        calls.append(host)
+        return "gho-keychain"
+
+    monkeypatch.setattr(copilot_auth, "read_macos_keychain_token", fake_read)
+    assert copilot_auth._read_macos_keychain_oauth_token() == "gho-keychain"
+    assert calls == ["github.com"]
+
+
 def test_read_cached_oauth_token_reads_hosts_file(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -97,6 +193,7 @@ def test_read_cached_oauth_token_reads_hosts_file(
     monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
     monkeypatch.setenv("GITHUB_COPILOT_TOKEN_FILE", str(hosts))
     monkeypatch.setattr(copilot_auth, "_read_windows_copilot_cli_oauth_token", lambda: None)
+    monkeypatch.setattr(copilot_auth, "_read_macos_keychain_oauth_token", lambda: None)
     monkeypatch.setattr(copilot_auth, "_read_gh_cli_oauth_token", lambda: None)
 
     assert copilot_auth.read_cached_oauth_token() == "gho-file"
@@ -112,6 +209,7 @@ def test_read_cached_oauth_token_skips_expired_entries(
     )
     monkeypatch.setenv("GITHUB_COPILOT_TOKEN_FILE", str(hosts))
     monkeypatch.setattr(copilot_auth, "_read_windows_copilot_cli_oauth_token", lambda: None)
+    monkeypatch.setattr(copilot_auth, "_read_macos_keychain_oauth_token", lambda: None)
     monkeypatch.setattr(copilot_auth, "_read_gh_cli_oauth_token", lambda: None)
 
     assert copilot_auth.read_cached_oauth_token() is None

--- a/tests/test_copilot_linux_secret.py
+++ b/tests/test_copilot_linux_secret.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from headroom import copilot_linux_secret
+
+
+def test_read_copilot_oauth_token_uses_secret_tool(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):  # noqa: ANN001, ANN003
+        calls.append(command)
+        assert kwargs["capture_output"] is True
+        return SimpleNamespace(returncode=0, stdout="gho-secret\n")
+
+    monkeypatch.setattr(copilot_linux_secret.sys, "platform", "linux")
+    monkeypatch.setattr(copilot_linux_secret, "_read_copilot_config_login", lambda: "octo")
+    monkeypatch.setattr(copilot_linux_secret.subprocess, "run", fake_run)
+
+    assert copilot_linux_secret.read_copilot_oauth_token(host="github.com") == "gho-secret"
+    assert calls[0] == ["secret-tool", "lookup", "service", "copilot-cli"]
+
+
+def test_read_copilot_oauth_token_returns_none_off_linux(monkeypatch) -> None:
+    monkeypatch.setattr(copilot_linux_secret.sys, "platform", "darwin")
+
+    assert copilot_linux_secret.read_copilot_oauth_token() is None
+
+
+def test_candidate_secret_tool_commands_include_login_specific_lookup() -> None:
+    commands = copilot_linux_secret._candidate_secret_tool_commands(
+        "secret-tool",
+        "github.com",
+        "octo",
+    )
+
+    assert [
+        "secret-tool",
+        "lookup",
+        "service",
+        "copilot-cli",
+        "account",
+        "https://github.com:octo",
+    ] in commands
+
+
+def test_read_copilot_oauth_token_tries_until_match(monkeypatch) -> None:
+    expected = [
+        "secret-tool",
+        "lookup",
+        "service",
+        "copilot-cli",
+        "account",
+        "https://github.com:octo",
+    ]
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):  # noqa: ANN001, ANN003
+        calls.append(command)
+        stdout = "gho-secret\n" if command == expected else ""
+        return SimpleNamespace(returncode=0, stdout=stdout)
+
+    monkeypatch.setattr(copilot_linux_secret.sys, "platform", "linux")
+    monkeypatch.setattr(copilot_linux_secret, "_read_copilot_config_login", lambda: "octo")
+    monkeypatch.setattr(copilot_linux_secret.subprocess, "run", fake_run)
+
+    assert copilot_linux_secret.read_copilot_oauth_token(host="github.com") == "gho-secret"
+    assert expected in calls

--- a/tests/test_copilot_macos_keychain.py
+++ b/tests/test_copilot_macos_keychain.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from headroom import copilot_macos_keychain
+
+
+def test_read_copilot_oauth_token_uses_security(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        calls.append(command)
+        assert kwargs["capture_output"] is True
+        assert kwargs["timeout"] == 5
+        return SimpleNamespace(returncode=0, stdout="gho-keychain\n")
+
+    monkeypatch.setattr(copilot_macos_keychain.sys, "platform", "darwin")
+    monkeypatch.setenv("GITHUB_COPILOT_KEYCHAIN_SERVICE", "GitHub Copilot")
+    monkeypatch.setenv("GITHUB_COPILOT_KEYCHAIN_ACCOUNT", "chopratejas")
+    monkeypatch.setattr(copilot_macos_keychain.subprocess, "run", fake_run)
+
+    assert copilot_macos_keychain.read_copilot_oauth_token(host="github.com") == "gho-keychain"
+    assert calls[0] == ["security", "find-generic-password", "-s", "GitHub Copilot", "-w"]
+
+
+def test_read_copilot_oauth_token_returns_none_off_macos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(copilot_macos_keychain.sys, "platform", "linux")
+
+    assert copilot_macos_keychain.read_copilot_oauth_token() is None
+
+
+def test_candidate_security_commands_include_account_specific_lookup() -> None:
+    commands = copilot_macos_keychain._candidate_security_commands(
+        "github.com",
+        ["GitHub Copilot"],
+        ["chopratejas"],
+    )
+
+    assert ["security", "find-generic-password", "-s", "GitHub Copilot", "-w"] in commands
+    assert [
+        "security",
+        "find-generic-password",
+        "-s",
+        "GitHub Copilot",
+        "-a",
+        "chopratejas",
+        "-w",
+    ] in commands
+
+
+def test_read_copilot_oauth_token_tries_copilot_cli_host_login_account(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    calls: list[list[str]] = []
+    copilot_home = tmp_path / ".copilot"
+    copilot_home.mkdir()
+    (copilot_home / "config.json").write_text(
+        '{"lastLoggedInUser":{"host":"https://github.com","login":"chopratejas"}}',
+        encoding="utf-8",
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> object:
+        calls.append(command)
+        stdout = "gho-keychain\n" if command == expected else ""
+        return type("CompletedProcess", (), {"returncode": 0 if stdout else 44, "stdout": stdout})()
+
+    expected = [
+        "security",
+        "find-generic-password",
+        "-s",
+        "copilot-cli",
+        "-a",
+        "https://github.com:chopratejas",
+        "-w",
+    ]
+    monkeypatch.setattr(copilot_macos_keychain.sys, "platform", "darwin")
+    monkeypatch.setenv("COPILOT_HOME", str(copilot_home))
+    monkeypatch.delenv("GITHUB_COPILOT_KEYCHAIN_SERVICE", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_KEYCHAIN_ACCOUNT", raising=False)
+    monkeypatch.setattr(copilot_macos_keychain.subprocess, "run", fake_run)
+
+    assert copilot_macos_keychain.read_copilot_oauth_token(host="github.com") == "gho-keychain"
+    assert expected in calls

--- a/tests/test_copilot_subscription_smoke.py
+++ b/tests/test_copilot_subscription_smoke.py
@@ -1,0 +1,199 @@
+"""Cross-platform smoke test for GitHub Copilot subscription routing.
+
+The subscription flow has to behave identically on macOS, Linux, and Windows
+(and in headless Docker/CI), but the only OS-specific part — reading the
+Copilot CLI token from the platform secret store — is impossible to exercise
+portably. This suite proves the *portable* contract instead:
+
+1. With an explicit token in the environment, resolution + API-URL discovery
+   succeed on every platform without touching any secret store. This is the
+   universal escape hatch (``GITHUB_COPILOT_TOKEN`` etc.) that makes the
+   feature work anywhere, including headless CI.
+2. Each OS-specific secret reader is inert on a foreign platform — so on any
+   given OS only that OS's reader can fire, and a missing/foreign secret store
+   degrades to ``None`` rather than crashing.
+3. The proxy injects exactly the token the wrapper validated (the
+   deterministic-handoff fix), never a different discoverable one.
+4. The full wrapper→proxy chain carries one consistent token end to end.
+
+Everything here is hermetic: no Keychain, no ``secret-tool``, no Credential
+Manager, no network. It runs the same on every OS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from headroom import copilot_auth, copilot_linux_secret, copilot_macos_keychain
+
+BUSINESS_API = "https://api.business.githubcopilot.com"
+
+
+def _stub_all_secret_stores(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate 'no OS secret store / not logged in' on every platform."""
+    monkeypatch.setattr(copilot_auth, "_read_windows_copilot_cli_oauth_token", lambda: None)
+    monkeypatch.setattr(copilot_auth, "_read_macos_keychain_oauth_token", lambda: None)
+    monkeypatch.setattr(copilot_auth, "_read_linux_secret_oauth_token", lambda: None)
+    monkeypatch.setattr(copilot_auth, "_read_file_oauth_token_candidates", lambda: [])
+    monkeypatch.setattr(copilot_auth, "_read_gh_cli_oauth_token", lambda: None)
+
+
+def _clear_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        *copilot_auth._COPILOT_OAUTH_TOKEN_ENV_VARS,
+        *copilot_auth._GENERIC_GITHUB_TOKEN_ENV_VARS,
+        *copilot_auth._API_TOKEN_ENV_VARS,
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# 1. The env-var path resolves on any platform with no secret store.
+# ---------------------------------------------------------------------------
+def test_env_token_resolves_subscription_without_secret_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_all_secret_stores(monkeypatch)
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN", "gho-env-universal")
+    monkeypatch.setattr(
+        copilot_auth,
+        "_fetch_copilot_user_info",
+        lambda token: (
+            {"endpoints": {"api": BUSINESS_API}} if token == "gho-env-universal" else None
+        ),
+    )
+
+    assert copilot_auth.resolve_subscription_bearer_token() == "gho-env-universal"
+    assert copilot_auth.resolve_copilot_api_url("gho-env-universal") == BUSINESS_API
+
+
+def test_api_url_falls_back_to_default_when_user_info_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_token_env(monkeypatch)
+    monkeypatch.delenv("GITHUB_COPILOT_API_URL", raising=False)
+    monkeypatch.setattr(copilot_auth, "_fetch_copilot_user_info", lambda token: None)
+
+    # No network / no endpoints advertised → safe default, never a crash.
+    assert copilot_auth.resolve_copilot_api_url("gho-anything") == copilot_auth.DEFAULT_API_URL
+
+
+def test_subscription_rejects_token_github_does_not_accept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_all_secret_stores(monkeypatch)
+    _clear_token_env(monkeypatch)
+    # A generic GitHub token is present but GitHub's Copilot API rejects it;
+    # a valid Copilot token is discoverable behind it.
+    monkeypatch.setattr(
+        copilot_auth,
+        "iter_oauth_token_candidates",
+        lambda: [
+            copilot_auth.CopilotTokenCandidate(
+                token="ghp-generic-pat", source="env:GITHUB_TOKEN", confidence="generic-github"
+            ),
+            copilot_auth.CopilotTokenCandidate(
+                token="gho-real-copilot",
+                source="macos-keychain:copilot-cli",
+                confidence="high",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        copilot_auth,
+        "_fetch_copilot_user_info",
+        lambda token: {"endpoints": {"api": BUSINESS_API}} if token == "gho-real-copilot" else None,
+    )
+
+    assert copilot_auth.resolve_subscription_bearer_token() == "gho-real-copilot"
+
+
+# ---------------------------------------------------------------------------
+# 2. Each OS reader is inert on a foreign platform.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("foreign_platform", ["linux", "win32"])
+def test_macos_reader_noop_off_darwin(
+    monkeypatch: pytest.MonkeyPatch, foreign_platform: str
+) -> None:
+    monkeypatch.setattr(copilot_macos_keychain.sys, "platform", foreign_platform)
+    assert copilot_macos_keychain.read_copilot_oauth_token(host="github.com") is None
+
+
+@pytest.mark.parametrize("foreign_platform", ["darwin", "win32"])
+def test_linux_reader_noop_off_linux(
+    monkeypatch: pytest.MonkeyPatch, foreign_platform: str
+) -> None:
+    monkeypatch.setattr(copilot_linux_secret.sys, "platform", foreign_platform)
+    assert copilot_linux_secret.read_copilot_oauth_token(host="github.com") is None
+
+
+def test_windows_reader_noop_off_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(copilot_auth.os, "name", "posix")
+    assert copilot_auth._read_windows_copilot_cli_oauth_token() is None
+
+
+# ---------------------------------------------------------------------------
+# 3. The proxy injects exactly the wrapper-validated token (determinism).
+# ---------------------------------------------------------------------------
+def test_proxy_injects_explicit_token_over_discovered_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Reset the cached module-level provider so this test is self-contained.
+    monkeypatch.setattr(copilot_auth, "_provider", None)
+    # What `wrap copilot --subscription` exports for the proxy:
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "gho-validated")
+    monkeypatch.setenv("GITHUB_COPILOT_API_URL", BUSINESS_API)
+    monkeypatch.setenv("GITHUB_COPILOT_USE_TOKEN_EXCHANGE", "false")
+    # A *different* token is discoverable — it must be ignored entirely.
+    monkeypatch.setattr(
+        copilot_auth, "read_cached_oauth_token", lambda: "gho-WRONG-should-not-be-used"
+    )
+
+    headers = asyncio.run(
+        copilot_auth.apply_copilot_api_auth(
+            {"authorization": "Bearer placeholder"},
+            url=f"{BUSINESS_API}/v1/chat/completions",
+        )
+    )
+
+    assert headers["Authorization"] == "Bearer gho-validated"
+    assert "authorization" not in headers
+
+
+# ---------------------------------------------------------------------------
+# 4. Full wrapper→proxy chain carries one consistent token, any account host.
+# ---------------------------------------------------------------------------
+def test_end_to_end_subscription_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(copilot_auth, "_provider", None)
+
+    # (a) wrapper side: resolve + validate the subscription token, then
+    #     discover the account-specific API endpoint.
+    _stub_all_secret_stores(monkeypatch)
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN", "gho-seat-token")
+    monkeypatch.setattr(
+        copilot_auth,
+        "_fetch_copilot_user_info",
+        lambda token: {"endpoints": {"api": BUSINESS_API}} if token == "gho-seat-token" else None,
+    )
+    resolved_token = copilot_auth.resolve_subscription_bearer_token()
+    resolved_url = copilot_auth.resolve_copilot_api_url(resolved_token)
+    assert resolved_token == "gho-seat-token"
+    assert resolved_url == BUSINESS_API
+
+    # (b) hand-off: the wrapper exports exactly these for the proxy.
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", resolved_token)
+    monkeypatch.setenv("GITHUB_COPILOT_API_URL", resolved_url)
+
+    # (c) proxy side: build the upstream URL (Copilot has no /v1 prefix) and
+    #     inject the same token onto the outbound request.
+    upstream = copilot_auth.build_copilot_upstream_url(resolved_url, "/v1/chat/completions")
+    assert upstream == "https://api.business.githubcopilot.com/chat/completions"
+
+    headers = asyncio.run(
+        copilot_auth.apply_copilot_api_auth({"authorization": "Bearer placeholder"}, url=upstream)
+    )
+    assert headers["Authorization"] == f"Bearer {resolved_token}"


### PR DESCRIPTION
## Summary

Adds **GitHub Copilot subscription mode** to `headroom wrap copilot`:

```bash
headroom wrap copilot --subscription -- --model gpt-4o -p "…"
```

This lets anyone with a **Copilot subscription** run the Copilot CLI through
Headroom — so their context gets compressed — **without bringing a separate
Anthropic/OpenAI API key**. It uses the Copilot seat they already pay GitHub for.

## How it works

The Copilot CLI's only interposition hook is its provider-override (the "BYOK
transport"). So Headroom uses that knob, but instead of a third-party key it
supplies the user's **own subscription token** (discovered from the OS secret
store, validated against GitHub) and points the proxy back at **GitHub's own
Copilot API** (`https://api.*.githubcopilot.com`). Net result: it's the user's
subscription — just compressed. (The CLI still labels it "BYOK" and requires an
explicit `--model`; that's an artifact of the only knob it exposes, not economic
BYOK.)

Unlike `wrap claude` (where `ANTHROPIC_BASE_URL` is a transparent override that
preserves the CLI's own auth), Copilot's override *strips* auth — which is why
Headroom must read and re-inject the subscription token.

## What's in this PR

- **`--subscription` flag** on `wrap copilot` + token discovery
  (`copilot_auth.py`, `copilot_macos_keychain.py`, `copilot_linux_secret.py`,
  Windows Credential Manager), GitHub validation, and account-API-URL resolution.
- **Deterministic token handoff (review fix):** the wrapper-validated token is
  passed to the proxy as an **explicit launch argument** (`copilot_api_token` →
  `GITHUB_COPILOT_API_TOKEN` in the proxy subprocess), instead of mutating the
  parent process's global `os.environ`. Previously the proxy re-ran *unvalidated*
  discovery and could inject a different token (→ environment-dependent 401s).
  This also removed the global-state mutation and the test-isolation it forced.
- **Hermetic cross-platform smoke suite** (`tests/test_copilot_subscription_smoke.py`):
  proves the env-var token path resolves on any OS, each OS secret reader is
  inert off-platform, and the proxy injects exactly the validated token — no
  Keychain/`secret-tool`/network required.
- **Testing guide + issue template** for cross-platform verification
  (`TESTING-copilot-subscription.md`, `.github/ISSUE_TEMPLATE/`).

## Status / verification

| Platform | Mechanism (compress + forward) | Token auto-discovery |
|----------|:---:|:---:|
| macOS (Keychain `copilot-cli`) | ✅ verified end-to-end | ✅ verified |
| Linux (`secret-tool`/libsecret) | ✅ expected | ❓ **needs testing** |
| Windows (Credential Manager) | ✅ expected | ❓ **needs testing** |
| Any OS via `GITHUB_COPILOT_TOKEN` | ✅ test-covered | n/a (fallback) |

- macOS was confirmed live: traffic forwarded to `api.individual.githubcopilot.com`
  with the subscription token, body compressed, real completion returned.
- The **token handoff is OS-independent**; only the **secret-store discovery** is
  OS-specific and unverified on Linux/Windows. `GITHUB_COPILOT_TOKEN` is the
  guaranteed fallback everywhere.

## Known limitations / follow-ups

- **No native Windows wheel** in the release matrix yet, so native Windows
  auto-discovery isn't fully testable via `pip` (Docker/WSL2 cover the
  *mechanism*). Adding `windows-latest` to the wheel matrix is a planned
  follow-up.
- **Docker-native install cannot auto-discover** host secret-store tokens (a
  container can't read the host Keychain/Credential Manager) — pass
  `GITHUB_COPILOT_TOKEN` in that model.

## Help us test 🙏

If you have a Copilot subscription on **Linux or Windows**, please follow
[`TESTING-copilot-subscription.md`](https://github.com/chopratejas/headroom/blob/fix/copilot-subscription-auth/TESTING-copilot-subscription.md)
and file a report via the **Copilot Subscription Test Report** issue template.
We especially need the token **storage schema** if auto-discovery fails.

## Testing

- [x] Unit/smoke tests pass (`tests/test_copilot_*`, `tests/test_cli/test_wrap_copilot.py`)
- [x] `ruff check` / `ruff format` clean
- [x] `mypy headroom/cli/wrap.py` clean
- [x] Manual end-to-end on macOS (subscription token → compressed → GitHub Copilot API)
