### PR TITLE
[codex] Add Anthropic upstream base URL aliases

### DIFF
--- a/docs/content/docs/proxy.mdx
+++ b/docs/content/docs/proxy.mdx
@@ -42,7 +42,7 @@ Telemetry is enabled by default. Opt out with `HEADROOM_TELEMETRY=off` or `--no-
 | `--log-messages` | `false` | Store full request/response content for the live feed |
 | `--budget` | None | Daily budget limit in USD |
 | `--openai-api-url` | `https://api.openai.com` | Custom OpenAI API URL |
-| `--anthropic-api-url` | Anthropic default | Custom Anthropic API URL |
+| `--anthropic-api-url` / `--anthropic-base-url` | Anthropic default | Custom upstream Anthropic-compatible base URL |
 | `--gemini-api-url` | Gemini default | Custom Gemini API URL |
 | `--backend` | `anthropic` | Backend: `anthropic`, `bedrock`, `openrouter`, `anyllm`, or `litellm-<provider>` |
 | `--no-telemetry` | `false` | Disable anonymous telemetry |
@@ -226,6 +226,19 @@ ANTHROPIC_BASE_URL=http://localhost:8787 claude
 # Cursor / any OpenAI-compatible client
 OPENAI_BASE_URL=http://localhost:8787/v1 cursor
 ```
+
+For private LiteLLM or Anthropic-compatible gateways, keep `ANTHROPIC_BASE_URL`
+pointing Claude Code at Headroom and set Headroom's upstream target separately:
+
+```bash
+HEADROOM_ANTHROPIC_BASE_URL=https://litellm.company.example/v1 headroom proxy
+ANTHROPIC_BASE_URL=http://localhost:8787 claude
+```
+
+`ANTHROPIC_TARGET_API_URL` and `ANTHROPIC_UPSTREAM_BASE_URL` are also accepted
+as upstream-only aliases. Headroom intentionally does not read
+`ANTHROPIC_BASE_URL` as an upstream target because agent clients use that
+variable to reach the local proxy.
 
 ## Cloud providers
 

--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -387,8 +387,14 @@ def _selected_context_tool() -> str:
 )
 @click.option(
     "--anthropic-api-url",
+    "--anthropic-base-url",
+    "anthropic_api_url",
     default=None,
-    help="Custom Anthropic API URL for passthrough endpoints (env: ANTHROPIC_TARGET_API_URL)",
+    help=(
+        "Custom upstream Anthropic-compatible base URL for passthrough endpoints "
+        "(env: ANTHROPIC_TARGET_API_URL, HEADROOM_ANTHROPIC_BASE_URL, "
+        "ANTHROPIC_UPSTREAM_BASE_URL)"
+    ),
 )
 @click.option(
     "--openai-api-url",

--- a/headroom/providers/registry.py
+++ b/headroom/providers/registry.py
@@ -13,6 +13,12 @@ from headroom.providers.codex import DEFAULT_API_URL as DEFAULT_OPENAI_API_URL
 from headroom.providers.gemini import DEFAULT_API_URL as DEFAULT_GEMINI_API_URL
 
 DEFAULT_CLOUDCODE_API_URL = "https://cloudcode-pa.googleapis.com"
+ANTHROPIC_UPSTREAM_URL_ENV_VARS = (
+    "ANTHROPIC_TARGET_API_URL",
+    "HEADROOM_ANTHROPIC_BASE_URL",
+    "HEADROOM_ANTHROPIC_API_URL",
+    "ANTHROPIC_UPSTREAM_BASE_URL",
+)
 
 if TYPE_CHECKING:
     from headroom.backends.base import Backend
@@ -89,6 +95,14 @@ def _normalize_api_url(url: str | None, *, default: str) -> str:
     return normalized
 
 
+def _first_env(env: Mapping[str, str], names: tuple[str, ...]) -> str | None:
+    for name in names:
+        value = env.get(name)
+        if value:
+            return value
+    return None
+
+
 def resolve_api_overrides(
     *,
     anthropic_api_url: str | None,
@@ -100,7 +114,7 @@ def resolve_api_overrides(
     """Resolve provider API URL overrides from CLI/config inputs and environment."""
     env = environ or os.environ
     return ProviderApiOverrides(
-        anthropic=anthropic_api_url or env.get("ANTHROPIC_TARGET_API_URL"),
+        anthropic=anthropic_api_url or _first_env(env, ANTHROPIC_UPSTREAM_URL_ENV_VARS),
         openai=openai_api_url or env.get("OPENAI_TARGET_API_URL"),
         gemini=gemini_api_url or env.get("GEMINI_TARGET_API_URL"),
         cloudcode=cloudcode_api_url or env.get("CLOUDCODE_TARGET_API_URL"),

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -99,6 +99,7 @@ from headroom.providers.registry import (
     build_proxy_provider_runtime,
     create_proxy_backend,
     format_backend_status,
+    resolve_api_overrides,
 )
 
 # =============================================================================
@@ -2948,11 +2949,21 @@ def _proxy_config_from_env() -> ProxyConfig:
                 "Invalid %s; falling back to HEADROOM_* env vars", _MULTI_WORKER_CONFIG_ENV
             )
 
+    provider_api_overrides = resolve_api_overrides(
+        anthropic_api_url=None,
+        openai_api_url=None,
+        gemini_api_url=None,
+        cloudcode_api_url=None,
+        environ=os.environ,
+    )
+
     return ProxyConfig(
         host=_get_env_str("HEADROOM_HOST", "127.0.0.1"),
         port=_get_env_int("HEADROOM_PORT", 8787),
-        openai_api_url=os.environ.get("OPENAI_TARGET_API_URL"),
-        anthropic_api_url=os.environ.get("ANTHROPIC_TARGET_API_URL"),
+        openai_api_url=provider_api_overrides.openai,
+        anthropic_api_url=provider_api_overrides.anthropic,
+        gemini_api_url=provider_api_overrides.gemini,
+        cloudcode_api_url=provider_api_overrides.cloudcode,
         backend=_get_env_str("HEADROOM_BACKEND", "anthropic"),
         bedrock_region=_get_env_str("HEADROOM_BEDROCK_REGION", "us-west-2"),
         bedrock_profile=os.environ.get("AWS_PROFILE"),
@@ -3208,7 +3219,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--anthropic-api-url",
-        help=f"Custom Anthropic API URL (default: {DEFAULT_ANTHROPIC_API_URL})",
+        "--anthropic-base-url",
+        dest="anthropic_api_url",
+        help=(
+            "Custom upstream Anthropic-compatible base URL "
+            f"(default: {DEFAULT_ANTHROPIC_API_URL})"
+        ),
     )
 
     # Backend (anthropic direct, bedrock, openrouter, anyllm, or litellm-<provider>)
@@ -3355,12 +3371,19 @@ if __name__ == "__main__":
     tool_profiles = _parse_tool_profiles(args.tool_profile)
     # Parse extra never-compress tools from CLI and env var
     exclude_tools = _parse_exclude_tools(args.exclude_tools)
+    provider_api_overrides = resolve_api_overrides(
+        anthropic_api_url=args.anthropic_api_url,
+        openai_api_url=args.openai_api_url,
+        gemini_api_url=None,
+        cloudcode_api_url=None,
+        environ=os.environ,
+    )
 
     config = ProxyConfig(
         host=_get_env_str("HEADROOM_HOST", args.host),
         port=_get_env_int("HEADROOM_PORT", args.port),
-        openai_api_url=_get_env_str("OPENAI_TARGET_API_URL", args.openai_api_url),
-        anthropic_api_url=_get_env_str("ANTHROPIC_TARGET_API_URL", args.anthropic_api_url),
+        openai_api_url=provider_api_overrides.openai,
+        anthropic_api_url=provider_api_overrides.anthropic,
         # Backend settings
         backend=_get_env_str("HEADROOM_BACKEND", args.backend),  # type: ignore[arg-type]
         bedrock_region=_get_env_str("HEADROOM_BEDROCK_REGION", args.bedrock_region),

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -187,6 +187,53 @@ class TestCLIProxyEnvVars:
         assert result.exit_code == 0, result.output
         assert captured_config["config"].gemini_api_url == "http://my-gemini:5000"
 
+    def test_headroom_anthropic_base_url_from_env(self, runner):
+        """HEADROOM_ANTHROPIC_BASE_URL should configure the upstream Anthropic target."""
+        captured_config = {}
+
+        def mock_run_server(config, **kwargs):
+            captured_config["config"] = config
+
+        with patch("headroom.proxy.server.run_server", mock_run_server):
+            result = runner.invoke(
+                main,
+                ["proxy"],
+                env={"HEADROOM_ANTHROPIC_BASE_URL": "http://my-litellm:4000/v1"},
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured_config["config"].anthropic_api_url == "http://my-litellm:4000/v1"
+
+    def test_anthropic_base_url_is_not_upstream_env(self, runner):
+        """ANTHROPIC_BASE_URL remains the client->Headroom URL and is not read as upstream."""
+        captured_config = {}
+
+        def mock_run_server(config, **kwargs):
+            captured_config["config"] = config
+
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k
+            not in {
+                "ANTHROPIC_TARGET_API_URL",
+                "HEADROOM_ANTHROPIC_BASE_URL",
+                "HEADROOM_ANTHROPIC_API_URL",
+                "ANTHROPIC_UPSTREAM_BASE_URL",
+            }
+        }
+        env["ANTHROPIC_BASE_URL"] = "http://localhost:8787"
+
+        with (
+            patch("headroom.proxy.server.run_server", mock_run_server),
+            patch.dict(os.environ, env, clear=True),
+        ):
+            result = runner.invoke(main, ["proxy"], catch_exceptions=False)
+
+        assert result.exit_code == 0, result.output
+        assert captured_config["config"].anthropic_api_url is None
+
     def test_openai_api_url_cli_flag(self, runner):
         """--openai-api-url CLI flag should take precedence."""
         captured_config = {}
@@ -203,6 +250,23 @@ class TestCLIProxyEnvVars:
 
         assert result.exit_code == 0, result.output
         assert captured_config["config"].openai_api_url == "http://from-cli:4000"
+
+    def test_anthropic_base_url_cli_alias(self, runner):
+        """--anthropic-base-url should configure the upstream Anthropic target."""
+        captured_config = {}
+
+        def mock_run_server(config, **kwargs):
+            captured_config["config"] = config
+
+        with patch("headroom.proxy.server.run_server", mock_run_server):
+            result = runner.invoke(
+                main,
+                ["proxy", "--anthropic-base-url", "http://from-cli-litellm:4000"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured_config["config"].anthropic_api_url == "http://from-cli-litellm:4000"
 
     def test_cli_flag_overrides_env_var(self, runner):
         """CLI flag should take precedence over env var."""

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -32,6 +32,52 @@ def test_resolve_api_overrides_prefers_explicit_values_over_environment(monkeypa
     )
 
 
+def test_resolve_api_overrides_reads_headroom_anthropic_base_url(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_TARGET_API_URL", raising=False)
+    monkeypatch.setenv("HEADROOM_ANTHROPIC_BASE_URL", "https://litellm.internal/v1")
+
+    overrides = resolve_api_overrides(
+        anthropic_api_url=None,
+        openai_api_url=None,
+        gemini_api_url=None,
+        cloudcode_api_url=None,
+    )
+
+    assert overrides.anthropic == "https://litellm.internal/v1"
+
+
+def test_resolve_api_overrides_ignores_client_anthropic_base_url(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_TARGET_API_URL", raising=False)
+    monkeypatch.delenv("HEADROOM_ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("HEADROOM_ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_UPSTREAM_BASE_URL", raising=False)
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://localhost:8787")
+
+    overrides = resolve_api_overrides(
+        anthropic_api_url=None,
+        openai_api_url=None,
+        gemini_api_url=None,
+        cloudcode_api_url=None,
+    )
+
+    assert overrides.anthropic is None
+
+
+def test_resolve_api_overrides_supports_anthropic_upstream_alias(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_TARGET_API_URL", raising=False)
+    monkeypatch.delenv("HEADROOM_ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("ANTHROPIC_UPSTREAM_BASE_URL", "https://litellm-upstream.internal")
+
+    overrides = resolve_api_overrides(
+        anthropic_api_url=None,
+        openai_api_url=None,
+        gemini_api_url=None,
+        cloudcode_api_url=None,
+    )
+
+    assert overrides.anthropic == "https://litellm-upstream.internal"
+
+
 def test_resolve_api_targets_normalizes_trailing_v1() -> None:
     targets = resolve_api_targets(
         ProviderApiOverrides(

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -266,7 +266,7 @@ headroom proxy --mode cache
 | `--no-learn` | off | Explicitly disable traffic learning |
 | `--backend` | `anthropic` | Backend: `anthropic`, `bedrock`, `openrouter`, `anyllm`, or `litellm-*` |
 | `--anyllm-provider` | `openai` | Provider name for `anyllm` |
-| `--anthropic-api-url` | unset | Custom Anthropic passthrough API URL |
+| `--anthropic-api-url`, `--anthropic-base-url` | unset | Custom upstream Anthropic-compatible base URL |
 | `--openai-api-url` | unset | Custom OpenAI passthrough API URL |
 | `--gemini-api-url` | unset | Custom Gemini passthrough API URL |
 | `--region` | `us-west-2` | Cloud region for Bedrock / Vertex / related backends |
@@ -277,7 +277,8 @@ headroom proxy --mode cache
 Notes:
 
 - `--learn` implies memory unless `--no-learn` is also set.
-- Proxy startup can also read environment variables such as `HEADROOM_HOST`, `HEADROOM_PORT`, `HEADROOM_BUDGET`, `HEADROOM_MODE`, `HEADROOM_ANYLLM_PROVIDER`, `HEADROOM_ANTHROPIC_PRE_UPSTREAM_CONCURRENCY`, `HEADROOM_ANTHROPIC_PRE_UPSTREAM_ACQUIRE_TIMEOUT_SECONDS`, `HEADROOM_ANTHROPIC_PRE_UPSTREAM_MEMORY_CONTEXT_TIMEOUT_SECONDS`, `ANTHROPIC_TARGET_API_URL`, `OPENAI_TARGET_API_URL`, and `GEMINI_TARGET_API_URL`. CLI flags take precedence over environment variables.
+- Proxy startup can also read environment variables such as `HEADROOM_HOST`, `HEADROOM_PORT`, `HEADROOM_BUDGET`, `HEADROOM_MODE`, `HEADROOM_ANYLLM_PROVIDER`, `HEADROOM_ANTHROPIC_PRE_UPSTREAM_CONCURRENCY`, `HEADROOM_ANTHROPIC_PRE_UPSTREAM_ACQUIRE_TIMEOUT_SECONDS`, `HEADROOM_ANTHROPIC_PRE_UPSTREAM_MEMORY_CONTEXT_TIMEOUT_SECONDS`, `ANTHROPIC_TARGET_API_URL`, `HEADROOM_ANTHROPIC_BASE_URL`, `ANTHROPIC_UPSTREAM_BASE_URL`, `OPENAI_TARGET_API_URL`, and `GEMINI_TARGET_API_URL`. CLI flags take precedence over environment variables.
+- For Claude Code behind private LiteLLM, keep `ANTHROPIC_BASE_URL` pointed at Headroom and set the real upstream separately, for example `HEADROOM_ANTHROPIC_BASE_URL=https://litellm.company.example/v1 headroom proxy`. Headroom intentionally does not read `ANTHROPIC_BASE_URL` as an upstream target.
 - The default Anthropic pre-upstream cap is intentionally conservative for CPU/ONNX-heavy work. Larger containers may want to raise it after checking the resolved runtime values on `/readyz` or `/debug/warmup`.
 
 See also: [Proxy Server](proxy.md), [Configuration](configuration.md)


### PR DESCRIPTION
## Summary

- Add upstream-only Anthropic base URL aliases for Headroom proxy configuration:
  - `HEADROOM_ANTHROPIC_BASE_URL`
  - `HEADROOM_ANTHROPIC_API_URL`
  - `ANTHROPIC_UPSTREAM_BASE_URL`
- Add `--anthropic-base-url` as a CLI alias for `--anthropic-api-url`.
- Keep `ANTHROPIC_BASE_URL` reserved for client-to-Headroom routing so Claude Code can point at the local proxy without creating an upstream self-loop.
- Document the private LiteLLM / Anthropic-compatible gateway flow.

## Why

In enterprise Claude Code setups, `ANTHROPIC_BASE_URL` is already used by the client to reach Headroom. When the real upstream is a private LiteLLM Anthropic-compatible endpoint, Headroom needs a separate upstream-only configuration surface.

Closes #561.

## Validation

- `git diff --check`
- `python3 -m py_compile headroom/providers/registry.py headroom/cli/proxy.py headroom/proxy/server.py tests/test_provider_registry.py tests/test_cli_proxy_env.py`
- `.venv/bin/python -m pytest tests/test_provider_registry.py tests/test_cli_proxy_env.py` (`39 passed`)