### PR TITLE
fix(proxy): narrow multi-worker warning to CompressionCache and PrefixTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+
+* **proxy:** narrow multi-worker startup warning to accurately name only `CompressionCache` and `PrefixTracker` as per-worker state; CCR store and TOIN are global singletons (file-backed) and are already shared across workers, so the previous warning was misleading. Updated `RUST_DEV.md` to match.
+
 ## [0.23.0](https://github.com/chopratejas/headroom/compare/v0.22.4...v0.23.0) (2026-06-04)
 
 ### Features

--- a/RUST_DEV.md
+++ b/RUST_DEV.md
@@ -331,16 +331,24 @@ in-memory.
 
 (Historical context — applies only when the operator explicitly
 chooses `CcrBackendConfig::InMemory`.) Each uvicorn worker is a
-separate Python process. Each process holds its own copies of:
+separate Python process. The following state is fragmented across workers
+in the Python proxy:
 
 1. **`InMemoryCcrStore`** — sharded `DashMap` mapping
    `hash → original_content` for content the compressor replaced with
    `<<ccr:HASH>>` markers.
-2. **`HeadroomProxy._compression_caches`** (`headroom/proxy/server.py:367`)
-   — per-session `CompressionCache` dict.
+2. **`HeadroomProxy._compression_caches`** (`headroom/proxy/server.py`)
+   — per-session `CompressionCache` dict (instance var, truly per-worker).
 3. **`HeadroomProxy.session_tracker_store`** — per-session prefix-tracker
-   state derived from Anthropic's `cache_read_input_tokens` responses.
-4. **TOIN learner state** — pattern statistics used to bias the compressor.
+   state derived from Anthropic's `cache_read_input_tokens` responses
+   (instance var, truly per-worker).
+
+Note: **CCR store** and **TOIN learner state** in the Python proxy are
+global singletons (file-backed via `CompressionStore` and
+`~/.headroom/toin.json` respectively). They are shared across all workers
+in the same process group and are NOT fragmented by multi-worker
+deployments. The startup warning covers only `CompressionCache` and
+`PrefixTracker`.
 
 When uvicorn round-robins requests across workers, a session whose
 turn-1 landed on worker A may have turn-2 land on worker B. Worker B has

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -3080,18 +3080,18 @@ def run_server(
     app_target: Any
     uvicorn_kwargs: dict[str, Any] = {}
     if workers > 1:
-        # CCR / compression-cache / prefix-tracker / TOIN state are all
-        # per-process. Round-robin across workers fragments these caches
-        # and produces silent retrieval failures for `Retrieve original:
-        # hash=X` markers and avoidable cache busts on the upstream
-        # provider. See the "Multi-worker deployment — CCR fragmentation"
-        # section in RUST_DEV.md for the full failure modes and the
-        # sticky-session workaround.
+        # CompressionCache and PrefixTracker are per-worker instance vars.
+        # Round-robin across workers fragments them: a session whose turn-1
+        # lands on worker A and turn-2 on worker B gets cache busts and
+        # stale prefix predictions because worker B has no knowledge of
+        # what worker A accumulated. CCR store and TOIN are global
+        # singletons (file-backed) so they are already shared — they are
+        # NOT affected by this warning. See RUST_DEV.md →
+        # "Multi-worker deployment — CCR fragmentation" for full details.
         logger.warning(
-            "Headroom is running with workers=%d. The in-memory CCR store, "
-            "compression cache, prefix tracker, and TOIN state are all "
-            "per-process; multi-worker deployments produce silent retrieval "
-            "failures and avoidable cache busts when sessions land on different "
+            "Headroom is running with workers=%d. The in-memory compression "
+            "cache and prefix tracker are per-worker; multi-worker deployments "
+            "produce avoidable cache busts when sessions land on different "
             "workers. Run --workers 1 (or place a sticky-session load balancer "
             "in front of multiple --workers 1 processes). See RUST_DEV.md → "
             "'Multi-worker deployment — CCR fragmentation'.",


### PR DESCRIPTION
## Problem

When running headroom with `--workers N`, the startup warning incorrectly claimed that CCR store and TOIN state are per-process/fragmented. This was inaccurate.

## What the audit found

| Store | Was claimed | Reality |
|---|---|---|
| `CompressionCache` | per-worker | **Correct** — instance var on each `HeadroomProxy` |
| `PrefixTracker` | per-worker | **Correct** — instance var on each `HeadroomProxy` |
| CCR store | per-worker | **Wrong** — global singleton (`get_compression_store()`), shared across workers by default |
| TOIN state | per-worker | **Wrong** — global singleton (`get_toin()`), backed by `~/.headroom/toin.json`, shared |

The real problem is narrower: **CompressionCache and PrefixTracker are fragmented** across workers. A session that lands on worker A builds prefix-tracker state that worker B never sees, producing avoidable cache busts. CCR lookups and TOIN learning are unaffected by multi-worker deployments.

## Changes

### Warning accuracy (`headroom/proxy/server.py`)

Warning message now names only `CompressionCache` and `PrefixTracker`; comment above explains why CCR + TOIN are excluded.

### Documentation (`RUST_DEV.md`)

Updated "Multi-worker deployment — CCR fragmentation" section to list only the two truly-per-worker stores and note that CCR store and TOIN are global file-backed singletons.

## Files changed

- `headroom/proxy/server.py` — narrowed multi-worker warning message and comment
- `RUST_DEV.md` — updated multi-worker fragmentation documentation
- `CHANGELOG.md` — changelog entry

## Testing

No new tests required — this is a documentation and log message accuracy fix. Existing tests pass.