### PR TITLE
fix(proxy): capture Codex rate-limit headers on streaming SSE and WebSocket transports

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -4087,9 +4087,7 @@ class OpenAIHandlerMixin:
                         # here must never break the proxied session.
                         try:
                             _ws_handshake_resp = getattr(upstream, "response", None)
-                            _ws_handshake_headers = getattr(
-                                _ws_handshake_resp, "headers", None
-                            )
+                            _ws_handshake_headers = getattr(_ws_handshake_resp, "headers", None)
                             if _ws_handshake_headers is not None:
                                 from headroom.subscription.codex_rate_limits import (
                                     get_codex_rate_limit_state,
@@ -4105,9 +4103,7 @@ class OpenAIHandlerMixin:
                                 # WS path. ``raw_items()`` yields every (name, value)
                                 # pair without raising; ``.items()`` is the fallback
                                 # for plain-dict shapes (e.g. older clients / tests).
-                                _hs_iter = getattr(
-                                    _ws_handshake_headers, "raw_items", None
-                                )
+                                _hs_iter = getattr(_ws_handshake_headers, "raw_items", None)
                                 _hs_pairs = (
                                     _hs_iter()
                                     if callable(_hs_iter)

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -4075,6 +4075,54 @@ class OpenAIHandlerMixin:
                             )
                             _upstream_connect_recorded = True
                             _upstream_first_event_started = time.perf_counter()
+
+                        # Capture Codex rate-limit window data from the upstream
+                        # WebSocket handshake response headers. The Responses WS
+                        # transport (Codex gpt-5.4+) is the common path for newer
+                        # Codex, and these ``x-codex-*`` headers are the only place
+                        # session/weekly usage is reported — without this they
+                        # never reach ``/stats`` or the dashboard on the WS path.
+                        # Access is defensive: the handshake-response shape varies
+                        # across ``websockets`` client versions, so any failure
+                        # here must never break the proxied session.
+                        try:
+                            _ws_handshake_resp = getattr(upstream, "response", None)
+                            _ws_handshake_headers = getattr(
+                                _ws_handshake_resp, "headers", None
+                            )
+                            if _ws_handshake_headers is not None:
+                                from headroom.subscription.codex_rate_limits import (
+                                    get_codex_rate_limit_state,
+                                )
+
+                                # Prefer ``raw_items()``: the ``websockets``
+                                # ``Headers.items()`` raises ``MultipleValuesError``
+                                # if the handshake response carries any duplicate
+                                # header (chatgpt.com routinely returns multiple
+                                # ``set-cookie`` headers), which would otherwise send
+                                # the whole capture into the ``except`` below and
+                                # leave ``/stats`` stale — defeating this fix on the
+                                # WS path. ``raw_items()`` yields every (name, value)
+                                # pair without raising; ``.items()`` is the fallback
+                                # for plain-dict shapes (e.g. older clients / tests).
+                                _hs_iter = getattr(
+                                    _ws_handshake_headers, "raw_items", None
+                                )
+                                _hs_pairs = (
+                                    _hs_iter()
+                                    if callable(_hs_iter)
+                                    else _ws_handshake_headers.items()
+                                )
+                                get_codex_rate_limit_state().update_from_headers(
+                                    {str(k).lower(): str(v) for k, v in _hs_pairs}
+                                )
+                        except Exception as _ws_rl_err:  # pragma: no cover - defensive
+                            logger.debug(
+                                "[%s] WS: failed to capture Codex rate-limit headers: %r",
+                                request_id,
+                                _ws_rl_err,
+                            )
+
                         await upstream.send(first_msg_raw)
 
                         # Unit 3: flag the upstream side flips on seeing

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -967,6 +967,22 @@ class StreamingMixin:
 
             return StreamingResponse(_error_gen(), media_type="text/event-stream")
 
+        # Capture Codex rate-limit window data from the upstream response
+        # headers, for *every* status. Codex (gpt-5.x) almost always streams, so
+        # without this the session/weekly windows surfaced in ``/stats`` and the
+        # dashboard would only refresh on the rare non-streaming reply. We do this
+        # *before* the error early-return below so a streaming 429/5xx — the moment
+        # usage is most relevant — still refreshes the windows, matching the
+        # non-streaming HTTP handlers which capture on all statuses.
+        # ``update_from_headers`` is a no-op when the response carries no
+        # ``x-codex-*`` headers (e.g. the Anthropic streaming path), so this is
+        # safe to call unconditionally.
+        from headroom.subscription.codex_rate_limits import (
+            get_codex_rate_limit_state,
+        )
+
+        get_codex_rate_limit_state().update_from_headers(dict(upstream_response.headers))
+
         if upstream_response.status_code >= 400:
             logger.warning(
                 "[%s] Forwarding upstream streaming error status=%s url=%s",
@@ -1050,9 +1066,15 @@ class StreamingMixin:
                 headers=response_headers,
             )
 
-        # Forward upstream ratelimit headers to the client
+        # Forward upstream rate-limit headers to the client. We pass both the
+        # generic ``*ratelimit*`` headers (Anthropic) and Codex's ``x-codex-*``
+        # window/credit headers — the latter do not contain the ``ratelimit``
+        # substring, so without the second clause the Codex CLI's own
+        # session/weekly display would stop updating on the streaming path.
         forwarded_headers = {
-            k: v for k, v in upstream_response.headers.items() if "ratelimit" in k.lower()
+            k: v
+            for k, v in upstream_response.headers.items()
+            if "ratelimit" in k.lower() or k.lower().startswith("x-codex")
         }
 
         async def generate():

--- a/tests/test_openai_codex_ws_lifecycle.py
+++ b/tests/test_openai_codex_ws_lifecycle.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from websockets.datastructures import Headers
 
 from headroom.proxy.handlers.openai import OpenAIHandlerMixin
 from headroom.proxy.helpers import COMPRESSION_TIMEOUT_SECONDS
@@ -235,6 +236,25 @@ def _first_frame() -> str:
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_codex_rate_limit_singleton():
+    """Isolate the process-global CodexRateLimitState across tests.
+
+    The tracker is a module singleton, so a snapshot captured by one test
+    would otherwise leak into the next (and is order-dependent under
+    pytest-randomly). Save/restore ``_latest`` around every test.
+    """
+    from headroom.subscription.codex_rate_limits import get_codex_rate_limit_state
+
+    state = get_codex_rate_limit_state()
+    saved = state._latest
+    state._latest = None
+    try:
+        yield
+    finally:
+        state._latest = saved
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -339,6 +359,93 @@ async def test_ws_session_metrics_include_response_completed_usage():
     assert recorded["cache_read_tokens"] == 75
     assert recorded["cache_write_tokens"] == 25
     assert recorded["uncached_input_tokens"] == 25
+
+
+@pytest.mark.asyncio
+async def test_ws_captures_codex_rate_limit_headers_from_handshake():
+    """Codex WS handshake response headers must refresh the rate-limit state.
+
+    Newer Codex (gpt-5.4+) speaks WebSocket, and the ``x-codex-*`` window
+    headers ride the upstream handshake response (``upstream.response.headers``).
+    Regression guard for the bug where session/weekly usage never updated on
+    the WebSocket transport because the handler only captured headers on the
+    non-streaming HTTP path.
+
+    The fixture uses a *real* ``websockets.datastructures.Headers`` multimap
+    containing a duplicated ``set-cookie`` (chatgpt.com routinely sends several).
+    ``Headers.items()`` raises ``MultipleValuesError`` on duplicate keys, so this
+    also pins the requirement that the handler iterate via ``raw_items()`` — with
+    plain ``.items()`` the whole capture would be silently skipped.
+    """
+    from headroom.subscription.codex_rate_limits import get_codex_rate_limit_state
+
+    state = get_codex_rate_limit_state()
+
+    handshake_headers = Headers()
+    handshake_headers["x-codex-primary-used-percent"] = "37.5"
+    handshake_headers["x-codex-primary-window-minutes"] = "300"
+    handshake_headers["x-codex-secondary-used-percent"] = "12.0"
+    handshake_headers["x-codex-secondary-window-minutes"] = "10080"
+    handshake_headers["x-codex-limit-name"] = "gpt-5.4-codex"
+    handshake_headers["content-type"] = "application/json"
+    # Duplicate header — would make Headers.items() raise MultipleValuesError.
+    handshake_headers["set-cookie"] = "a=1"
+    handshake_headers["set-cookie"] = "b=2"
+
+    upstream_events = [
+        json.dumps({"type": "response.created", "response": {"id": "r_1"}}),
+        json.dumps({"type": "response.completed", "response": {"id": "r_1"}}),
+    ]
+    upstream = _FakeUpstream(upstream_events)
+    # Modern ``websockets`` exposes the handshake response via ``.response``.
+    upstream.response = SimpleNamespace(headers=handshake_headers)
+    fake_ws_mod = _make_fake_websockets_module(upstream)
+
+    client_ws = _FakeWebSocket(frames=[_first_frame()])
+    handler = _DummyOpenAIHandler()
+
+    with patch.dict(sys.modules, {"websockets": fake_ws_mod}):
+        await handler.handle_openai_responses_ws(client_ws)
+
+    snap = state.latest
+    assert snap is not None
+    assert snap.primary is not None
+    assert snap.primary.used_percent == 37.5
+    assert snap.primary.window_minutes == 300
+    assert snap.secondary is not None
+    assert snap.secondary.used_percent == 12.0
+    assert snap.secondary.window_minutes == 10080
+    assert snap.limit_name == "gpt-5.4-codex"
+
+
+@pytest.mark.asyncio
+async def test_ws_missing_handshake_response_does_not_break_session():
+    """A handshake without a ``.response`` attribute must not crash the session.
+
+    Older ``websockets`` clients (or unexpected handshake shapes) may not
+    expose ``.response``; the capture is best-effort and must never take down
+    the proxied WS session.
+    """
+    from headroom.subscription.codex_rate_limits import get_codex_rate_limit_state
+
+    state = get_codex_rate_limit_state()
+
+    upstream_events = [
+        json.dumps({"type": "response.created", "response": {"id": "r_1"}}),
+        json.dumps({"type": "response.completed", "response": {"id": "r_1"}}),
+    ]
+    upstream = _FakeUpstream(upstream_events)  # no ``.response`` attribute
+    fake_ws_mod = _make_fake_websockets_module(upstream)
+
+    client_ws = _FakeWebSocket(frames=[_first_frame()])
+    handler = _DummyOpenAIHandler()
+
+    with patch.dict(sys.modules, {"websockets": fake_ws_mod}):
+        await handler.handle_openai_responses_ws(client_ws)
+
+    # Session completed cleanly; state simply stayed empty.
+    assert handler.ws_sessions.active_count() == 0
+    assert state.latest is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_streaming_ratelimit_headers.py
+++ b/tests/test_proxy_streaming_ratelimit_headers.py
@@ -18,6 +18,24 @@ import headroom.proxy.handlers.streaming as streaming_module
 from headroom.proxy.server import HeadroomProxy
 
 
+@pytest.fixture(autouse=True)
+def _reset_codex_rate_limit_singleton():
+    """Isolate the process-global CodexRateLimitState across tests.
+
+    The tracker is a module singleton; save/restore ``_latest`` around every
+    test so a captured snapshot never leaks into (or depends on) another test.
+    """
+    from headroom.subscription.codex_rate_limits import get_codex_rate_limit_state
+
+    state = get_codex_rate_limit_state()
+    saved = state._latest
+    state._latest = None
+    try:
+        yield
+    finally:
+        state._latest = saved
+
+
 class TestStreamingRatelimitHeaderForwarding:
     """Test that upstream ratelimit headers are forwarded in streaming responses."""
 
@@ -397,3 +415,153 @@ class TestStreamingRatelimitHeaderForwarding:
 
         assert attempts["count"] == 2
         assert chunks
+
+    @pytest.mark.asyncio
+    async def test_codex_rate_limit_headers_captured_and_forwarded_in_streaming(self):
+        """Codex x-codex-* headers must refresh /stats state AND reach the client.
+
+        Regression guard for the bug where Codex session/weekly usage never
+        updated on the streaming SSE transport: the proxy neither captured the
+        ``x-codex-*`` headers into ``CodexRateLimitState`` nor forwarded them to
+        the client (the old ``"ratelimit" in k`` filter dropped them, so the
+        Codex CLI's own usage display also went stale).
+        """
+        from headroom.subscription.codex_rate_limits import get_codex_rate_limit_state
+
+        state = get_codex_rate_limit_state()
+
+        proxy = self._create_mock_proxy()
+        mock_response = self._create_mock_upstream_response(
+            extra_headers={
+                "x-codex-primary-used-percent": "42.0",
+                "x-codex-primary-window-minutes": "300",
+                "x-codex-secondary-used-percent": "8.0",
+                "x-codex-secondary-window-minutes": "10080",
+                "x-codex-limit-name": "gpt-5.4-codex",
+            }
+        )
+
+        mock_request = MagicMock()
+        proxy.http_client.build_request = MagicMock(return_value=mock_request)
+        proxy.http_client.send = AsyncMock(return_value=mock_response)
+
+        result = await proxy._stream_response(
+            url="https://chatgpt.com/backend-api/codex/responses",
+            headers={"authorization": "Bearer sk-test"},
+            body={"model": "gpt-5.4", "stream": True, "input": "hi"},
+            provider="openai",
+            model="gpt-5.4",
+            request_id="test-codex-sse",
+            original_tokens=10,
+            optimized_tokens=10,
+            tokens_saved=0,
+            transforms_applied=[],
+            tags={},
+            optimization_latency=0.0,
+        )
+
+        # 1. Rate-limit state refreshed from the *streaming* response.
+        snap = state.latest
+        assert snap is not None
+        assert snap.primary is not None
+        assert snap.primary.used_percent == 42.0
+        assert snap.primary.window_minutes == 300
+        assert snap.secondary is not None
+        assert snap.secondary.used_percent == 8.0
+        assert snap.secondary.window_minutes == 10080
+        assert snap.limit_name == "gpt-5.4-codex"
+
+        # 2. x-codex headers forwarded so the Codex CLI's native usage display
+        #    keeps working through the proxy on the streaming path.
+        assert result.headers.get("x-codex-primary-used-percent") == "42.0"
+        assert result.headers.get("x-codex-limit-name") == "gpt-5.4-codex"
+        # 3. Generic ratelimit headers still forwarded; unrelated headers dropped.
+        assert result.headers.get("anthropic-ratelimit-tokens-limit") == "80000"
+        assert result.headers.get("x-request-id") is None
+
+    @pytest.mark.asyncio
+    async def test_codex_rate_limit_captured_on_streaming_429(self):
+        """A streaming 429 carrying x-codex-* must still refresh /stats.
+
+        The capture runs *before* the >=400 early-return, matching the
+        non-streaming HTTP handlers (which capture on all statuses). A 429 is
+        exactly when the session/weekly windows are most worth surfacing, so the
+        previous success-only placement left the most important update missing.
+        """
+        from headroom.subscription.codex_rate_limits import get_codex_rate_limit_state
+
+        state = get_codex_rate_limit_state()
+
+        proxy = self._create_mock_proxy()
+        mock_response = self._create_mock_upstream_response()
+        mock_response.status_code = 429
+        mock_response.headers = httpx.Headers(
+            {
+                "content-type": "application/json",
+                "x-codex-primary-used-percent": "99.5",
+                "x-codex-primary-window-minutes": "300",
+            }
+        )
+        mock_response.aread = AsyncMock(return_value=b'{"error":{"message":"rate limited"}}')
+        mock_response.aclose = AsyncMock()
+
+        mock_request = MagicMock()
+        proxy.http_client.build_request = MagicMock(return_value=mock_request)
+        proxy.http_client.send = AsyncMock(return_value=mock_response)
+
+        result = await proxy._stream_response(
+            url="https://chatgpt.com/backend-api/codex/responses",
+            headers={"authorization": "Bearer sk-test"},
+            body={"model": "gpt-5.4", "stream": True, "input": "hi"},
+            provider="openai",
+            model="gpt-5.4",
+            request_id="test-codex-429",
+            original_tokens=10,
+            optimized_tokens=10,
+            tokens_saved=0,
+            transforms_applied=[],
+            tags={},
+            optimization_latency=0.0,
+        )
+
+        assert result.status_code == 429
+        snap = state.latest
+        assert snap is not None
+        assert snap.primary is not None
+        assert snap.primary.used_percent == 99.5
+
+    @pytest.mark.asyncio
+    async def test_anthropic_stream_leaves_codex_state_untouched(self):
+        """The now-unconditional capture must be a no-op for non-Codex streams."""
+        from headroom.subscription.codex_rate_limits import get_codex_rate_limit_state
+
+        state = get_codex_rate_limit_state()
+
+        proxy = self._create_mock_proxy()
+        mock_response = self._create_mock_upstream_response()  # anthropic-ratelimit-* only
+
+        mock_request = MagicMock()
+        proxy.http_client.build_request = MagicMock(return_value=mock_request)
+        proxy.http_client.send = AsyncMock(return_value=mock_response)
+
+        await proxy._stream_response(
+            url="https://api.anthropic.com/v1/messages",
+            headers={"x-api-key": "sk-test"},
+            body={
+                "model": "claude-sonnet-4-20250514",
+                "max_tokens": 100,
+                "stream": True,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            request_id="test-anthropic-noop",
+            original_tokens=10,
+            optimized_tokens=10,
+            tokens_saved=0,
+            transforms_applied=[],
+            tags={},
+            optimization_latency=0.0,
+        )
+
+        assert state.latest is None


### PR DESCRIPTION
## Description

Codex session/weekly usage (the `x-codex-*` rate-limit windows) never updated when Codex
traffic went through the proxy over **streaming SSE** or **WebSocket** transports — the two
common Codex paths. `get_codex_rate_limit_state().update_from_headers(...)` was only called on
the two **non-streaming** HTTP branches (`openai.py` `/v1/chat/completions` and `/v1/responses`),
so `/stats` and the dashboard stayed stale on streaming/WS. On the SSE path the client-forward
filter also matched only the substring `"ratelimit"`, which dropped `x-codex-*` and stopped the
**Codex CLI's own** session/weekly display from updating through the proxy.

This PR captures the `x-codex-*` headers on all transports and keeps forwarding them to the client
on the SSE path.

Fixes #577

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- **SSE** (`headroom/proxy/handlers/streaming.py::_stream_response`):
  - Capture `update_from_headers(dict(upstream_response.headers))` **before** the `>= 400`
    early-return, so streaming **429/5xx** responses (when usage is most relevant) still refresh
    `/stats` — matching the non-streaming HTTP handlers, which already capture on all statuses.
  - Widen the client-forward filter from `"ratelimit" in k` to also pass `k.startswith("x-codex")`,
    restoring the Codex CLI's native usage display on the streaming path.
- **WebSocket** (`headroom/proxy/handlers/openai.py::handle_openai_responses_ws`):
  - Capture the upstream WS **handshake** response headers (`upstream.response.headers`) and update
    the tracker. Iterate via `raw_items()` (not `.items()`) to avoid `websockets`'
    `MultipleValuesError` on duplicate handshake headers such as `set-cookie` — which would
    otherwise be swallowed and skip the entire capture. The block is defensively guarded so it can
    never break the proxied session.
- **Tests**: SSE capture+forward, streaming-429 capture, Anthropic no-op invariant; WS capture with
  a real `websockets.datastructures.Headers` multimap including a duplicated `set-cookie` (pins the
  `raw_items()` requirement) and a missing-`.response` safety case; an autouse fixture isolating the
  process-global `CodexRateLimitState` singleton across tests.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`) — not run in this environment
- [x] New tests added for new functionality
- [ ] Manual testing performed — covered by integration-style unit tests of the real handlers

## Test Output

```
$ uv run pytest tests/test_proxy_streaming_ratelimit_headers.py \
                tests/test_openai_codex_ws_lifecycle.py \
                tests/test_codex_rate_limits.py -q
tests/test_proxy_streaming_ratelimit_headers.py ..........               [ 21%]
tests/test_openai_codex_ws_lifecycle.py ............                     [ 46%]
tests/test_codex_rate_limits.py .........................                [100%]
============================== 47 passed in 0.55s ==============================

$ ruff check headroom/proxy/handlers/streaming.py headroom/proxy/handlers/openai.py \
             tests/test_proxy_streaming_ratelimit_headers.py tests/test_openai_codex_ws_lifecycle.py
All checks passed!
```

Broader regression sweep on the touched code paths: `65 passed, 1 skipped, 1 failed`. The single
failure (`test_codex_ws_compression_scheduler.py::test_concurrent_compression_has_no_semaphore_tail`)
is unrelated — it fails only because the Rust extension `headroom._core` was not compiled in this
environment (it exercises the compression scheduler, not the rate-limit capture) and passes in isolation.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

Intentionally **out of scope** for this focused bugfix:

- **Persistence** of `CodexRateLimitState` across proxy restarts (`#4` in the issue's suggested
  fix). The reported symptom — windows never updating across turns — is the transport gap fixed
  here; persistence only matters across restarts and is a separate concern.
- **Relaying `x-codex-*` to the client over WebSocket.** The proxy `accept()`s the client WS
  handshake *before* it opens the upstream connection, so it cannot inject upstream handshake
  headers into its own handshake response. The WS fix therefore updates `/stats` only; SSE relays
  to the client as before.

Pre-existing items surfaced during review but left out of scope (no change to exposure here, only to
how often state refreshes): the process-global single-snapshot tracker and the unauthenticated
`/stats` endpoint both predate this change.
