### PR TITLE
feat(proxy): show resolved upstream API targets in startup banner

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -99,6 +99,7 @@ from headroom.providers.registry import (
     build_proxy_provider_runtime,
     create_proxy_backend,
     format_backend_status,
+    resolve_api_targets,
 )
 
 # =============================================================================
@@ -3020,6 +3021,9 @@ def run_server(
         bedrock_region=config.bedrock_region,
     )
 
+    # Resolve upstream API targets for display in the banner (#583).
+    api_targets = resolve_api_targets(config.provider_api_overrides)
+
     if print_banner:
         print(f"""
 ╔══════════════════════════════════════════════════════════════════════╗
@@ -3029,6 +3033,12 @@ def run_server(
 ║  Listening: http://{config.host}:{config.port:<5}                                      ║
 ║  Workers: {workers:<3}  Concurrency Limit: {limit_concurrency:<5}                          ║
 ║  Backend: {backend_status:<59}║
+╠══════════════════════════════════════════════════════════════════════╣
+║  UPSTREAM TARGETS:                                                   ║
+║    Anthropic:  {api_targets.anthropic:<57}║
+║    OpenAI:     {api_targets.openai:<57}║
+║    Gemini:     {api_targets.gemini:<57}║
+║    Cloud Code: {api_targets.cloudcode:<57}║
 ╠══════════════════════════════════════════════════════════════════════╣
 ║  FEATURES:                                                           ║
 ║    Optimization:    {"ENABLED " if config.optimize else "DISABLED"}                                       ║

--- a/tests/test_banner_upstream_targets.py
+++ b/tests/test_banner_upstream_targets.py
@@ -1,0 +1,120 @@
+"""Tests for upstream API targets in the proxy startup banner.
+
+Verifies that:
+1. Default API targets appear in the banner when no overrides are set
+2. Custom API targets (via ProxyConfig) appear correctly in the banner
+3. The banner is suppressed when print_banner=False
+
+Closes #583.
+"""
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from headroom.providers.claude import DEFAULT_API_URL as DEFAULT_ANTHROPIC_API_URL  # noqa: E402
+from headroom.providers.codex import DEFAULT_API_URL as DEFAULT_OPENAI_API_URL  # noqa: E402
+from headroom.providers.gemini import DEFAULT_API_URL as DEFAULT_GEMINI_API_URL  # noqa: E402
+from headroom.providers.registry import DEFAULT_CLOUDCODE_API_URL  # noqa: E402
+from headroom.proxy.models import ProxyConfig  # noqa: E402
+from headroom.proxy.server import run_server  # noqa: E402
+
+
+class TestBannerUpstreamTargets:
+    """Verify resolved upstream API targets are displayed in the startup banner."""
+
+    def _capture_banner(self, config: ProxyConfig | None = None) -> str:
+        """Run the server with print_banner=True, intercepting stdout and uvicorn."""
+        buf = StringIO()
+        config = config or ProxyConfig()
+        with (
+            patch("sys.stdout", buf),
+            patch("headroom.proxy.server.uvicorn") as mock_uvicorn,
+            patch("headroom.proxy.server.create_app"),
+        ):
+            mock_uvicorn.run = lambda *a, **kw: None
+            run_server(config, print_banner=True)
+        return buf.getvalue()
+
+    def test_default_targets_in_banner(self):
+        """Default API targets should appear when no overrides are configured."""
+        output = self._capture_banner()
+
+        assert "UPSTREAM TARGETS:" in output
+        assert DEFAULT_ANTHROPIC_API_URL in output
+        assert DEFAULT_OPENAI_API_URL in output
+        assert DEFAULT_GEMINI_API_URL in output
+        assert DEFAULT_CLOUDCODE_API_URL in output
+
+    def test_custom_anthropic_target_in_banner(self):
+        """A custom Anthropic API URL should be resolved and shown in the banner."""
+        config = ProxyConfig(anthropic_api_url="https://litellm.internal/v1")
+        output = self._capture_banner(config)
+
+        # resolve_api_targets strips trailing /v1
+        assert "https://litellm.internal" in output
+        # Other providers should keep their defaults
+        assert DEFAULT_OPENAI_API_URL in output
+
+    def test_custom_openai_target_in_banner(self):
+        """A custom OpenAI API URL should be resolved and shown in the banner."""
+        config = ProxyConfig(openai_api_url="http://my-vllm:4000")
+        output = self._capture_banner(config)
+
+        assert "http://my-vllm:4000" in output
+        assert DEFAULT_ANTHROPIC_API_URL in output
+
+    def test_custom_gemini_target_in_banner(self):
+        """A custom Gemini API URL should be resolved and shown in the banner."""
+        config = ProxyConfig(gemini_api_url="http://my-gemini:5000")
+        output = self._capture_banner(config)
+
+        assert "http://my-gemini:5000" in output
+
+    def test_custom_cloudcode_target_in_banner(self):
+        """A custom Cloud Code API URL should be resolved and shown in the banner."""
+        config = ProxyConfig(cloudcode_api_url="https://custom-cloudcode.example.com")
+        output = self._capture_banner(config)
+
+        assert "https://custom-cloudcode.example.com" in output
+
+    def test_multiple_custom_targets_in_banner(self):
+        """Multiple custom targets should all appear correctly in the banner."""
+        config = ProxyConfig(
+            anthropic_api_url="https://anthropic.internal",
+            openai_api_url="https://openai.internal",
+            gemini_api_url="https://gemini.internal",
+            cloudcode_api_url="https://cloudcode.internal",
+        )
+        output = self._capture_banner(config)
+
+        assert "https://anthropic.internal" in output
+        assert "https://openai.internal" in output
+        assert "https://gemini.internal" in output
+        assert "https://cloudcode.internal" in output
+
+    def test_banner_suppressed_when_disabled(self):
+        """When print_banner=False, upstream targets should NOT be printed."""
+        buf = StringIO()
+        with (
+            patch("sys.stdout", buf),
+            patch("headroom.proxy.server.uvicorn") as mock_uvicorn,
+            patch("headroom.proxy.server.create_app"),
+        ):
+            mock_uvicorn.run = lambda *a, **kw: None
+            run_server(ProxyConfig(), print_banner=False)
+        output = buf.getvalue()
+
+        assert "UPSTREAM TARGETS:" not in output
+
+    def test_trailing_v1_stripped_in_banner(self):
+        """URLs ending in /v1 should be normalized (stripped) in the banner."""
+        config = ProxyConfig(openai_api_url="http://my-proxy:8000/v1")
+        output = self._capture_banner(config)
+
+        # resolve_api_targets normalizes /v1 suffix
+        assert "http://my-proxy:8000" in output
+        assert "http://my-proxy:8000/v1" not in output


### PR DESCRIPTION
## Summary

Display the resolved upstream API targets in the proxy startup banner so users can verify their custom endpoint configuration at a glance.

Closes #583

## Problem

Headroom supports configuring custom upstream API endpoints via `--anthropic-api-url`, `--openai-api-url`, `--gemini-api-url` (and their `*_TARGET_API_URL` env var equivalents). These values are resolved at runtime into `api_targets`, but the startup banner only shows backend selection — not the final resolved upstream endpoints.

This makes it harder to verify configuration in deployments using custom gateways (e.g., LiteLLM or internal proxy routing).

## Solution

Added a new **UPSTREAM TARGETS** section to the startup banner, between the Backend line and the FEATURES section:

```
╠══════════════════════════════════════════════════════════════════════╣
║  UPSTREAM TARGETS:                                                   ║
║    Anthropic:  https://api.anthropic.com                             ║
║    OpenAI:     https://api.openai.com                                ║
║    Gemini:     https://generativelanguage.googleapis.com              ║
║    Cloud Code: https://cloudcode-pa.googleapis.com                   ║
╠══════════════════════════════════════════════════════════════════════╣
```

When custom endpoints are configured, the resolved URLs appear instead of the defaults. URLs are resolved through the existing `resolve_api_targets` pipeline, which normalizes trailing `/v1` suffixes and applies defaults for unconfigured providers.

## Changes

| File | Change |
|---|---|
| `headroom/proxy/server.py` | Added `resolve_api_targets` import + UPSTREAM TARGETS banner section (+10 lines) |
| `tests/test_banner_upstream_targets.py` | New test file with 8 tests |

## Tests

Added `tests/test_banner_upstream_targets.py` with 8 tests covering:

- ✅ Default API targets appear in the banner
- ✅ Custom Anthropic / OpenAI / Gemini / Cloud Code targets appear correctly
- ✅ Multiple custom targets work together
- ✅ Banner suppression (`print_banner=False`) still works
- ✅ URL normalization (trailing `/v1` stripped)

All existing tests pass (`test_cli_proxy_env.py` — 22/22 ✅).

## Scope

- **Purely informational** — no change to request handling or runtime behavior
- **Non-breaking** — only adds lines to the banner output
- Reuses the existing `resolve_api_targets` and `ProviderApiTargets` infrastructure