### PR TITLE
fix(proxy): route Claude Code model metadata to Anthropic

### DIFF
--- a/headroom/providers/registry.py
+++ b/headroom/providers/registry.py
@@ -312,8 +312,16 @@ _CLIENT_TRANSPORTS: dict[str, _ClientTransport] = {
 
 def _is_anthropic_auth(headers: Mapping[str, str]) -> bool:
     authorization = headers.get("authorization") or headers.get("Authorization") or ""
+    user_agent = headers.get("user-agent") or headers.get("User-Agent") or ""
     return bool(
         headers.get("x-api-key")
         or headers.get("anthropic-version")
         or authorization.startswith("Bearer sk-ant-")
+        or _is_claude_code_client(user_agent)
     )
+
+
+def _is_claude_code_client(user_agent: str) -> bool:
+    """Return True for Claude Code/Claude CLI requests using Anthropic gateway auth."""
+    normalized = user_agent.lower()
+    return "claude-code/" in normalized or "claude-cli/" in normalized

--- a/tests/test_provider_proxy_routes.py
+++ b/tests/test_provider_proxy_routes.py
@@ -521,3 +521,47 @@ def test_v1_models_still_forwards_under_non_chatgpt_auth() -> None:
     assert response.status_code == 200
     # Forwarded — not synthesized — because no chatgpt-account-id header.
     assert calls, "Non-ChatGPT-auth /v1/models must forward, not synthesize"
+
+
+def test_v1_models_routes_claude_code_gateway_discovery_to_anthropic() -> None:
+    """Claude Code gateway/OAuth model discovery can use a Bearer token that
+    does not look like an Anthropic API key. Route those `/v1/models` requests
+    to Anthropic so Claude's gateway model cache is not populated from OpenAI.
+    """
+    calls: list[tuple[str, str, str]] = []
+
+    async def fake_passthrough(self, request, base_url, sub_path="", provider_name=""):  # type: ignore[no-untyped-def]
+        calls.append((request.url.path, base_url, provider_name))
+        return JSONResponse({"base_url": base_url, "provider": provider_name})
+
+    with patch.object(HeadroomProxy, "handle_passthrough", fake_passthrough):
+        with TestClient(_app()) as client:
+            list_response = client.get(
+                "/v1/models",
+                headers={
+                    "authorization": "Bearer claude-gateway-oauth-token",
+                    "user-agent": "claude-code/1.5.0 (darwin; arm64)",
+                },
+            )
+            get_response = client.get(
+                "/v1/models/claude-opus-4-8",
+                headers={
+                    "authorization": "Bearer claude-gateway-oauth-token",
+                    "user-agent": "claude-code/1.5.0 (darwin; arm64)",
+                },
+            )
+
+    assert list_response.status_code == 200
+    assert get_response.status_code == 200
+    assert list_response.json() == {
+        "base_url": "https://api.anthropic.test",
+        "provider": "anthropic",
+    }
+    assert get_response.json() == {
+        "base_url": "https://api.anthropic.test",
+        "provider": "anthropic",
+    }
+    assert calls == [
+        ("/v1/models", "https://api.anthropic.test", "anthropic"),
+        ("/v1/models/claude-opus-4-8", "https://api.anthropic.test", "anthropic"),
+    ]


### PR DESCRIPTION
## Summary
- route Claude Code/Claude CLI `/v1/models` discovery requests to the Anthropic upstream when they carry gateway-style Bearer auth
- keep the existing ChatGPT/Codex synthetic model-list handling and generic OpenAI Bearer routing unchanged
- add regression coverage for both `/v1/models` and `/v1/models/{id}` under a Claude Code user agent

## Context
Issue #626 reports Claude Code's gateway model cache being populated through Headroom and then missing newer Claude models. One reproducible routing edge is that Claude Code gateway/OAuth model discovery can use a Bearer token that does not look like a regular Anthropic API key. In that case Headroom treated `/v1/models` as OpenAI metadata and forwarded it to the OpenAI upstream instead of Anthropic.

I left the `[1m]` suffix itself untouched: that appears to be a Claude Code model-tier marker, not something Headroom should strip from request/response bodies.

## Verification
- `.\.venv313\Scripts\python.exe -m pytest -q tests\test_provider_proxy_routes.py -q`
- `.\.venv313\Scripts\ruff.exe check headroom\providers\registry.py tests\test_provider_proxy_routes.py`
- `git diff --check`