### PR TITLE
fix(init): serialize persistent runtime startup

### DIFF
--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import time
 from hashlib import sha1
 from pathlib import Path
 from typing import Any
@@ -16,11 +17,17 @@ from typing import Any
 import click
 
 from headroom.install.models import ConfigScope, InstallPreset, RuntimeKind, SupervisorKind
-from headroom.install.paths import claude_settings_path, codex_config_path, validate_profile_name
+from headroom.install.paths import (
+    claude_settings_path,
+    codex_config_path,
+    profile_root,
+    validate_profile_name,
+)
 from headroom.install.planner import build_manifest
 from headroom.install.providers import _apply_unix_env_scope, _apply_windows_env_scope
 from headroom.install.runtime import (
     resolve_headroom_command,
+    runtime_status,
     start_detached_agent,
     start_persistent_docker,
     stop_runtime,
@@ -46,6 +53,8 @@ _CODEX_FEATURE_MARKER_END = "# --- end Headroom init features ---"
 _SUPPORTED_TARGETS = ("claude", "copilot", "codex", "openclaw")
 _LOCAL_TARGETS = {"claude", "codex"}
 _GLOBAL_TARGETS = {"claude", "copilot", "codex", "openclaw"}
+
+_START_LOCK_TTL_SECONDS = 120
 
 
 def _command_string(parts: list[str]) -> str:
@@ -546,13 +555,67 @@ def _install_copilot_marketplace() -> None:
     )
 
 
