### PR TITLE
Lazy-load dynamic detector ML imports

### DIFF
--- a/headroom/cache/dynamic_detector.py
+++ b/headroom/cache/dynamic_detector.py
@@ -36,29 +36,17 @@ import math
 import re
 from dataclasses import dataclass, field
 from enum import Enum
+from importlib.util import find_spec
 from typing import Any, Literal
 
 from headroom.models.config import ML_MODEL_DEFAULTS
 
-# Optional imports - graceful degradation
-_SPACY_AVAILABLE = False
-_SENTENCE_TRANSFORMERS_AVAILABLE = False
-
-try:
-    import spacy
-
-    _SPACY_AVAILABLE = True
-except ImportError:
-    spacy = None  # type: ignore
-
-try:
-    import numpy as np
-    from sentence_transformers import SentenceTransformer
-
-    _SENTENCE_TRANSFORMERS_AVAILABLE = True
-except ImportError:
-    SentenceTransformer = None  # type: ignore
-    np = None  # type: ignore
+# Optional ML dependencies are checked without importing them so this module
+# stays cheap to import during proxy startup.
+_SPACY_AVAILABLE = find_spec("spacy") is not None
+_SENTENCE_TRANSFORMERS_AVAILABLE = (
+    find_spec("numpy") is not None and find_spec("sentence_transformers") is not None
+)
 
 
 class DynamicCategory(str, Enum):
@@ -601,6 +589,11 @@ class NERDetector:
             from headroom.models.ml_models import MLModelRegistry
 
             self._nlp = MLModelRegistry.get_spacy(config.spacy_model)
+        except ImportError:
+            self._load_error = (
+                "spaCy not installed. Install with: "
+                "pip install spacy && python -m spacy download en_core_web_sm"
+            )
         except OSError:
             self._load_error = (
                 f"spaCy model '{config.spacy_model}' not found. "
@@ -731,6 +724,11 @@ class SemanticDetector:
                 self.DYNAMIC_EXEMPLARS,
                 convert_to_numpy=True,
             )
+        except ImportError:
+            self._load_error = (
+                "sentence-transformers not installed. "
+                "Install with: pip install sentence-transformers"
+            )
         except Exception as e:
             self._load_error = f"Failed to load embedding model: {e}"
 
@@ -773,6 +771,11 @@ class SemanticDetector:
         if not sentences:
             return [], None
 
+        try:
+            import numpy as np
+        except ImportError:
+            return [], "numpy not installed. Install with: pip install numpy"
+
         sentence_texts = [s[0] for s in sentences]
         sentence_embeddings = self._model.encode(  # type: ignore[union-attr]
             sentence_texts,
@@ -780,7 +783,7 @@ class SemanticDetector:
         )
 
         # Compute similarities
-        similarities = np.dot(sentence_embeddings, self._exemplar_embeddings.T)  # type: ignore[union-attr]
+        similarities = np.dot(sentence_embeddings, self._exemplar_embeddings.T)
 
         for i, (text, start, end) in enumerate(sentences):
             # Get max similarity to any exemplar

--- a/tests/test_package_init_lazy.py
+++ b/tests/test_package_init_lazy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import textwrap
@@ -126,3 +127,47 @@ def test_proxy_server_import_skips_litellm_backend() -> None:
     assert data["litellm_backend_loaded"] is False
     assert data["anyllm_backend_loaded"] is False
     assert data["litellm_loaded"] is False
+
+
+def test_dynamic_detector_import_skips_optional_ml_dependencies(tmp_path: Path) -> None:
+    (tmp_path / "spacy.py").write_text("", encoding="utf-8")
+    (tmp_path / "numpy.py").write_text("", encoding="utf-8")
+    (tmp_path / "torch.py").write_text("", encoding="utf-8")
+    sentence_transformers_dir = tmp_path / "sentence_transformers"
+    sentence_transformers_dir.mkdir()
+    (sentence_transformers_dir / "__init__.py").write_text(
+        "import torch\n\nclass SentenceTransformer:\n    pass\n",
+        encoding="utf-8",
+    )
+
+    script = textwrap.dedent(
+        """
+        import json
+        import sys
+
+        import headroom.cache.dynamic_detector
+
+        print(json.dumps({
+            "spacy_loaded": "spacy" in sys.modules,
+            "sentence_transformers_loaded": "sentence_transformers" in sys.modules,
+            "torch_loaded": "torch" in sys.modules,
+        }))
+        """
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+    )
+
+    data = json.loads(result.stdout.strip())
+    assert data["spacy_loaded"] is False
+    assert data["sentence_transformers_loaded"] is False
+    assert data["torch_loaded"] is False


### PR DESCRIPTION
## Description

Avoid importing optional ML dependencies when `headroom.cache.dynamic_detector` is imported during wrap/proxy startup. This keeps the dynamic detector module cheap to import while preserving the existing NER and semantic detector behavior when those tiers are actually used.

Fixes #195

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Replaced eager `spacy`, `sentence_transformers`, and `numpy` imports in `dynamic_detector.py` with `find_spec` availability checks.
- Kept NER and semantic model loading on the existing first-use detector initialization paths.
- Moved `numpy` import to the semantic similarity calculation path where it is actually needed.
- Added regression coverage proving `dynamic_detector` import does not load optional ML modules even when stub versions of those modules are importable.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
.venv/bin/pytest tests/test_package_init_lazy.py
7 passed in 2.82s

.venv/bin/pytest tests/test_cache/test_dynamic_detector.py tests/test_package_init_lazy.py
43 passed, 2 skipped in 19.48s

.venv/bin/python -m ruff check headroom/cache/dynamic_detector.py tests/test_package_init_lazy.py
All checks passed!

.venv/bin/python -m ruff format --check headroom/cache/dynamic_detector.py tests/test_package_init_lazy.py
2 files already formatted

git diff --check
# no output
```

## Real Behavior Proof

- Environment: macOS local checkout, Python 3.11 virtualenv at `.venv`.
- Exact command / steps: Added a subprocess regression test that creates importable stub `spacy`, `numpy`, `torch`, and `sentence_transformers` modules, imports `headroom.cache.dynamic_detector`, and inspects `sys.modules`.
- Observed result: Before the implementation change, the new regression test failed because `spacy` was loaded during module import. After the change, `spacy`, `sentence_transformers`, and `torch` remain unloaded and the dynamic detector test suite still passes.
- Not tested: Full repository-wide `mypy headroom`; full CI requires maintainer approval for fork workflows.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This branch has been narrowed after review feedback. It now only contains the lazy `dynamic_detector` import fix. The wrapper startup-timeout behavior was removed from this PR so it can be reviewed separately from the existing timeout work.