### PR TITLE
feat(cli): add --format json|csv to perf

### DIFF
--- a/headroom/cli/perf.py
+++ b/headroom/cli/perf.py
@@ -1,5 +1,7 @@
 """Performance analysis CLI command."""
 
+import json
+
 import click
 
 from .main import main
@@ -13,7 +15,15 @@ from .main import main
     help="Analyze logs from the last N hours (default: 168 = 7 days)",
 )
 @click.option("--raw", is_flag=True, help="Show raw PERF records instead of report")
-def perf(hours: float, raw: bool) -> None:
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["text", "json", "csv"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format. `json` emits aggregated metrics, `csv` emits one row per request.",
+)
+def perf(hours: float, raw: bool, fmt: str) -> None:
     """Analyze proxy performance from logs.
 
     \b
@@ -26,13 +36,28 @@ def perf(hours: float, raw: bool) -> None:
 
     \b
     Examples:
-        headroom perf                Analyze last 7 days
-        headroom perf --hours 24     Analyze last 24 hours
-        headroom perf --raw          Show raw parsed records
+        headroom perf                       Analyze last 7 days
+        headroom perf --hours 24            Analyze last 24 hours
+        headroom perf --raw                 Show raw parsed records
+        headroom perf --format json         Emit aggregated metrics as JSON
+        headroom perf --format csv          Emit per-request rows as CSV
     """
-    from headroom.perf.analyzer import format_report, parse_log_files
+    from headroom.perf.analyzer import (
+        format_csv,
+        format_report,
+        parse_log_files,
+        summary_dict,
+    )
 
     report = parse_log_files(last_n_hours=hours)
+
+    fmt = fmt.lower()
+    if fmt == "json":
+        click.echo(json.dumps(summary_dict(report), indent=2))
+        return
+    if fmt == "csv":
+        click.echo(format_csv(report), nl=False)
+        return
 
     if raw:
         for r in report.perf_records:

--- a/headroom/perf/analyzer.py
+++ b/headroom/perf/analyzer.py
@@ -625,6 +625,127 @@ def format_report(report: PerfReport) -> str:
     return "\n".join(lines)
 
 
