### PR TITLE
fix(startup): suppress proxy startup log noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Bug Fixes
+
+* **startup:** suppress proxy startup log noise — litellm banner, trafilatura parse errors, HuggingFace Hub unauthenticated warnings, tiktoken fallback warning, and httpx INFO lines from sentence_transformers HEAD checks. Affected files: `headroom/providers/litellm.py`, `headroom/transforms/html_extractor.py`, `headroom/memory/adapters/embedders.py`, `headroom/providers/anthropic.py`, `headroom/providers/registry.py`, `headroom/image/onnx_router.py`, `headroom/transforms/kompress_compressor.py`.
+
+
 ## [0.23.0](https://github.com/chopratejas/headroom/compare/v0.22.4...v0.23.0) (2026-06-04)
 
 ### Features

--- a/ENTERPRISE.md
+++ b/ENTERPRISE.md
@@ -1,0 +1,5 @@
+# Enterprise
+
+## Enterprise Support
+
+Interested in using Headroom at scale? We're happy to discuss your deployment requirements! Email us at: **hello@headroomlabs.ai**

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
   <a href="#proof">Proof</a> ·
   <a href="#agent-compatibility-matrix">Agents</a> ·
   <a href="https://discord.gg/yRmaUNpsPJ">Discord</a> ·
-  <a href="llms.txt">llms.txt</a>
+  <a href="llms.txt">llms.txt</a> ·
+  <a href="ENTERPRISE.md">Enterprise</a>
 </p>
 
 <p align="center"><sub>

--- a/TESTING-copilot-subscription.md
+++ b/TESTING-copilot-subscription.md
@@ -22,7 +22,38 @@ Mechanically: the Copilot CLI's only interposition hook is its provider-override
 subscription token** and points back at **GitHub's own Copilot API**. So the CLI
 may print "BYOK" and require an explicit `--model`, but you are **not** paying a
 third party — it's your subscription, just compressed. (Proof it's working: the
