### PR TITLE
Issue 561 anthropic api url

### DIFF
--- a/docs/content/docs/proxy.mdx
+++ b/docs/content/docs/proxy.mdx
@@ -249,7 +249,13 @@ OPENROUTER_API_KEY=sk-or-... headroom proxy --backend openrouter
 export HEADROOM_HOST=0.0.0.0
 export HEADROOM_PORT=8787
 export HEADROOM_BUDGET=100.0
+
+# Route OpenAI passthrough requests to a custom endpoint
 export OPENAI_TARGET_API_URL=https://custom.openai.endpoint.com
+
+# Route Anthropic passthrough requests to a custom endpoint
+export ANTHROPIC_TARGET_API_URL=https://litellm.company.internal
+
 headroom proxy
 ```
 

--- a/wiki/proxy.md
+++ b/wiki/proxy.md
@@ -379,7 +379,13 @@ headroom_latency_ms_sum
 export HEADROOM_HOST=0.0.0.0
 export HEADROOM_PORT=8787
 export HEADROOM_BUDGET=100.0
+
+# Route OpenAI passthrough requests to a custom endpoint
 export OPENAI_TARGET_API_URL=https://custom.openai.endpoint.com
+
+# Route Anthropic passthrough requests to a custom endpoint
+export ANTHROPIC_TARGET_API_URL=https://litellm.company.internal
+
 headroom proxy
 ```
 

--- a/wiki/proxy.md
+++ b/wiki/proxy.md
@@ -76,6 +76,7 @@ When configured, Headroom emits OTLP traces for the shared compression pipeline 
 | `--budget` | None | Daily budget limit in USD |
 | `--code-aware` | true | Enable AST-based code compression (env: HEADROOM_CODE_AWARE_ENABLED) |
 | `--no-code-aware` | false | Disable code-aware compression |
+| `--anthropic-api-url` | `https://api.anthropic.com` | Custom Anthropic API URL endpoint |
 | `--openai-api-url` | `https://api.openai.com` | Custom OpenAI API URL endpoint |
 
 ### Run Modes


### PR DESCRIPTION
## Description

Adds documentation for Anthropic upstream URL overrides in the proxy documentation.

Issue #561 highlighted that Anthropic-compatible upstream configuration is not easily discoverable, despite existing support for:

--anthropic-api-url
ANTHROPIC_TARGET_API_URL

This PR improves documentation by surfacing these options alongside the existing OpenAI examples.


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

Added ANTHROPIC_TARGET_API_URL examples to proxy configuration documentation
Added documentation for --anthropic-api-url in wiki/proxy.md
Updated configuration examples to show Anthropic and OpenAI upstream URL overrides together


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable


## Additional Notes

No functional changes.