+def summary_dict(report: PerfReport) -> dict:
+    """Build the aggregated, machine-readable view of ``report``.
+
+    Mirrors the headline numbers shown in :func:`format_report` so CI jobs,
+    dashboards, and agent tools can consume them without parsing the text
+    output. Per-record arrays are intentionally omitted — callers who want
+    them can use ``perf --raw`` or the CSV formatter below.
+    """
+    records = report.perf_records
+    total_before = sum(r.tokens_before for r in records)
+    total_after = sum(r.tokens_after for r in records)
+    total_saved = sum(r.tokens_saved for r in records)
+    savings_pct = (total_saved / total_before * 100) if total_before > 0 else 0.0
+
+    cache_records = [r for r in records if (r.cache_read + r.cache_write) > 0]
+    total_cr = sum(r.cache_read for r in cache_records)
+    total_cw = sum(r.cache_write for r in cache_records)
+    total_cache = total_cr + total_cw
+    cache_hit_pct = (total_cr / total_cache * 100) if total_cache > 0 else 0.0
+
+    by_model: dict[str, dict] = {}
+    grouped: dict[str, list[PerfRecord]] = {}
+    for r in records:
+        grouped.setdefault(r.model, []).append(r)
+    for model, recs in grouped.items():
+        m_before = sum(r.tokens_before for r in recs)
+        m_after = sum(r.tokens_after for r in recs)
+        m_saved = sum(r.tokens_saved for r in recs)
+        by_model[model] = {
+            "requests": len(recs),
+            "tokens_before": m_before,
+            "tokens_after": m_after,
+            "tokens_saved": m_saved,
+            "savings_pct": (m_saved / m_before * 100) if m_before > 0 else 0.0,
+        }
+
+    by_transform: dict[str, dict] = {}
+    t_grouped: dict[str, list[TransformRecord]] = {}
+    for tr in report.transform_records:
+        t_grouped.setdefault(tr.name, []).append(tr)
+    for name, recs in t_grouped.items():
+        t_before = sum(r.tokens_before for r in recs)
+        t_after = sum(r.tokens_after for r in recs)
+        t_saved = sum(r.tokens_saved for r in recs)
+        by_transform[name] = {
+            "uses": len(recs),
+            "tokens_before": t_before,
+            "tokens_after": t_after,
+            "tokens_saved": t_saved,
+            "savings_pct": (t_saved / t_before * 100) if t_before > 0 else 0.0,
+        }
+
+    return {
+        "window_hours": report.requested_hours,
+        "oldest_kept_ts": report.oldest_kept_ts,
+        "newest_kept_ts": report.newest_kept_ts,
+        "total_requests": len(records),
+        "total_tokens_before": total_before,
+        "total_tokens_after": total_after,
+        "tokens_saved": total_saved,
+        "savings_pct": savings_pct,
+        "cache_read_tokens": total_cr,
+        "cache_write_tokens": total_cw,
+        "cache_hit_pct": cache_hit_pct,
+        "by_model": by_model,
+        "by_transform": by_transform,
+        "log_files_read": report.log_files_read,
+        "total_lines_parsed": report.total_lines_parsed,
+    }
+
+
+# Header order for `format_csv`. Kept explicit (rather than reading from the
+# dataclass fields) so downstream consumers can pin to a stable column layout
+# even if `PerfRecord` grows new fields later.
+_PERF_CSV_COLUMNS = (
+    "timestamp",
+    "request_id",
+    "model",
+    "num_messages",
+    "tokens_before",
+    "tokens_after",
+    "tokens_saved",
+    "cache_read",
+    "cache_write",
+    "cache_hit_pct",
+    "optimization_ms",
+)
+
+
+def format_csv(report: PerfReport) -> str:
+    """Render ``report.perf_records`` as CSV (one row per request).
+
+    Per-record granularity mirrors ``perf --raw`` so the CSV is directly
+    spreadsheet- or pandas-friendly. Aggregates are intentionally not
+    written here — they live in :func:`summary_dict` and JSON output.
+    """
+    import csv
+    import io
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    writer.writerow(_PERF_CSV_COLUMNS)
+    for r in report.perf_records:
+        writer.writerow(
+            [
+                r.timestamp,
+                r.request_id,
+                r.model,
+                r.num_messages,
+                r.tokens_before,
+                r.tokens_after,
+                r.tokens_saved,
+                r.cache_read,
+                r.cache_write,
+                r.cache_hit_pct,
+                f"{r.optimization_ms:.0f}",
+            ]
+        )
+    return buf.getvalue()
+
+
 def _format_toin_highlights() -> list[str]:
     """Render a human-readable TOIN highlights block from the live store.
 

--- a/tests/test_perf_format.py
+++ b/tests/test_perf_format.py
@@ -1,0 +1,164 @@
+"""Tests for `headroom perf --format {json,csv}` (issue #595).
+
+These tests exercise the formatter helpers directly so they don't need
+to spin up the proxy or read real log files.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+
+from headroom.perf.analyzer import (
+    PerfRecord,
+    PerfReport,
+    TransformRecord,
+    format_csv,
+    summary_dict,
+)
+
+
+def _make_report() -> PerfReport:
+    return PerfReport(
+        perf_records=[
+            PerfRecord(
+                timestamp="2026-06-01 10:00:00,000",
+                request_id="hr_001",
+                model="claude-opus-4-8",
+                num_messages=10,
+                tokens_before=1000,
+                tokens_after=400,
+                tokens_saved=600,
+                cache_read=200,
+                cache_write=50,
+                cache_hit_pct=80,
+                optimization_ms=43.1,
+            ),
+            PerfRecord(
+                timestamp="2026-06-01 10:05:00,000",
+                request_id="hr_002",
+                model="claude-opus-4-8",
+                num_messages=20,
+                tokens_before=2000,
+                tokens_after=600,
+                tokens_saved=1400,
+                cache_read=400,
+                cache_write=100,
+                cache_hit_pct=80,
+                optimization_ms=55.0,
+            ),
+            PerfRecord(
+                timestamp="2026-06-01 10:10:00,000",
+                request_id="hr_003",
+                model="gpt-5",
+                num_messages=5,
+                tokens_before=500,
+                tokens_after=200,
+                tokens_saved=300,
+            ),
+        ],
+        transform_records=[
+            TransformRecord(
+                timestamp="2026-06-01 10:00:00,000",
+                name="content_router",
+                tokens_before=3000,
+                tokens_after=1200,
+                tokens_saved=1800,
+            ),
+        ],
+        log_files_read=1,
+        total_lines_parsed=42,
+        requested_hours=24.0,
+        oldest_kept_ts="2026-06-01 10:00:00,000",
+        newest_kept_ts="2026-06-01 10:10:00,000",
+    )
+
+
+def test_summary_dict_top_level_aggregates() -> None:
+    summary = summary_dict(_make_report())
+    assert summary["window_hours"] == 24.0
+    assert summary["total_requests"] == 3
+    assert summary["total_tokens_before"] == 3500
+    assert summary["total_tokens_after"] == 1200
+    assert summary["tokens_saved"] == 2300
+    # 2300 / 3500 == 65.7142...
+    assert summary["savings_pct"] == 2300 / 3500 * 100
+    # Only two of the three records carry cache info: read=600 write=150, total=750
+    assert summary["cache_read_tokens"] == 600
+    assert summary["cache_write_tokens"] == 150
+    assert summary["cache_hit_pct"] == 600 / 750 * 100
+
+
+def test_summary_dict_by_model_groups_by_model() -> None:
+    summary = summary_dict(_make_report())
+    by_model = summary["by_model"]
+    assert set(by_model.keys()) == {"claude-opus-4-8", "gpt-5"}
+
+    claude = by_model["claude-opus-4-8"]
+    assert claude["requests"] == 2
+    assert claude["tokens_before"] == 3000
+    assert claude["tokens_after"] == 1000
+    assert claude["tokens_saved"] == 2000
+
+    gpt = by_model["gpt-5"]
+    assert gpt["requests"] == 1
+    assert gpt["tokens_saved"] == 300
+
+
+def test_summary_dict_by_transform_groups_by_name() -> None:
+    summary = summary_dict(_make_report())
+    assert summary["by_transform"]["content_router"]["uses"] == 1
+    assert summary["by_transform"]["content_router"]["tokens_saved"] == 1800
+
+
+def test_summary_dict_round_trips_through_json() -> None:
+    # Anything non-JSON-serialisable in the summary would blow up here.
+    summary = summary_dict(_make_report())
+    encoded = json.dumps(summary)
+    decoded = json.loads(encoded)
+    assert decoded["total_requests"] == 3
+
+
+def test_summary_dict_handles_empty_report() -> None:
+    summary = summary_dict(PerfReport())
+    assert summary["total_requests"] == 0
+    assert summary["total_tokens_before"] == 0
+    assert summary["savings_pct"] == 0.0
+    assert summary["cache_hit_pct"] == 0.0
+    assert summary["by_model"] == {}
+    assert summary["by_transform"] == {}
+
+
+def test_format_csv_writes_header_and_rows() -> None:
+    output = format_csv(_make_report())
+    reader = csv.reader(io.StringIO(output))
+    rows = list(reader)
+
+    assert rows[0] == [
+        "timestamp",
+        "request_id",
+        "model",
+        "num_messages",
+        "tokens_before",
+        "tokens_after",
+        "tokens_saved",
+        "cache_read",
+        "cache_write",
+        "cache_hit_pct",
+        "optimization_ms",
+    ]
+    assert len(rows) == 4  # header + 3 records
+    first = rows[1]
+    assert first[1] == "hr_001"
+    assert first[2] == "claude-opus-4-8"
+    assert first[4] == "1000"
+    assert first[10] == "43"  # optimization_ms rounded
+
+
+def test_format_csv_empty_report_writes_header_only() -> None:
+    output = format_csv(PerfReport())
+    reader = csv.reader(io.StringIO(output))
+    rows = list(reader)
+    assert len(rows) == 1  # header only
+    assert rows[0][0] == "timestamp"


### PR DESCRIPTION
## Summary

- Add `--format {text,json,csv}` to `headroom perf` (default `text` — existing behavior unchanged).
- `--format json` emits the same headline numbers `format_report` prints, but as a structured object (`window_hours`, `total_requests`, `total_tokens_before/after`, `tokens_saved`, `savings_pct`, `cache_hit_pct`, `by_model`, `by_transform`).
- `--format csv` emits one row per `PERF` record (same per-record granularity as `--raw`) so it drops straight into pandas or a spreadsheet.

The aggregate keys live in a new `summary_dict(report)` helper next to `format_report`; CSV uses an explicit `_PERF_CSV_COLUMNS` tuple so the column layout stays stable if `PerfRecord` grows new fields.

## Testing

- `python -m pytest tests/test_perf_format.py -v` — 7 tests, all green
- `ruff check headroom/cli/perf.py headroom/perf/analyzer.py tests/test_perf_format.py` — passes
- `ruff format --check` — passes

Fixes #595.