-proxy forwards to `https://api.*.githubcopilot.com` with your token.)
+proxy forwards to GitHub's Copilot API — `https://api.githubcopilot.com` by
+default — with your token.)
+
+## API host & Enterprise / data-residency
+
+Headroom routes wrapped Copilot traffic to GitHub's **generic public host**,
+`https://api.githubcopilot.com`, for both `--subscription` and the implicit
+OAuth path. That host serves the full model set (including newer models on the
+responses API) and matches the routing that worked before 0.23.
+
+Headroom deliberately does **not** auto-select a per-account host from
+`/copilot_internal/user`. That endpoint advertises a segmented host (e.g.
+`api.individual.githubcopilot.com`) that does **not** serve newer models on the
+responses API and is not the host the official Copilot client routes with — using
+it regressed `headroom wrap copilot` after 0.22.4
+([#610](https://github.com/chopratejas/headroom/issues/610)).
+
+**Enterprise / data-residency:** if your organization is provisioned on a
+dedicated Copilot API host (GitHub Enterprise Cloud with data residency, or an
+egress proxy), pin it explicitly — the override flows through both
+`--subscription` and OAuth, and onward through the proxy to the upstream request:
+
+```bash
+export GITHUB_COPILOT_API_URL=https://api.<your-host>.githubcopilot.com
+headroom wrap copilot --subscription -- --model gpt-5.4
+```
+
+If you operate such an environment and would like Headroom to **auto-detect** the
+correct host instead of pinning it, please [open an issue](https://github.com/chopratejas/headroom/issues/new) —
+the intended path is to resolve it from GitHub's token-exchange endpoint (the
+source the official Copilot client uses), and we'd want to validate it against a
+real enterprise tenant.
 
 ## Status
 

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -2439,6 +2439,13 @@ def copilot(
         headroom wrap copilot --provider-type openai --wire-api responses -- --model gpt-5.4
         headroom wrap copilot --subscription -- --model gpt-4.1
         headroom wrap copilot --no-context-tool -- --prompt "explain this file"
+
+    \b
+    Copilot hosted API (--subscription and the implicit OAuth path) routes to the
+    generic host https://api.githubcopilot.com, which serves the full model set.
+    Enterprise / data-residency accounts provisioned on a dedicated host pin it
+    explicitly with GITHUB_COPILOT_API_URL (the override flows through to upstream).
+    See TESTING-copilot-subscription.md for details.
     """
     copilot_bin = shutil.which("copilot")
     if not copilot_bin:
@@ -2534,6 +2541,15 @@ def copilot(
                 else "COPILOT_AUTH_MODE=github-oauth"
             ),
         ]
+        # Resolve the Copilot API host: an explicit GITHUB_COPILOT_API_URL wins,
+        # otherwise the generic public host (api.githubcopilot.com). This is the
+        # same policy for --subscription and the implicit OAuth path. The
+        # account-specific endpoints.api advertised by /copilot_internal/user is
+        # deliberately NOT used to route — it returns a segmented host (e.g.
+        # api.individual.githubcopilot.com) that does not serve newer models on
+        # the responses API (#610), and it is not the host the official Copilot
+        # client routes with. Accounts that require a dedicated host (enterprise /
+        # data residency) set GITHUB_COPILOT_API_URL explicitly.
         openai_api_url = resolve_copilot_api_url(client_bearer)
         env["GITHUB_COPILOT_API_URL"] = openai_api_url
         env["OPENAI_TARGET_API_URL"] = openai_api_url

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -141,6 +141,29 @@ def _check_proxy(port: int) -> bool:
         return False
 
 
+def _port_bind_error(port: int) -> OSError | None:
+    """Return the bind error for a local proxy port, or None when it is usable."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", port))
+    except OSError as exc:
+        return exc
+    return None
+
+
+def _format_unbindable_port_error(port: int, error: OSError, agent_type: str) -> str:
+    """Build an actionable message for ports that fail before uvicorn can bind."""
+    command = "headroom proxy"
+    if agent_type != "unknown":
+        command = f"headroom wrap {agent_type}"
+    suggested_port = port + 1
+    return (
+        f"Port {port} is unavailable on 127.0.0.1 before the proxy can start: {error}. "
+        "On Windows this can happen when the port is in an excluded or reserved range. "
+        f"Rerun with a different port, for example `{command} --port {suggested_port}`."
+    )
+
+
 def _get_log_path() -> Path:
     """Get path for proxy log file."""
     from headroom import paths as _paths
@@ -1740,6 +1763,12 @@ def _ensure_proxy(
                 return None
 
         # Start (or restart) the proxy with the requested flags
+        bind_error = helpers._port_bind_error(port)
+        if bind_error is not None:
+            raise click.ClickException(
+                helpers._format_unbindable_port_error(port, bind_error, agent_type)
+            )
+
         click.echo(f"  Starting Headroom proxy on port {port}...")
         try:
             proc = cast(

--- a/headroom/copilot_auth.py
+++ b/headroom/copilot_auth.py
@@ -474,21 +474,27 @@ def build_copilot_upstream_url(base_url: str, path: str) -> str:
 
 
 def resolve_copilot_api_url(oauth_token: str | None = None) -> str:
-    """Return the Copilot API endpoint advertised for the current OAuth token."""
+    """Return the Copilot API host to route wrapped requests through.
 
-    token = (oauth_token or read_cached_oauth_token() or "").strip()
-    if not token:
-        return os.environ.get("GITHUB_COPILOT_API_URL", DEFAULT_API_URL).strip() or DEFAULT_API_URL
+    Resolution order:
 
-    payload = _fetch_copilot_user_info(token)
-    if payload is None:
-        return os.environ.get("GITHUB_COPILOT_API_URL", DEFAULT_API_URL).strip() or DEFAULT_API_URL
+    1. An explicit ``GITHUB_COPILOT_API_URL`` — the operator's escape hatch
+       (corporate proxy, enterprise / data-residency host, tests).
+    2. The generic public host ``https://api.githubcopilot.com``.
 
-    endpoints = payload.get("endpoints") if isinstance(payload, dict) else None
-    api_url = endpoints.get("api") if isinstance(endpoints, dict) else None
-    if isinstance(api_url, str) and api_url.strip():
-        return api_url.strip()
-    return os.environ.get("GITHUB_COPILOT_API_URL", DEFAULT_API_URL).strip() or DEFAULT_API_URL
+    The account-specific ``endpoints.api`` advertised by ``/copilot_internal/user``
+    is intentionally NOT used to route. It returns a segmented host (e.g.
+    ``api.individual.githubcopilot.com``) that does not serve newer models on the
+    responses API — wrapping such a request regressed after 0.22.4 (#610) — and it
+    is not the host the official Copilot client routes with (that comes from the
+    token-exchange endpoint, not user info). Accounts that genuinely require a
+    dedicated host set ``GITHUB_COPILOT_API_URL`` explicitly. ``oauth_token`` is
+    accepted for call-site compatibility but no longer triggers a network lookup.
+    """
+
+    del oauth_token  # reserved; routing no longer depends on a user-info lookup
+    override = os.environ.get("GITHUB_COPILOT_API_URL", "").strip()
+    return override or DEFAULT_API_URL
 
 
 def _fetch_copilot_user_info(token: str) -> dict[str, Any] | None:

--- a/headroom/image/onnx_router.py
+++ b/headroom/image/onnx_router.py
@@ -20,7 +20,7 @@ from typing import Any
 import numpy as np
 
 from headroom.image.trained_router import ImageSignals, RouteDecision, Technique
-from headroom.onnx_runtime import create_cpu_session_options
+from headroom.onnx_runtime import create_cpu_session_options, hf_hub_download_local_first
 
 logger = logging.getLogger(__name__)
 
@@ -57,26 +57,18 @@ class OnnxTechniqueRouter:
             return
 
         import onnxruntime as ort
-        from huggingface_hub import hf_hub_download
-        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
         from tokenizers import Tokenizer
 
         logger.info("Loading technique-router ONNX INT8...")
 
-        def _hub_dl(repo: str, filename: str) -> str:
-            try:
-                return hf_hub_download(repo, filename, local_files_only=True)
-            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
-                return hf_hub_download(repo, filename)
-
-        model_path = _hub_dl(_TECHNIQUE_ROUTER_REPO, "model_quantized.onnx")
+        model_path = hf_hub_download_local_first(_TECHNIQUE_ROUTER_REPO, "model_quantized.onnx")
         self._classifier_session = ort.InferenceSession(
             model_path,
             create_cpu_session_options(ort),
             providers=["CPUExecutionProvider"],
         )
 
-        tokenizer_path = _hub_dl(_TECHNIQUE_ROUTER_REPO, "tokenizer.json")
+        tokenizer_path = hf_hub_download_local_first(_TECHNIQUE_ROUTER_REPO, "tokenizer.json")
         self._tokenizer = Tokenizer.from_file(tokenizer_path)
         self._tokenizer.enable_truncation(max_length=64)
         self._tokenizer.enable_padding(length=64)
@@ -84,7 +76,7 @@ class OnnxTechniqueRouter:
         # Load label mapping
         import json
 
-        config_path = _hub_dl(_TECHNIQUE_ROUTER_REPO, "config.json")
+        config_path = hf_hub_download_local_first(_TECHNIQUE_ROUTER_REPO, "config.json")
         with open(config_path) as f:
             config = json.load(f)
         self._id2label = {int(k): v for k, v in config.get("id2label", {}).items()}
@@ -100,25 +92,17 @@ class OnnxTechniqueRouter:
             return
 
         import onnxruntime as ort
-        from huggingface_hub import hf_hub_download
-        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
 
         logger.info("Loading SigLIP ONNX INT8 image encoder...")
 
-        def _hub_dl(repo: str, filename: str) -> str:
-            try:
-                return hf_hub_download(repo, filename, local_files_only=True)
-            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
-                return hf_hub_download(repo, filename)
-
-        model_path = _hub_dl(_SIGLIP_ENCODER_REPO, "image_encoder_int8.onnx")
+        model_path = hf_hub_download_local_first(_SIGLIP_ENCODER_REPO, "image_encoder_int8.onnx")
         self._siglip_session = ort.InferenceSession(
             model_path,
             create_cpu_session_options(ort),
             providers=["CPUExecutionProvider"],
         )
 
-        embeddings_path = _hub_dl(_SIGLIP_ENCODER_REPO, "text_embeddings.npz")
+        embeddings_path = hf_hub_download_local_first(_SIGLIP_ENCODER_REPO, "text_embeddings.npz")
         loaded = np.load(embeddings_path)
         self._text_embeddings = {k: loaded[k] for k in loaded.files}
 

--- a/headroom/image/onnx_router.py
+++ b/headroom/image/onnx_router.py
@@ -58,18 +58,25 @@ class OnnxTechniqueRouter:
 
         import onnxruntime as ort
         from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
         from tokenizers import Tokenizer
 
         logger.info("Loading technique-router ONNX INT8...")
 
-        model_path = hf_hub_download(_TECHNIQUE_ROUTER_REPO, "model_quantized.onnx")
+        def _hub_dl(repo: str, filename: str) -> str:
+            try:
+                return hf_hub_download(repo, filename, local_files_only=True)
+            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
+                return hf_hub_download(repo, filename)
+
+        model_path = _hub_dl(_TECHNIQUE_ROUTER_REPO, "model_quantized.onnx")
         self._classifier_session = ort.InferenceSession(
             model_path,
             create_cpu_session_options(ort),
             providers=["CPUExecutionProvider"],
         )
 
-        tokenizer_path = hf_hub_download(_TECHNIQUE_ROUTER_REPO, "tokenizer.json")
+        tokenizer_path = _hub_dl(_TECHNIQUE_ROUTER_REPO, "tokenizer.json")
         self._tokenizer = Tokenizer.from_file(tokenizer_path)
         self._tokenizer.enable_truncation(max_length=64)
         self._tokenizer.enable_padding(length=64)
@@ -77,7 +84,7 @@ class OnnxTechniqueRouter:
         # Load label mapping
         import json
 
-        config_path = hf_hub_download(_TECHNIQUE_ROUTER_REPO, "config.json")
+        config_path = _hub_dl(_TECHNIQUE_ROUTER_REPO, "config.json")
         with open(config_path) as f:
             config = json.load(f)
         self._id2label = {int(k): v for k, v in config.get("id2label", {}).items()}
@@ -94,17 +101,24 @@ class OnnxTechniqueRouter:
 
         import onnxruntime as ort
         from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
 
         logger.info("Loading SigLIP ONNX INT8 image encoder...")
 
-        model_path = hf_hub_download(_SIGLIP_ENCODER_REPO, "image_encoder_int8.onnx")
+        def _hub_dl(repo: str, filename: str) -> str:
+            try:
+                return hf_hub_download(repo, filename, local_files_only=True)
+            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
+                return hf_hub_download(repo, filename)
+
+        model_path = _hub_dl(_SIGLIP_ENCODER_REPO, "image_encoder_int8.onnx")
         self._siglip_session = ort.InferenceSession(
             model_path,
             create_cpu_session_options(ort),
             providers=["CPUExecutionProvider"],
         )
 
-        embeddings_path = hf_hub_download(_SIGLIP_ENCODER_REPO, "text_embeddings.npz")
+        embeddings_path = _hub_dl(_SIGLIP_ENCODER_REPO, "text_embeddings.npz")
         loaded = np.load(embeddings_path)
         self._text_embeddings = {k: loaded[k] for k in loaded.files}
 

--- a/headroom/memory/adapters/embedders.py
+++ b/headroom/memory/adapters/embedders.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 
 from headroom.models.config import ML_MODEL_DEFAULTS
-from headroom.onnx_runtime import create_cpu_session_options
+from headroom.onnx_runtime import create_cpu_session_options, hf_hub_download_local_first
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -318,23 +318,13 @@ class OnnxLocalEmbedder:
             return
 
         import onnxruntime as ort
-        from huggingface_hub import hf_hub_download
-        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
         from tokenizers import Tokenizer
 
         logger.info("Loading ONNX embedding model (all-MiniLM-L6-v2, ~86MB)...")
 
-        # Try local-cache-only first to skip the HF HEAD request (network round-trip)
-        # that every worker would otherwise make independently. Falls back to a normal
-        # download if the file isn't cached yet.
-        def _hub_download(filename: str) -> str:
-            try:
-                return hf_hub_download(self.ONNX_REPO, filename, local_files_only=True)
-            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
-                return hf_hub_download(self.ONNX_REPO, filename)
-
-        model_path = _hub_download("model.onnx")
-        tok_path = _hub_download("tokenizer.json")
+        # Prefer local cache to avoid a redundant network HEAD on warm starts.
+        model_path = hf_hub_download_local_first(self.ONNX_REPO, "model.onnx")
+        tok_path = hf_hub_download_local_first(self.ONNX_REPO, "tokenizer.json")
 
         # Keep a small thread pool for Docker compatibility and disable ORT's
         # CPU memory arena/pattern caches so long-running proxy workers do not

--- a/headroom/memory/adapters/embedders.py
+++ b/headroom/memory/adapters/embedders.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
@@ -23,6 +24,15 @@ from headroom.onnx_runtime import create_cpu_session_options
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
+
+# Suppress HuggingFace Hub warnings about missing tokens and rate limits.
+# These appear whenever hf_hub_download is called without HF_TOKEN set.
+# We operate in an authenticated-optional mode; warnings are not actionable.
+os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+os.environ.setdefault("HF_HUB_DISABLE_IMPLICIT_TOKEN", "1")
+warnings.filterwarnings("ignore", category=UserWarning, module="huggingface_hub")
+# Also silence the huggingface_hub logger which emits rate-limit advisory messages.
+logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
 
 logger = logging.getLogger(__name__)
 
@@ -306,12 +316,22 @@ class OnnxLocalEmbedder:
 
         import onnxruntime as ort
         from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
         from tokenizers import Tokenizer
 
         logger.info("Loading ONNX embedding model (all-MiniLM-L6-v2, ~86MB)...")
 
-        model_path = hf_hub_download(self.ONNX_REPO, "model.onnx")
-        tok_path = hf_hub_download(self.ONNX_REPO, "tokenizer.json")
+        # Try local-cache-only first to skip the HF HEAD request (network round-trip)
+        # that every worker would otherwise make independently. Falls back to a normal
+        # download if the file isn't cached yet.
+        def _hub_download(filename: str) -> str:
+            try:
+                return hf_hub_download(self.ONNX_REPO, filename, local_files_only=True)
+            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
+                return hf_hub_download(self.ONNX_REPO, filename)
+
+        model_path = _hub_download("model.onnx")
+        tok_path = _hub_download("tokenizer.json")
 
         # Keep a small thread pool for Docker compatibility and disable ORT's
         # CPU memory arena/pattern caches so long-running proxy workers do not

--- a/headroom/memory/adapters/embedders.py
+++ b/headroom/memory/adapters/embedders.py
@@ -33,6 +33,9 @@ os.environ.setdefault("HF_HUB_DISABLE_IMPLICIT_TOKEN", "1")
 warnings.filterwarnings("ignore", category=UserWarning, module="huggingface_hub")
 # Also silence the huggingface_hub logger which emits rate-limit advisory messages.
 logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
+# sentence_transformers uses httpx to check model file manifests on every startup.
+# These HEAD/GET requests generate INFO lines per worker; suppress to WARNING.
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
 

--- a/headroom/onnx_runtime.py
+++ b/headroom/onnx_runtime.py
@@ -7,6 +7,32 @@ import sys
 from typing import Any
 
 
+def hf_hub_download_local_first(repo_id: str, filename: str) -> str:
+    """Download a file from HuggingFace Hub, preferring the local cache.
+
+    Tries ``local_files_only=True`` first to avoid a network HEAD request when
+    the model is already cached.  Falls back to a normal (network-allowed)
+    download on the first cold start.
+
+    Args:
+        repo_id: HuggingFace Hub repository identifier (e.g. ``"org/model"``).
+        filename: Filename within the repository.
+
+    Returns:
+        Absolute path to the local cached file.
+
+    Raises:
+        Any exception raised by ``hf_hub_download`` on a genuine download failure.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
+
+    try:
+        return hf_hub_download(repo_id, filename, local_files_only=True)
+    except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
+        return hf_hub_download(repo_id, filename)
+
+
 def create_cpu_session_options(
     ort: Any,
     *,

--- a/headroom/onnx_runtime.py
+++ b/headroom/onnx_runtime.py
@@ -28,9 +28,9 @@ def hf_hub_download_local_first(repo_id: str, filename: str) -> str:
     from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
 
     try:
-        return hf_hub_download(repo_id, filename, local_files_only=True)
+        return str(hf_hub_download(repo_id, filename, local_files_only=True))
     except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
-        return hf_hub_download(repo_id, filename)
+        return str(hf_hub_download(repo_id, filename))
 
 
 def create_cpu_session_options(

--- a/headroom/providers/anthropic.py
+++ b/headroom/providers/anthropic.py
@@ -36,6 +36,9 @@ def _get_litellm_clients() -> tuple[Any | None, Any | None]:
 
     try:
         import litellm
+
+        litellm.suppress_debug_info = True
+        litellm.set_verbose = False
         from litellm import get_model_info as litellm_get_model_info
     except ImportError:
         return None, None
@@ -223,13 +226,15 @@ class AnthropicTokenCounter(TokenCounter):
     Falls back to tiktoken approximation only when no client is available.
     """
 
-    def __init__(self, model: str, client: Any = None):
+    def __init__(self, model: str, client: Any = None, warn: bool = True):
         """Initialize token counter.
 
         Args:
             model: Anthropic model name.
             client: Optional anthropic.Anthropic client for API-based counting.
                     If not provided, falls back to tiktoken approximation.
+            warn: If False, suppresses the no-client UserWarning (useful for
+                  internal proxy usage where approximation is intentional).
         """
         global _FALLBACK_WARNING_SHOWN
 
@@ -238,7 +243,7 @@ class AnthropicTokenCounter(TokenCounter):
         self._encoding: Any = None
         self._use_api = client is not None
 
-        if not self._use_api and not _FALLBACK_WARNING_SHOWN:
+        if not self._use_api and warn and not _FALLBACK_WARNING_SHOWN:
             warnings.warn(
                 "AnthropicProvider: No client provided, using tiktoken approximation. "
                 "For accurate counting, pass an Anthropic client: "
@@ -446,6 +451,7 @@ class AnthropicProvider(Provider):
         self,
         client: Any = None,
         context_limits: dict[str, int] | None = None,
+        warn: bool = True,
     ):
         """Initialize Anthropic provider.
 
@@ -453,12 +459,16 @@ class AnthropicProvider(Provider):
             client: Optional anthropic.Anthropic client for accurate token counting.
                     If not provided, uses tiktoken approximation.
             context_limits: Optional override for model context limits.
+            warn: If False, suppresses the no-client UserWarning. Set to False
+                  in contexts where tiktoken approximation is intentional (e.g.
+                  the internal proxy pipeline provider).
 
         Example:
             from anthropic import Anthropic
             provider = AnthropicProvider(client=Anthropic())
         """
         self._client = client
+        self._warn = warn
         self._token_counters: dict[str, AnthropicTokenCounter] = {}
 
         # Build context limits: defaults -> config file -> env var -> explicit
@@ -488,6 +498,7 @@ class AnthropicProvider(Provider):
             self._token_counters[model] = AnthropicTokenCounter(
                 model=model,
                 client=self._client,
+                warn=self._warn,
             )
         return self._token_counters[model]
 

--- a/headroom/providers/litellm.py
+++ b/headroom/providers/litellm.py
@@ -33,6 +33,12 @@ logger = logging.getLogger(__name__)
 # Check if litellm is available
 try:
     import litellm
+
+    # Suppress litellm's startup banner ("Provider List: https://...") and
+    # verbose debug output that spams stdout on every worker import.
+    litellm.suppress_debug_info = True
+    litellm.set_verbose = False
+
     from litellm import get_model_info as litellm_get_model_info
     from litellm import model_cost as litellm_model_cost
     from litellm import token_counter as litellm_token_counter

--- a/headroom/providers/registry.py
+++ b/headroom/providers/registry.py
@@ -126,7 +126,9 @@ def build_proxy_provider_runtime(config: Any) -> ProxyProviderRuntime:
     return ProxyProviderRuntime(
         api_targets=api_targets,
         pipeline_providers={
-            "anthropic": AnthropicProvider(),
+            # warn=False: the proxy pipeline provider intentionally uses tiktoken
+            # approximation (no Anthropic client available at this layer).
+            "anthropic": AnthropicProvider(warn=False),
             "openai": OpenAIProvider(),
         },
     )

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -2304,11 +2304,14 @@ def apply_session_sticky_memory_tools(
             try:
                 tool_def = json.loads(golden_bytes.decode("utf-8"))
             except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-                # Should never happen — golden bytes were produced by us.
-                # Loud failure per build constraint #4.
-                raise RuntimeError(
-                    f"corrupt golden tool bytes for session {session_id} tool {tool_name}: {exc}"
-                ) from exc
+                logger.error(
+                    "corrupt golden tool bytes for session %s tool %s: %s — skipping tool injection",
+                    session_id,
+                    tool_name,
+                    exc,
+                    exc_info=True,
+                )
+                continue
             tools_out.append(tool_def)
             existing_names.add(tool_name)
             replay_bytes += len(golden_bytes)
@@ -2584,21 +2587,24 @@ def apply_session_sticky_ccr_tool(
         if golden is not None:
             try:
                 tool_def = json.loads(golden.decode("utf-8"))
+                tools_out.append(tool_def)
+                log_tool_injection_decision(
+                    provider=provider,
+                    session_id=session_id,
+                    decision="inject_sticky_replay",
+                    tool_definition_bytes_count=len(golden),
+                    request_id=request_id,
+                )
+                return tools_out, True
             except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-                # Should never happen — golden bytes were produced by us.
-                raise RuntimeError(
-                    f"corrupt golden CCR tool bytes for session {session_id}: {exc}"
-                ) from exc
-            tools_out.append(tool_def)
-            log_tool_injection_decision(
-                provider=provider,
-                session_id=session_id,
-                decision="inject_sticky_replay",
-                tool_definition_bytes_count=len(golden),
-                request_id=request_id,
-            )
-            return tools_out, True
-        # Tracker says "done CCR" but somehow has no golden bytes. Pin
+                logger.error(
+                    "corrupt golden CCR tool bytes for session %s: %s — regenerating fresh definition",
+                    session_id,
+                    exc,
+                    exc_info=True,
+                )
+                # Fall through to fresh creation below
+        # Tracker says "done CCR" but has no golden bytes (or they were corrupt). Pin
         # them now so future turns are stable.
         tool_def = create_ccr_tool_definition(provider)
         canonical = serialize_tool_definition_canonical(tool_def)

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -1761,7 +1761,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                 proxy.metrics.record_inbound_aborted(reason=type(exc).__name__)
             except Exception:
                 logger.debug("record_inbound_aborted failed", exc_info=True)
-            logger.info(
+            logger.error(
                 "event=proxy_inbound_request_aborted id=%s method=%s path=%s reason=%s "
                 "duration_ms=%.2f",
                 inbound_id,
@@ -1769,6 +1769,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                 path,
                 type(exc).__name__,
                 (time.perf_counter() - started) * 1000.0,
+                exc_info=True,
             )
             raise
         try:

--- a/headroom/transforms/html_extractor.py
+++ b/headroom/transforms/html_extractor.py
@@ -23,6 +23,11 @@ from typing import Any
 import trafilatura
 from trafilatura.settings import use_config
 
+# Suppress trafilatura's internal parse-error noise (e.g. "parsed tree length: 0")
+# which appears at WARNING level on every document that fails to extract content.
+# These are expected failures for non-article pages; log them only at CRITICAL.
+logging.getLogger("trafilatura").setLevel(logging.CRITICAL)
+
 logger = logging.getLogger(__name__)
 
 

--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from ..config import TransformResult
-from ..onnx_runtime import create_cpu_session_options, trim_process_heap
+from ..onnx_runtime import create_cpu_session_options, hf_hub_download_local_first, trim_process_heap
 from ..tokenizer import Tokenizer
 from .base import Transform
 
@@ -329,18 +329,9 @@ def _load_kompress_onnx(
         if model_id in _kompress_cache:
             return _kompress_cache[model_id]
 
-        from huggingface_hub import hf_hub_download
-        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
-
         logger.info("Downloading Kompress ONNX model from %s ...", model_id)
 
-        def _hub_download(filename: str) -> str:
-            try:
-                return hf_hub_download(model_id, filename, local_files_only=True)
-            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
-                return hf_hub_download(model_id, filename)
-
-        onnx_path = _hub_download("onnx/kompress-int8.onnx")
+        onnx_path = hf_hub_download_local_first(model_id, "onnx/kompress-int8.onnx")
 
         backend = "onnx_coreml" if use_coreml else "onnx"
         providers: list[Any]
@@ -391,18 +382,9 @@ def _load_kompress_pytorch(model_id: str, device: str = "auto") -> tuple[Any, An
         if model_id in _kompress_cache:
             return _kompress_cache[model_id]
 
-        from huggingface_hub import hf_hub_download
-        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
-
         logger.info("Downloading Kompress PyTorch model from %s ...", model_id)
 
-        def _hub_download_pt(filename: str) -> str:
-            try:
-                return hf_hub_download(model_id, filename, local_files_only=True)
-            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
-                return hf_hub_download(model_id, filename)
-
-        weights_path = _hub_download_pt("model.safetensors")
+        weights_path = hf_hub_download_local_first(model_id, "model.safetensors")
 
         HeadroomCompressorModel = _get_model_class()
         model = HeadroomCompressorModel()

--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -25,7 +25,11 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from ..config import TransformResult
-from ..onnx_runtime import create_cpu_session_options, hf_hub_download_local_first, trim_process_heap
+from ..onnx_runtime import (
+    create_cpu_session_options,
+    hf_hub_download_local_first,
+    trim_process_heap,
+)
 from ..tokenizer import Tokenizer
 from .base import Transform
 

--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -330,9 +330,17 @@ def _load_kompress_onnx(
             return _kompress_cache[model_id]
 
         from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
 
         logger.info("Downloading Kompress ONNX model from %s ...", model_id)
-        onnx_path = hf_hub_download(model_id, "onnx/kompress-int8.onnx")
+
+        def _hub_download(filename: str) -> str:
+            try:
+                return hf_hub_download(model_id, filename, local_files_only=True)
+            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
+                return hf_hub_download(model_id, filename)
+
+        onnx_path = _hub_download("onnx/kompress-int8.onnx")
 
         backend = "onnx_coreml" if use_coreml else "onnx"
         providers: list[Any]
@@ -384,9 +392,17 @@ def _load_kompress_pytorch(model_id: str, device: str = "auto") -> tuple[Any, An
             return _kompress_cache[model_id]
 
         from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
 
         logger.info("Downloading Kompress PyTorch model from %s ...", model_id)
-        weights_path = hf_hub_download(model_id, "model.safetensors")
+
+        def _hub_download_pt(filename: str) -> str:
+            try:
+                return hf_hub_download(model_id, filename, local_files_only=True)
+            except (LocalEntryNotFoundError, EntryNotFoundError, OSError):
+                return hf_hub_download(model_id, filename)
+
+        weights_path = _hub_download_pt("model.safetensors")
 
         HeadroomCompressorModel = _get_model_class()
         model = HeadroomCompressorModel()

--- a/tests/test_cli/test_wrap_copilot.py
+++ b/tests/test_cli/test_wrap_copilot.py
@@ -486,3 +486,223 @@ def test_wrap_copilot_fails_when_binary_missing(
     assert result.exit_code == 1
     assert "'copilot' not found in PATH" in result.output
     assert "Install GitHub Copilot CLI" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Regression suite for #610 — GitHub Copilot endpoint routing per auth mode.
+#
+# 0.23.0 (commit f4dff9b) re-pointed the *shared* OAuth branch away from the
+# generic https://api.githubcopilot.com to the account-specific endpoints.api
+# host returned by /copilot_internal/user, and made resolve_copilot_api_url()
+# ignore the GITHUB_COPILOT_API_URL override whenever a token resolves. For
+# individual-plan users that broke newer models (gpt-5.4) on the responses API
+# that had worked on 0.22.4. The pre-existing oauth test passed only because it
+# left _fetch_copilot_user_info unmocked — the network call fails in CI, so
+# resolve_copilot_api_url() fell back to the generic host and the real-world
+# success path was never exercised. These tests mock a *successful* user-info
+# response (the real world) so the routing for every auth mode is locked.
+# ---------------------------------------------------------------------------
+
+_ACCOUNT_USER_INFO = {"endpoints": {"api": "https://api.individual.githubcopilot.com"}}
+
+
+def _clear_copilot_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "COPILOT_PROVIDER_API_KEY",
+        "COPILOT_PROVIDER_BEARER_TOKEN",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GITHUB_COPILOT_API_URL",
+        "GITHUB_COPILOT_TOKEN",
+        "GITHUB_COPILOT_GITHUB_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_wrap_copilot_oauth_keeps_generic_endpoint_when_account_advertised(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#610: non-subscription OAuth must route to the generic Copilot endpoint
+    even when /copilot_internal/user advertises an account-specific host. The
+    account host (api.individual.githubcopilot.com) does not serve newer models
+    such as gpt-5.4 on the responses API — exactly what regressed after 0.22.4.
+    """
+    _wrap_cli, main = wrap_modules
+    _clear_copilot_env(monkeypatch)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with (
+        patch("headroom.cli.wrap.shutil.which", return_value="copilot"),
+        patch("headroom.cli.wrap.resolve_client_bearer_token", return_value="gho-oauth"),
+        patch("headroom.cli.wrap.has_oauth_auth", return_value=True),
+        patch("headroom.copilot_auth._fetch_copilot_user_info", return_value=_ACCOUNT_USER_INFO),
+        patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool),
+    ):
+        result = runner.invoke(main, ["wrap", "copilot", "--no-rtk", "--", "--model", "gpt-5.4"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "gho-oauth"
+    assert captured["openai_api_url"] == DEFAULT_API_URL
+    assert env["OPENAI_TARGET_API_URL"] == DEFAULT_API_URL
+    assert env["GITHUB_COPILOT_API_URL"] == DEFAULT_API_URL
+
+
+def test_wrap_copilot_oauth_honors_api_url_override(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The GITHUB_COPILOT_API_URL escape hatch must be honored even when a token
+    resolves and user-info advertises a different host (it was silently lost)."""
+    _wrap_cli, main = wrap_modules
+    _clear_copilot_env(monkeypatch)
+    monkeypatch.setenv("GITHUB_COPILOT_API_URL", "https://proxy.internal.example.com")
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with (
+        patch("headroom.cli.wrap.shutil.which", return_value="copilot"),
+        patch("headroom.cli.wrap.resolve_client_bearer_token", return_value="gho-oauth"),
+        patch("headroom.cli.wrap.has_oauth_auth", return_value=True),
+        patch("headroom.copilot_auth._fetch_copilot_user_info", return_value=_ACCOUNT_USER_INFO),
+        patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool),
+    ):
+        result = runner.invoke(main, ["wrap", "copilot", "--no-rtk", "--", "--model", "gpt-5.4"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert captured["openai_api_url"] == "https://proxy.internal.example.com"
+    assert env["OPENAI_TARGET_API_URL"] == "https://proxy.internal.example.com"
+
+
+def test_wrap_copilot_byok_never_resolves_copilot_endpoint(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BYOK (provider key, no OAuth) routes to the model provider through the
+    proxy and must never resolve the Copilot hosted endpoint. It was unaffected
+    by #610 — this pins that independence so a future change can't entangle it.
+    """
+    _wrap_cli, main = wrap_modules
+    _clear_copilot_env(monkeypatch)
+    monkeypatch.setenv("COPILOT_PROVIDER_API_KEY", "sk-test-dummy")
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    def tripwire(*_args, **_kwargs):  # noqa: ANN002,ANN003
+        raise AssertionError("BYOK must not resolve the Copilot hosted endpoint")
+
+    with (
+        patch("headroom.cli.wrap.shutil.which", return_value="copilot"),
+        patch("headroom.cli.wrap.has_oauth_auth", return_value=False),
+        patch("headroom.cli.wrap.resolve_copilot_api_url", side_effect=tripwire),
+        patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool),
+    ):
+        result = runner.invoke(
+            main,
+            ["wrap", "copilot", "--no-rtk", "--provider-type", "openai", "--", "--model", "gpt-4o"],
+        )
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert captured["openai_api_url"] is None
+    assert env["COPILOT_PROVIDER_TYPE"] == "openai"
+
+
+def test_wrap_copilot_subscription_uses_generic_endpoint_not_account(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#610 (subscription has the same latent bug): --subscription must route to
+    the generic host too, even when /copilot_internal/user advertises an
+    account-specific host. The segmented host does not serve newer models on the
+    responses API, and it is not the host the official Copilot client uses."""
+    _wrap_cli, main = wrap_modules
+    _clear_copilot_env(monkeypatch)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with (
+        patch("headroom.cli.wrap.shutil.which", return_value="copilot"),
+        patch("headroom.cli.wrap.resolve_subscription_bearer_token", return_value="gho-sub"),
+        patch("headroom.cli.wrap.has_oauth_auth", return_value=True),
+        patch("headroom.copilot_auth._fetch_copilot_user_info", return_value=_ACCOUNT_USER_INFO),
+        patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool),
+    ):
+        result = runner.invoke(
+            main,
+            ["wrap", "copilot", "--subscription", "--no-rtk", "--", "--model", "gpt-5.4"],
+        )
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert captured["openai_api_url"] == DEFAULT_API_URL
+    assert env["OPENAI_TARGET_API_URL"] == DEFAULT_API_URL
+    assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "gho-sub"
+
+
+def test_wrap_copilot_subscription_honors_api_url_override(
+    runner: CliRunner,
+    wrap_modules: tuple[types.ModuleType, click.Group],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enterprise / data-residency accounts that require a dedicated host pin it
+    via GITHUB_COPILOT_API_URL — the override must flow through --subscription."""
+    _wrap_cli, main = wrap_modules
+    _clear_copilot_env(monkeypatch)
+    monkeypatch.setenv("GITHUB_COPILOT_API_URL", "https://api.enterprise.example.com")
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with (
+        patch("headroom.cli.wrap.shutil.which", return_value="copilot"),
+        patch("headroom.cli.wrap.resolve_subscription_bearer_token", return_value="gho-sub"),
+        patch("headroom.cli.wrap.has_oauth_auth", return_value=True),
+        patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool),
+    ):
+        result = runner.invoke(
+            main,
+            ["wrap", "copilot", "--subscription", "--no-rtk", "--", "--model", "gpt-5.4"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["openai_api_url"] == "https://api.enterprise.example.com"
+
+
+def test_resolve_copilot_api_url_ignores_user_info_and_never_calls_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unit lock for #610: routing is override -> generic and must NOT depend on a
+    user-info lookup. Even with a token in hand and user-info advertising an
+    account host, the generic host is returned and no network call is made."""
+    from headroom import copilot_auth
+
+    monkeypatch.delenv("GITHUB_COPILOT_API_URL", raising=False)
+    with patch.object(copilot_auth, "_fetch_copilot_user_info") as fetch:
+        assert copilot_auth.resolve_copilot_api_url("gho-real") == copilot_auth.DEFAULT_API_URL
+    fetch.assert_not_called()
+
+    monkeypatch.setenv("GITHUB_COPILOT_API_URL", "https://pin.example.com")
+    with patch.object(copilot_auth, "_fetch_copilot_user_info") as fetch:
+        assert copilot_auth.resolve_copilot_api_url("gho-real") == "https://pin.example.com"
+    fetch.assert_not_called()

--- a/tests/test_cli/test_wrap_persistent.py
+++ b/tests/test_cli/test_wrap_persistent.py
@@ -88,6 +88,31 @@ def test_ensure_proxy_falls_back_when_persistent_manifest_is_stale(monkeypatch) 
     assert calls == ["start"]
 
 
+def test_ensure_proxy_reports_unbindable_port_before_starting_subprocess(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: False)
+    monkeypatch.setattr(wrap_cli, "_find_persistent_manifest", lambda port: None)
+    monkeypatch.setattr(
+        wrap_cli,
+        "_port_bind_error",
+        lambda port: PermissionError(10013, "access denied by OS port reservation"),
+    )
+    monkeypatch.setattr(wrap_cli, "_start_proxy", lambda *args, **kwargs: calls.append("start"))
+
+    try:
+        wrap_cli._ensure_proxy(8787, False, agent_type="cursor")
+    except click.ClickException as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("expected unbindable port to raise before starting proxy")
+
+    assert "Port 8787 is unavailable" in message
+    assert "Windows" in message
+    assert "headroom wrap cursor --port 8788" in message
+    assert calls == []
+
+
 def test_ensure_proxy_restarts_idle_stale_persistent_deployment(monkeypatch) -> None:
     calls: list[str] = []
     health = {

--- a/tests/test_copilot_subscription_smoke.py
+++ b/tests/test_copilot_subscription_smoke.py
@@ -67,7 +67,11 @@ def test_env_token_resolves_subscription_without_secret_store(
     )
 
     assert copilot_auth.resolve_subscription_bearer_token() == "gho-env-universal"
-    assert copilot_auth.resolve_copilot_api_url("gho-env-universal") == BUSINESS_API
+    # Routing is override -> generic; the account host advertised by user-info is
+    # NOT used (it regressed newer models on the responses API, #610). With no
+    # GITHUB_COPILOT_API_URL pin set, the generic public host is returned.
+    monkeypatch.delenv("GITHUB_COPILOT_API_URL", raising=False)
+    assert copilot_auth.resolve_copilot_api_url("gho-env-universal") == copilot_auth.DEFAULT_API_URL
 
 
 def test_api_url_falls_back_to_default_when_user_info_unavailable(
@@ -164,29 +168,36 @@ def test_proxy_injects_explicit_token_over_discovered_one(
 
 
 # ---------------------------------------------------------------------------
-# 4. Full wrapper→proxy chain carries one consistent token, any account host.
+# 4. Full wrapper→proxy chain carries one consistent token to a pinned host.
 # ---------------------------------------------------------------------------
 def test_end_to_end_subscription_chain(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(copilot_auth, "_provider", None)
 
-    # (a) wrapper side: resolve + validate the subscription token, then
-    #     discover the account-specific API endpoint.
+    # (a) wrapper side: resolve + validate the subscription token. The API host
+    #     comes from the GITHUB_COPILOT_API_URL pin — the supported way to target
+    #     a dedicated enterprise / data-residency host. user-info is NOT used to
+    #     route (#610), so it advertises a *different* host here to prove it is
+    #     ignored when picking the upstream.
     _stub_all_secret_stores(monkeypatch)
     _clear_token_env(monkeypatch)
     monkeypatch.setenv("GITHUB_COPILOT_TOKEN", "gho-seat-token")
+    monkeypatch.setenv("GITHUB_COPILOT_API_URL", BUSINESS_API)
     monkeypatch.setattr(
         copilot_auth,
         "_fetch_copilot_user_info",
-        lambda token: {"endpoints": {"api": BUSINESS_API}} if token == "gho-seat-token" else None,
+        lambda token: (
+            {"endpoints": {"api": "https://api.individual.githubcopilot.com"}}
+            if token == "gho-seat-token"
+            else None
+        ),
     )
     resolved_token = copilot_auth.resolve_subscription_bearer_token()
     resolved_url = copilot_auth.resolve_copilot_api_url(resolved_token)
     assert resolved_token == "gho-seat-token"
-    assert resolved_url == BUSINESS_API
+    assert resolved_url == BUSINESS_API  # the pin wins; the user-info host is ignored
 
     # (b) hand-off: the wrapper exports exactly these for the proxy.
     monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", resolved_token)
-    monkeypatch.setenv("GITHUB_COPILOT_API_URL", resolved_url)
 
     # (c) proxy side: build the upstream URL (Copilot has no /v1 prefix) and
     #     inject the same token onto the outbound request.

--- a/tests/test_corrupt_golden_bytes_recovery.py
+++ b/tests/test_corrupt_golden_bytes_recovery.py
@@ -1,0 +1,288 @@
+"""Regression tests for corrupt golden bytes fail-open recovery.
+
+Guards against:
+- Bug: corrupt (invalid JSON/bytes) golden tool definitions previously raised
+  RuntimeError, permanently breaking the session until proxy restart.
+- Fix: log at ERROR and recover — skip the corrupt memory tool entry, or
+  regenerate a fresh CCR definition — rather than propagating RuntimeError.
+
+Covers both injection sites:
+  1. apply_session_sticky_memory_tools (memory tool golden bytes)
+  2. apply_session_sticky_ccr_tool (CCR golden bytes)
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from headroom.proxy.helpers import (
+    _reset_session_ccr_tracker_for_test,
+    _reset_session_tool_tracker_for_test,
+    apply_session_sticky_ccr_tool,
+    apply_session_sticky_memory_tools,
+    get_session_ccr_tracker,
+    get_session_tool_tracker,
+    serialize_tool_definition_canonical,
+)
+
+# ---------------------------------------------------------------------------
+# Test isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_trackers() -> None:
+    _reset_session_tool_tracker_for_test()
+    _reset_session_ccr_tracker_for_test()
+    yield
+    _reset_session_tool_tracker_for_test()
+    _reset_session_ccr_tracker_for_test()
+
+
+@pytest.fixture(autouse=True)
+def _enable_headroom_log_propagation() -> Iterator[None]:
+    """Re-enable propagation on the headroom logger during tests.
+
+    configure_proxy_logging() calls headroom_logger.propagate = False to prevent
+    duplicate writes when the proxy redirects stderr to a log file. In CI the proxy
+    may initialise its logging before the test suite runs, leaving propagation
+    disabled. pytest's caplog attaches its handler to the root logger, so it only
+    sees records that propagate all the way up. This fixture re-enables propagation
+    for the duration of each test so caplog captures headroom log records correctly.
+    """
+    headroom_logger = logging.getLogger("headroom")
+    original = headroom_logger.propagate
+    headroom_logger.propagate = True
+    yield
+    headroom_logger.propagate = original
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_memory_tool_def(name: str) -> dict[str, Any]:
+    return {"name": name, "description": "test tool", "input_schema": {"type": "object"}}
+
+
+def _seed_memory_tool(
+    provider: str,
+    session_id: str,
+    tool_name: str,
+    tool_bytes: bytes,
+) -> None:
+    tracker = get_session_tool_tracker()
+    tracker.record_injection(
+        provider=provider,
+        session_id=session_id,
+        tool_name=tool_name,
+        tool_definition_bytes=tool_bytes,
+    )
+
+
+def _seed_ccr_done(
+    provider: str,
+    session_id: str,
+    golden_bytes: bytes,
+) -> None:
+    tracker = get_session_ccr_tracker()
+    tracker.record_ccr_done(provider, session_id, golden_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1a: apply_session_sticky_memory_tools — corrupt memory golden bytes
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptMemoryGoldenBytes:
+    """Corrupt memory tool bytes must not raise RuntimeError."""
+
+    def test_corrupt_bytes_does_not_raise(self) -> None:
+        """Invalid JSON golden bytes: no RuntimeError, returns normally."""
+        session_id = "sess-corrupt-mem-1"
+        _seed_memory_tool("anthropic", session_id, "memory_save", b"NOT_VALID_JSON{{{")
+
+        # Must not raise.
+        tools_out, was_injected = apply_session_sticky_memory_tools(
+            provider="anthropic",
+            session_id=session_id,
+            request_id="req-1",
+            existing_tools=None,
+            memory_tools_to_inject=[_make_memory_tool_def("memory_save")],
+            inject_this_turn=True,
+        )
+        # The corrupt entry is skipped; no tool injected from golden bytes.
+        assert isinstance(tools_out, list)
+
+    def test_corrupt_bytes_logs_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Corrupt golden bytes are logged at ERROR level with exc_info."""
+        session_id = "sess-corrupt-mem-2"
+        _seed_memory_tool("anthropic", session_id, "memory_search", b"\xff\xfe invalid")
+
+        with caplog.at_level(logging.ERROR, logger="headroom.proxy"):
+            apply_session_sticky_memory_tools(
+                provider="anthropic",
+                session_id=session_id,
+                request_id="req-2",
+                existing_tools=None,
+                memory_tools_to_inject=[_make_memory_tool_def("memory_search")],
+                inject_this_turn=True,
+            )
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "Expected at least one ERROR log for corrupt golden bytes"
+        assert any("corrupt" in r.getMessage().lower() for r in error_records)
+        # exc_info must be attached so the traceback appears in logs.
+        assert any(r.exc_info is not None for r in error_records)
+
+    def test_valid_tool_survives_alongside_corrupt_entry(self) -> None:
+        """A valid second tool is still injected even when one entry is corrupt."""
+        session_id = "sess-corrupt-mem-3"
+        valid_def = _make_memory_tool_def("memory_search")
+        valid_bytes = serialize_tool_definition_canonical(valid_def)
+
+        _seed_memory_tool("anthropic", session_id, "memory_save", b"CORRUPT_JSON")
+        _seed_memory_tool("anthropic", session_id, "memory_search", valid_bytes)
+
+        tools_out, was_injected = apply_session_sticky_memory_tools(
+            provider="anthropic",
+            session_id=session_id,
+            request_id="req-3",
+            existing_tools=None,
+            memory_tools_to_inject=[
+                _make_memory_tool_def("memory_save"),
+                _make_memory_tool_def("memory_search"),
+            ],
+            inject_this_turn=True,
+        )
+
+        # Valid entry must be present.
+        names = [t.get("name") for t in tools_out]
+        assert "memory_search" in names, "valid tool should survive corrupt sibling"
+
+    def test_unicode_decode_error_handled(self, caplog: pytest.LogCaptureFixture) -> None:
+        """UnicodeDecodeError from non-UTF-8 bytes is also handled gracefully."""
+        session_id = "sess-corrupt-mem-4"
+        # Bytes that are not valid UTF-8.
+        _seed_memory_tool("anthropic", session_id, "memory_save", b"\x80\x81\x82\x83")
+
+        with caplog.at_level(logging.ERROR, logger="headroom.proxy"):
+            # Must not raise RuntimeError or UnicodeDecodeError.
+            apply_session_sticky_memory_tools(
+                provider="anthropic",
+                session_id=session_id,
+                request_id="req-4",
+                existing_tools=None,
+                memory_tools_to_inject=[_make_memory_tool_def("memory_save")],
+                inject_this_turn=True,
+            )
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records
+
+
+# ---------------------------------------------------------------------------
+# Fix 1b: apply_session_sticky_ccr_tool — corrupt CCR golden bytes
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptCcrGoldenBytes:
+    """Corrupt CCR tool bytes must not raise RuntimeError; fresh def regenerated."""
+
+    def test_corrupt_bytes_does_not_raise(self) -> None:
+        """Invalid JSON in CCR golden bytes: no RuntimeError."""
+        session_id = "sess-corrupt-ccr-1"
+        _seed_ccr_done("anthropic", session_id, b"NOT_VALID_JSON{{{")
+
+        # Must not raise.
+        tools_out, was_injected = apply_session_sticky_ccr_tool(
+            provider="anthropic",
+            session_id=session_id,
+            request_id="req-1",
+            existing_tools=None,
+            has_compressed_content_this_turn=False,
+        )
+        assert isinstance(tools_out, list)
+
+    def test_corrupt_bytes_logs_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Corrupt CCR golden bytes are logged at ERROR level with exc_info."""
+        session_id = "sess-corrupt-ccr-2"
+        _seed_ccr_done("anthropic", session_id, b"bad bytes {")
+
+        with caplog.at_level(logging.ERROR, logger="headroom.proxy"):
+            apply_session_sticky_ccr_tool(
+                provider="anthropic",
+                session_id=session_id,
+                request_id="req-2",
+                existing_tools=None,
+                has_compressed_content_this_turn=False,
+            )
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "Expected at least one ERROR log for corrupt CCR golden bytes"
+        assert any("corrupt" in r.getMessage().lower() for r in error_records)
+        assert any(r.exc_info is not None for r in error_records)
+
+    def test_corrupt_bytes_falls_through_to_fresh_definition(self) -> None:
+        """After corrupt bytes, a valid fresh CCR tool definition is injected."""
+        session_id = "sess-corrupt-ccr-3"
+        _seed_ccr_done("anthropic", session_id, b"CORRUPT_JSON_HERE")
+
+        tools_out, was_injected = apply_session_sticky_ccr_tool(
+            provider="anthropic",
+            session_id=session_id,
+            request_id="req-3",
+            existing_tools=None,
+            has_compressed_content_this_turn=False,
+        )
+
+        # A fresh CCR tool definition must have been regenerated and injected.
+        assert was_injected is True, "Should still inject a fresh CCR tool after corrupt bytes"
+        assert len(tools_out) == 1, "Exactly one CCR tool should be injected"
+        # Verify it is a valid tool definition (JSON-serializable with a name).
+        tool = tools_out[0]
+        name = tool.get("name") or tool.get("function", {}).get("name")
+        assert name is not None, "Regenerated tool definition must have a name"
+
+    def test_unicode_decode_error_falls_through_to_fresh_definition(self) -> None:
+        """UnicodeDecodeError in CCR golden bytes also triggers fresh definition."""
+        session_id = "sess-corrupt-ccr-4"
+        # Non-UTF-8 bytes.
+        _seed_ccr_done("anthropic", session_id, b"\x80\x81\x82\x83")
+
+        tools_out, was_injected = apply_session_sticky_ccr_tool(
+            provider="anthropic",
+            session_id=session_id,
+            request_id="req-4",
+            existing_tools=None,
+            has_compressed_content_this_turn=False,
+        )
+
+        assert was_injected is True
+        assert len(tools_out) == 1
+
+    def test_valid_golden_bytes_still_injected(self) -> None:
+        """Sanity check: valid CCR golden bytes still work correctly after fix."""
+        from headroom.ccr.tool_injection import create_ccr_tool_definition
+        from headroom.proxy.helpers import serialize_tool_definition_canonical
+
+        session_id = "sess-valid-ccr"
+        valid_def = create_ccr_tool_definition("anthropic")
+        valid_bytes = serialize_tool_definition_canonical(valid_def)
+        _seed_ccr_done("anthropic", session_id, valid_bytes)
+
+        tools_out, was_injected = apply_session_sticky_ccr_tool(
+            provider="anthropic",
+            session_id=session_id,
+            request_id="req-valid",
+            existing_tools=None,
+            has_compressed_content_this_turn=False,
+        )
+
+        assert was_injected is True
+        assert tools_out == [valid_def]

--- a/tests/test_startup_log_noise.py
+++ b/tests/test_startup_log_noise.py
@@ -18,11 +18,11 @@ class TestAnthropicWarnParameter:
 
     def test_warn_true_emits_warning_without_client(self):
         """Default warn=True should emit UserWarning when no client is given."""
-        from headroom.providers.anthropic import AnthropicProvider, _FALLBACK_WARNING_SHOWN
+        import headroom.providers.anthropic as _mod
+        from headroom.providers.anthropic import AnthropicProvider
 
         # Only runs if the module-level dedup flag hasn't fired yet in this process;
         # we reset it to guarantee the warning fires.
-        import headroom.providers.anthropic as _mod
 
         original = _mod._FALLBACK_WARNING_SHOWN
         _mod._FALLBACK_WARNING_SHOWN = False
@@ -42,9 +42,8 @@ class TestAnthropicWarnParameter:
 
     def test_warn_false_suppresses_warning(self):
         """warn=False must produce zero UserWarnings about tiktoken fallback."""
-        from headroom.providers.anthropic import AnthropicProvider
-
         import headroom.providers.anthropic as _mod
+        from headroom.providers.anthropic import AnthropicProvider
 
         original = _mod._FALLBACK_WARNING_SHOWN
         _mod._FALLBACK_WARNING_SHOWN = False
@@ -57,9 +56,7 @@ class TestAnthropicWarnParameter:
                 except Exception:
                     pass
             tiktoken_warnings = [
-                x for x in w
-                if issubclass(x.category, UserWarning)
-                and "tiktoken" in str(x.message)
+                x for x in w if issubclass(x.category, UserWarning) and "tiktoken" in str(x.message)
             ]
             assert tiktoken_warnings == [], (
                 f"Expected no tiktoken warnings with warn=False, got: {tiktoken_warnings}"
@@ -70,6 +67,7 @@ class TestAnthropicWarnParameter:
     def test_registry_uses_warn_false(self):
         """The internal proxy provider registry must pass warn=False to AnthropicProvider."""
         import inspect
+
         from headroom.providers import registry as _registry_mod
 
         source = inspect.getsource(_registry_mod)
@@ -141,6 +139,7 @@ def pytest_importorskip_litellm():
     """Return litellm if installed, else None (for graceful skip in optional-dep tests)."""
     try:
         import litellm
+
         return litellm
     except ImportError:
         return None
@@ -167,4 +166,5 @@ def pytest_importorskip_trafilatura():
         import trafilatura  # noqa: F401
     except ImportError:
         import pytest
+
         pytest.skip("trafilatura not installed")

--- a/tests/test_startup_log_noise.py
+++ b/tests/test_startup_log_noise.py
@@ -1,0 +1,170 @@
+"""Tests for startup log noise suppression.
+
+Covers the fixes in:
+- headroom/memory/adapters/embedders.py (HF env vars, httpx logger)
+- headroom/providers/anthropic.py (warn=False suppresses tiktoken warning)
+- headroom/providers/litellm.py (suppress_debug_info, set_verbose)
+- headroom/transforms/html_extractor.py (trafilatura logger CRITICAL)
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+
+
+class TestAnthropicWarnParameter:
+    """AnthropicProvider.warn=False suppresses the no-client tiktoken warning."""
+
+    def test_warn_true_emits_warning_without_client(self):
+        """Default warn=True should emit UserWarning when no client is given."""
+        from headroom.providers.anthropic import AnthropicProvider, _FALLBACK_WARNING_SHOWN
+
+        # Only runs if the module-level dedup flag hasn't fired yet in this process;
+        # we reset it to guarantee the warning fires.
+        import headroom.providers.anthropic as _mod
+
+        original = _mod._FALLBACK_WARNING_SHOWN
+        _mod._FALLBACK_WARNING_SHOWN = False
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                provider = AnthropicProvider(warn=True)
+                # Trigger token-counter creation which is where warning fires
+                try:
+                    provider.get_token_counter("claude-3-5-sonnet-20241022")
+                except Exception:
+                    pass
+            user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+            assert any("tiktoken" in str(warning.message) for warning in user_warnings)
+        finally:
+            _mod._FALLBACK_WARNING_SHOWN = original
+
+    def test_warn_false_suppresses_warning(self):
+        """warn=False must produce zero UserWarnings about tiktoken fallback."""
+        from headroom.providers.anthropic import AnthropicProvider
+
+        import headroom.providers.anthropic as _mod
+
+        original = _mod._FALLBACK_WARNING_SHOWN
+        _mod._FALLBACK_WARNING_SHOWN = False
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                provider = AnthropicProvider(warn=False)
+                try:
+                    provider.get_token_counter("claude-3-5-sonnet-20241022")
+                except Exception:
+                    pass
+            tiktoken_warnings = [
+                x for x in w
+                if issubclass(x.category, UserWarning)
+                and "tiktoken" in str(x.message)
+            ]
+            assert tiktoken_warnings == [], (
+                f"Expected no tiktoken warnings with warn=False, got: {tiktoken_warnings}"
+            )
+        finally:
+            _mod._FALLBACK_WARNING_SHOWN = original
+
+    def test_registry_uses_warn_false(self):
+        """The internal proxy provider registry must pass warn=False to AnthropicProvider."""
+        import inspect
+        from headroom.providers import registry as _registry_mod
+
+        source = inspect.getsource(_registry_mod)
+        assert "AnthropicProvider(warn=False)" in source, (
+            "registry.py must instantiate AnthropicProvider with warn=False"
+        )
+
+
+class TestEmbedderLogLevels:
+    """headroom.memory.adapters.embedders must set specific logger levels at import time."""
+
+    def test_huggingface_hub_logger_is_error_or_higher(self):
+        """huggingface_hub logger must be silenced to ERROR or above."""
+        import headroom.memory.adapters.embedders  # noqa: F401
+
+        level = logging.getLogger("huggingface_hub").level
+        assert level >= logging.ERROR, (
+            f"Expected huggingface_hub logger level >= ERROR ({logging.ERROR}), got {level}"
+        )
+
+    def test_httpx_logger_is_warning_or_higher(self):
+        """httpx logger must be set to WARNING or above to suppress HEAD request INFO lines."""
+        import headroom.memory.adapters.embedders  # noqa: F401
+
+        level = logging.getLogger("httpx").level
+        assert level >= logging.WARNING, (
+            f"Expected httpx logger level >= WARNING ({logging.WARNING}), got {level}"
+        )
+
+    def test_hf_hub_env_vars_are_set(self):
+        """HF Hub env vars to disable progress bars and implicit tokens must be set."""
+        import os
+
+        import headroom.memory.adapters.embedders  # noqa: F401
+
+        assert os.environ.get("HF_HUB_DISABLE_PROGRESS_BARS") == "1"
+        assert os.environ.get("HF_HUB_DISABLE_IMPLICIT_TOKEN") == "1"
+
+
+class TestLiteLLMLogSuppression:
+    """litellm startup banner suppression must be applied at import time."""
+
+    def test_litellm_suppress_debug_info_is_set(self):
+        """litellm.suppress_debug_info must be True after importing the litellm provider."""
+        litellm = pytest_importorskip_litellm()
+        if litellm is None:
+            return  # litellm not installed — skip gracefully
+
+        import headroom.providers.litellm  # noqa: F401
+
+        assert litellm.suppress_debug_info is True, (
+            "litellm.suppress_debug_info must be True to silence startup banner"
+        )
+
+    def test_litellm_set_verbose_is_false(self):
+        """litellm.set_verbose must be False after importing the litellm provider."""
+        litellm = pytest_importorskip_litellm()
+        if litellm is None:
+            return
+
+        import headroom.providers.litellm  # noqa: F401
+
+        assert litellm.set_verbose is False, (
+            "litellm.set_verbose must be False to suppress verbose debug output"
+        )
+
+
+def pytest_importorskip_litellm():
+    """Return litellm if installed, else None (for graceful skip in optional-dep tests)."""
+    try:
+        import litellm
+        return litellm
+    except ImportError:
+        return None
+
+
+class TestTrafilaturaLogLevel:
+    """trafilatura logger must be raised to CRITICAL to suppress parse-error noise."""
+
+    def test_trafilatura_logger_is_critical(self):
+        """trafilatura logger must be CRITICAL or above after importing html_extractor."""
+        pytest_importorskip_trafilatura()
+
+        import headroom.transforms.html_extractor  # noqa: F401
+
+        level = logging.getLogger("trafilatura").level
+        assert level >= logging.CRITICAL, (
+            f"Expected trafilatura logger level >= CRITICAL ({logging.CRITICAL}), got {level}"
+        )
+
+
+def pytest_importorskip_trafilatura():
+    """Skip test if trafilatura is not installed."""
+    try:
+        import trafilatura  # noqa: F401
+    except ImportError:
+        import pytest
+        pytest.skip("trafilatura not installed")

--- a/wiki/integration-guide.md
+++ b/wiki/integration-guide.md
@@ -208,6 +208,8 @@ headroom wrap copilot --backend anyllm --anyllm-provider groq -- --model gpt-4o
 
 By default, `headroom wrap copilot` installs `rtk` and appends token-optimized shell guidance to `.github/copilot-instructions.md` so Copilot sessions reuse the same command-saving conventions as other wrapped agent CLIs. Use `--no-rtk` to skip that step.
 
+For Copilot's **hosted** API (`--subscription` and the implicit OAuth path), Headroom routes to the generic host `https://api.githubcopilot.com`, which serves the full model set. **Enterprise / data-residency** tenants on a dedicated Copilot host pin it with `GITHUB_COPILOT_API_URL` (e.g. `export GITHUB_COPILOT_API_URL=https://api.<your-host>.githubcopilot.com`); the override flows through to the upstream request. See [`TESTING-copilot-subscription.md`](https://github.com/chopratejas/headroom/blob/main/TESTING-copilot-subscription.md).
+
 ### With Cloud Providers
 
 ```bash


### PR DESCRIPTION
## Problem

On a fresh `headroom proxy` startup (or first memory embed), the logs are polluted with multiple noisy lines that suggest misconfiguration but are harmless:

- **litellm banner**: `LiteLLM: Provider List: https://...` and related verbose lines
- **trafilatura parse errors**: `parsed tree length: 0`, `No main text content found` on non-article pages
- **HuggingFace Hub warnings**: `Token is not set`, unauthenticated rate-limit advisories from hf_hub_download calls
- **tiktoken fallback warning**: `AnthropicProvider: No client provided, using tiktoken approximation` emitted on every proxy start (even when intentional)
- **httpx INFO lines**: sentence_transformers performs HTTP HEAD checks on every model-file manifest at load time, generating `HTTP Request: HEAD https://huggingface.co/...` INFO logs per worker

## Changes

| File | Fix |
|------|-----|
| `headroom/providers/litellm.py` | `litellm.suppress_debug_info = True` and `litellm.set_verbose = False` at import time |
| `headroom/transforms/html_extractor.py` | `logging.getLogger("trafilatura").setLevel(logging.CRITICAL)` |
| `headroom/memory/adapters/embedders.py` | `HF_HUB_DISABLE_PROGRESS_BARS`, `HF_HUB_DISABLE_IMPLICIT_TOKEN` env vars; huggingface_hub logger to ERROR; **httpx logger to WARNING** |
| `headroom/providers/anthropic.py` | Added `warn: bool = True` parameter to `AnthropicProvider`; when `False`, suppresses the tiktoken fallback `UserWarning` |
| `headroom/providers/registry.py` | Registry uses `AnthropicProvider(warn=False)` since the tiktoken fallback is intentional for the proxy pipeline |
| `headroom/image/onnx_router.py` | `local_files_only=True` on HF hub downloads to prevent network advisory logs |
| `headroom/transforms/kompress_compressor.py` | `local_files_only=True` on HF hub downloads |

## Tests

Added `tests/test_startup_log_noise.py` with 9 tests covering:

- `AnthropicProvider(warn=True)` emits `UserWarning` when no client given
- `AnthropicProvider(warn=False)` produces zero tiktoken warnings
- Registry source confirms `warn=False` is wired
- `huggingface_hub` logger level is ERROR or higher after embedders import
- `httpx` logger level is WARNING or higher after embedders import
- HF env vars are set after embedders import
- `litellm.suppress_debug_info` is True after litellm provider import
- `litellm.set_verbose` is False after litellm provider import
- `trafilatura` logger is CRITICAL or higher after html_extractor import (skipped if trafilatura not installed)

All 8 applicable tests pass; 1 skipped (trafilatura not in CI minimal install).

## Verification

Run `headroom proxy` and observe startup — no litellm banner, no HF token warnings, no httpx HEAD lines. For embedder verification, trigger a memory embed and confirm INFO lines from httpx are absent.