+def _profile_start_lock_path(profile: str) -> Path:
+    return profile_root(profile) / "startup.lock"
+
+
+def _acquire_profile_start_lock(profile: str) -> int | None:
+    path = _profile_start_lock_path(profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        return os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        try:
+            stale = time.time() - path.stat().st_mtime > _START_LOCK_TTL_SECONDS
+        except OSError:
+            return None
+        if not stale:
+            return None
+        try:
+            path.unlink()
+        except OSError:
+            return None
+        try:
+            return os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            return None
+
+
+def _release_profile_start_lock(profile: str, fd: int) -> None:
+    os.close(fd)
+    try:
+        _profile_start_lock_path(profile).unlink()
+    except OSError:
+        pass
+
+
+def _runtime_is_running(manifest: Any) -> bool:
+    try:
+        return runtime_status(manifest) == "running"
+    except Exception:
+        return False
+
+
 def _ensure_profile_running(profile: str) -> None:
     manifest = load_manifest(profile)
     if manifest is None:
         return
     if wait_ready(manifest, timeout_seconds=1):
         return
+    if _runtime_is_running(manifest):
+        wait_ready(manifest, timeout_seconds=15)
+        return
+    lock_fd = _acquire_profile_start_lock(manifest.profile)
+    if lock_fd is None:
+        wait_ready(manifest, timeout_seconds=15)
+        return
     try:
+        os.write(lock_fd, str(os.getpid()).encode())
+        if wait_ready(manifest, timeout_seconds=1):
+            return
+        if _runtime_is_running(manifest):
+            wait_ready(manifest, timeout_seconds=15)
+            return
         if manifest.preset == InstallPreset.PERSISTENT_DOCKER.value:
             start_persistent_docker(manifest)
         elif manifest.supervisor_kind == SupervisorKind.SERVICE.value:
@@ -562,6 +625,8 @@ def _ensure_profile_running(profile: str) -> None:
         wait_ready(manifest, timeout_seconds=45)
     except Exception:
         return
+    finally:
+        _release_profile_start_lock(manifest.profile, lock_fd)
 
 
 def _probe_init_targets(global_scope: bool) -> list[tuple[str, str | None]]:

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -779,6 +779,8 @@ def test_ensure_profile_running_covers_runtime_modes(monkeypatch) -> None:
     detached_calls: list[str] = []
     wait_calls: list[tuple[str, int]] = []
 
+    monkeypatch.setattr(init_cli, "runtime_status", lambda manifest: "stopped")
+
     monkeypatch.setattr(init_cli, "load_manifest", lambda profile: manifests.get(profile))
 
     def fake_wait_ready(manifest, timeout_seconds: int) -> bool:
@@ -810,6 +812,95 @@ def test_ensure_profile_running_covers_runtime_modes(monkeypatch) -> None:
     assert ("docker-profile", 45) in wait_calls
 
 
+def test_ensure_profile_running_skips_spawn_while_runtime_is_starting(monkeypatch) -> None:
+    init_cli, _ = _load_init_module(monkeypatch)
+    manifest = SimpleNamespace(
+        preset=init_cli.InstallPreset.PERSISTENT_TASK.value,
+        supervisor_kind=init_cli.SupervisorKind.NONE.value,
+        profile="task-profile",
+    )
+    detached_calls: list[str] = []
+    wait_calls: list[int] = []
+
+    monkeypatch.setattr(init_cli, "load_manifest", lambda profile: manifest)
+    monkeypatch.setattr(init_cli, "runtime_status", lambda manifest: "running")
+
+    def fake_wait_ready(manifest, timeout_seconds: int) -> bool:
+        wait_calls.append(timeout_seconds)
+        return False
+
+    monkeypatch.setattr(init_cli, "wait_ready", fake_wait_ready)
+    monkeypatch.setattr(
+        init_cli,
+        "start_detached_agent",
+        lambda profile: detached_calls.append(profile),
+    )
+
+    init_cli._ensure_profile_running("task-profile")
+
+    assert detached_calls == []
+    assert wait_calls == [1, 15]
+
+
+def test_ensure_profile_running_skips_spawn_when_start_lock_exists(
+    monkeypatch, tmp_path: Path
+) -> None:
+    init_cli, _ = _load_init_module(monkeypatch)
+    manifest = SimpleNamespace(
+        preset=init_cli.InstallPreset.PERSISTENT_TASK.value,
+        supervisor_kind=init_cli.SupervisorKind.NONE.value,
+        profile="task-profile",
+    )
+    detached_calls: list[str] = []
+    wait_calls: list[int] = []
+
+    monkeypatch.setattr(init_cli.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(init_cli, "load_manifest", lambda profile: manifest)
+    monkeypatch.setattr(init_cli, "runtime_status", lambda manifest: "stopped")
+
+    def fake_wait_ready(manifest, timeout_seconds: int) -> bool:
+        wait_calls.append(timeout_seconds)
+        return False
+
+    monkeypatch.setattr(init_cli, "wait_ready", fake_wait_ready)
+    monkeypatch.setattr(
+        init_cli,
+        "start_detached_agent",
+        lambda profile: detached_calls.append(profile),
+    )
+
+    lock_fd = init_cli._acquire_profile_start_lock("task-profile")
+    assert lock_fd is not None
+    try:
+        init_cli._ensure_profile_running("task-profile")
+    finally:
+        init_cli._release_profile_start_lock("task-profile", lock_fd)
+
+    assert detached_calls == []
+    assert wait_calls == [1, 15]
+
+
+def test_profile_start_lock_replaces_stale_lock(monkeypatch, tmp_path: Path) -> None:
+    init_cli, _ = _load_init_module(monkeypatch)
+    monkeypatch.setattr(init_cli.Path, "home", lambda: tmp_path)
+    path = init_cli._profile_start_lock_path("task-profile")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("old", encoding="utf-8")
+    old_mtime = path.stat().st_mtime
+    monkeypatch.setattr(
+        init_cli.time,
+        "time",
+        lambda: old_mtime + init_cli._START_LOCK_TTL_SECONDS + 1,
+    )
+
+    lock_fd = init_cli._acquire_profile_start_lock("task-profile")
+    assert lock_fd is not None
+    try:
+        assert path.exists()
+    finally:
+        init_cli._release_profile_start_lock("task-profile", lock_fd)
+
+
 def test_ensure_profile_running_returns_when_ready_or_on_exception(monkeypatch) -> None:
     init_cli, _ = _load_init_module(monkeypatch)
     manifest = SimpleNamespace(
@@ -818,6 +909,7 @@ def test_ensure_profile_running_returns_when_ready_or_on_exception(monkeypatch) 
         profile="task-profile",
     )
     detached_calls: list[str] = []
+    monkeypatch.setattr(init_cli, "runtime_status", lambda manifest: "stopped")
     monkeypatch.setattr(init_cli, "load_manifest", lambda profile: manifest)
     monkeypatch.setattr(init_cli, "wait_ready", lambda manifest, timeout_seconds: True)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Fixes #615.

This prevents concurrent `headroom init hook ensure` invocations from spawning multiple persistent-task runners while the proxy is still warming up.

- add a per-profile atomic `startup.lock` around `_ensure_profile_running` startup work
- wait instead of spawning when another hook is already starting the same profile
- wait instead of spawning when the runtime process/container is already running but `/readyz` is not ready yet
- recover from stale startup locks after a bounded TTL
- add regression coverage for the running-but-not-ready path, the concurrent-lock path, and stale-lock recovery

The change intentionally keeps the existing hook behavior quiet: failed readiness/start attempts still return without breaking the agent hook.

## Verification

- `$env:TMP=(Resolve-Path .tmp).Path; $env:TEMP=$env:TMP; .venv313\Scripts\python.exe -m pytest -q tests\test_cli\test_init_cli.py -q` (`52 passed`)
- `.venv313\Scripts\ruff.exe check headroom\cli\init.py tests\test_cli\test_init_cli.py`
- `.venv313\Scripts\ruff.exe format headroom\cli\init.py tests\test_cli\test_init_cli.py`
- `git diff --check`