### PR TITLE
fix(startup): move HF/httpx log suppression before sentence_transformers init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Bug Fixes
+
+* **startup:** move HF/httpx log suppression to CLI module level so it fires before sentence_transformers worker init, eliminating ~50 noisy startup lines per proxy run
+
+
 ## [0.23.0](https://github.com/chopratejas/headroom/compare/v0.22.4...v0.23.0) (2026-06-04)
 
 ### Features

--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -1,7 +1,9 @@
 """Proxy server CLI commands."""
 
+import logging
 import os
 import sys
+import warnings
 from typing import Any, Literal, cast
 
 import click
@@ -11,6 +13,40 @@ from headroom.providers.registry import resolve_api_overrides, resolve_api_targe
 from headroom.proxy.modes import PROXY_MODE_TOKEN, normalize_proxy_mode
 
 from .main import main
+
+# ---------------------------------------------------------------------------
+# Startup log suppression.
+#
+# sentence_transformers makes HEAD/GET requests to HuggingFace Hub on every
+# worker startup to validate the model manifest.  Each request produces an
+# INFO-level httpx record and a WARNING from huggingface_hub about a missing
+# HF_TOKEN.  With 8 workers this generates ~50 noisy lines per startup.
+#
+# Placing the suppression here (module-level in the first CLI module imported)
+# ensures it is in place before sentence_transformers, huggingface_hub, or
+# httpx are initialised by any downstream import or worker fork.
+#
+# The env vars silence the warnings.warn() path ("unauthenticated requests"
+# message) which bypasses the logging system entirely.
+# ---------------------------------------------------------------------------
+
+# Env-var knobs are read by huggingface_hub before its logger hierarchy forms.
+os.environ.setdefault("HF_HUB_DISABLE_IMPLICIT_TOKEN", "1")
+os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+
+# Logger-level suppression: httpx HEAD/GET manifest checks + HF advisory msgs.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
+logging.getLogger("huggingface_hub.utils._http").setLevel(logging.ERROR)
+logging.getLogger("sentence_transformers").setLevel(logging.WARNING)
+
+# warnings.warn() path: huggingface_hub emits UserWarning for missing tokens.
+warnings.filterwarnings("ignore", message=".*unauthenticated.*", category=UserWarning)
+warnings.filterwarnings("ignore", message=".*HF_TOKEN.*", category=UserWarning)
+warnings.filterwarnings("ignore", message=".*huggingface.*token.*", category=UserWarning)
+warnings.filterwarnings("ignore", category=UserWarning, module="huggingface_hub")
+
+# ---------------------------------------------------------------------------
 
 _CONTEXT_TOOL_ENV = "HEADROOM_CONTEXT_TOOL"
 _CONTEXT_TOOL_RTK = "rtk"


### PR DESCRIPTION
## Problem

The proxy prints ~50 noisy log lines on every startup with 8 workers:

```
httpx - INFO - HTTP Request: HEAD https://huggingface.co/answerdotai/ModernBERT-base/resolve/main/config.json "HTTP/1.1 307 Temporary Redirect"
huggingface_hub.utils._http - WARNING - Warning: You are sending unauthenticated requests...
httpx - INFO - HTTP Request: GET https://huggingface.co/api/models/answerdotai/ModernBERT-base/tree/main?recursive=true&expand=false "HTTP/1.1 200 OK"
```

## Root Cause

The existing suppression in `headroom/memory/adapters/embedders.py` (from PR #619) runs at module-import time for `embedders.py`. However, `sentence_transformers` is imported lazily — only when `SentenceTransformer()` is instantiated in a worker process. By the time `embedders.py` is first imported, the `httpx` and `huggingface_hub` loggers have already emitted their records.

## Fix

Move the suppression to `headroom/cli/proxy.py` module level. This file is imported during CLI registration (`_register_commands()` in `main.py`), which happens well before any worker forks or ML initialisation. Setting log levels here guarantees they are in place for every code path that eventually loads `sentence_transformers`.

## Changes

- `headroom/cli/proxy.py`: Add module-level log suppression block immediately after imports
  - `logging.getLogger("httpx").setLevel(WARNING)` — suppress manifest HEAD/GET INFO lines  
  - `logging.getLogger("huggingface_hub").setLevel(ERROR)`
  - `logging.getLogger("huggingface_hub.utils._http").setLevel(ERROR)`
  - `logging.getLogger("sentence_transformers").setLevel(WARNING)`
  - `os.environ.setdefault("HF_HUB_DISABLE_IMPLICIT_TOKEN", "1")` — silence pre-import env check
  - `os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")`
  - `warnings.filterwarnings` to suppress unauthenticated/HF_TOKEN `UserWarning`s (the stderr path that bypasses logging)

## Relationship to PR #619

PR #619 adds the same suppression in `embedders.py`. This PR is **complementary** — it adds the missing **earlier** suppression point. Both can be merged; the `embedders.py` suppression provides defence-in-depth for code paths that import `embedders.py` without going through the CLI (e.g. tests, scripts).

## Adversarial Review

**Security**: Suppressing `huggingface_hub` at ERROR level only silences INFO/WARNING advisory messages. Genuine auth errors (4xx/5xx) propagate as exceptions, not log records — they still raise and surface to the caller.

**Reliability**: `local_files_only` is NOT set — first-run downloads still work. The suppression only hides log noise; network calls still happen.

**Operations**: ERROR-level HF records (actual failures) still surface. The suppression targets the "You are sending unauthenticated requests" advisory which is not actionable in headroom's auth-optional model.

**Backward compatibility**: No API changes. Users who want verbose HF logging can set `HF_HUB_VERBOSITY=debug` in their environment; `setLevel` does not override explicit user configuration of the root logger.

**Test impact**: No tests were added because this is a logging-configuration change with no observable behaviour change (no new code paths, no new outputs). The effect is negative — lines disappear from stderr.