### PR TITLE
fix(proxy): treat Codex Desktop originator as Codex client

### DIFF
--- a/headroom/proxy/auth_mode.py
+++ b/headroom/proxy/auth_mode.py
@@ -225,11 +225,14 @@ def classify_client(headers: Mapping[str, Any] | Any) -> str | None:
     1. **``X-Client`` header** (explicit override) — clients that
        know they're talking to Headroom can self-identify with a
        short name. Trimmed, lowercased. Wins over UA matching.
-    2. **User-Agent substring match** against :data:`CLIENT_UA_MAP`
-       — covers the unmodified-client case. Substring, not prefix,
+    2. **``originator: Codex Desktop`` header** - Codex Desktop
+       sends this on subscription-auth traffic even when its User-Agent
+       does not include ``codex-cli/``.
+    3. **User-Agent substring match** against :data:`CLIENT_UA_MAP`
+       - covers the unmodified-client case. Substring, not prefix,
        because some clients prepend a corporate-wrapper UA before
        their own.
-    3. **None** when neither produces a hit. ``None`` is the loud
+    4. **None** when neither produces a hit. ``None`` is the loud
        "unknown harness" signal; downstream consumers can group
        these as "unidentified" rather than silently bucketing them
        into a default.
@@ -243,7 +246,11 @@ def classify_client(headers: Mapping[str, Any] | Any) -> str | None:
     explicit = _header_get(headers, "x-client").strip().lower()
     if explicit:
         return explicit
-    # 2. User-Agent substring match
+    # 2. Codex Desktop originator header
+    originator = _header_get(headers, "originator").strip().lower()
+    if originator in {"codex", "codex desktop"}:
+        return "codex"
+    # 3. User-Agent substring match
     ua_lower = _header_get(headers, "user-agent").lower()
     if not ua_lower:
         return None

--- a/tests/test_openai_codex_routing.py
+++ b/tests/test_openai_codex_routing.py
@@ -374,6 +374,40 @@ def test_codex_responses_timeout_fails_open_in_standalone_proxy(monkeypatch):
     assert body["input"][0]["output"] == "large tool output"
 
 
+def test_codex_desktop_originator_timeout_fails_open(monkeypatch):
+    """Codex Desktop sends originator, not always X-Client; keep timeout fail-open."""
+    request = _build_request(
+        {
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "large tool output",
+                }
+            ],
+        },
+        {"Authorization": "Bearer sk-test", "originator": "Codex Desktop"},
+    )
+    handler = _DummyOpenAIHandler()
+    handler.config.optimize = True
+
+    monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
+    monkeypatch.setattr(
+        handler,
+        "_compress_openai_responses_payload",
+        lambda *args, **kwargs: (_ for _ in ()).throw(TimeoutError()),
+    )
+
+    response = anyio.run(handler.handle_openai_responses, request)
+
+    assert response.status_code == 200
+    assert handler.captured_request is not None
+    _, url, _, body = handler.captured_request
+    assert url == "https://api.openai.com/v1/responses"
+    assert body["input"][0]["output"] == "large tool output"
+
+
 class _DummyWebSocket:
     def __init__(self, headers: dict[str, str]):
         self.headers = headers

--- a/tests/test_request_outcome.py
+++ b/tests/test_request_outcome.py
@@ -144,6 +144,12 @@ def test_classify_client_x_client_header_wins_over_user_agent() -> None:
     assert classify_client(h) == "my-custom-harness"
 
 
+def test_classify_client_recognises_codex_desktop_originator() -> None:
+    from headroom.proxy.auth_mode import classify_client
+
+    assert classify_client({"originator": "Codex Desktop"}) == "codex"
+
+
 def test_classify_client_returns_none_for_unknown_traffic() -> None:
     """``None`` is the loud "unidentified" signal — downstream consumers
     can group these as "unknown" rather than silently bucketing into


### PR DESCRIPTION
## Summary
- classify `originator: Codex Desktop` traffic as the Codex client when no explicit `X-Client` override is present
- keep `/v1/responses` compression timeouts fail-open for Codex Desktop subscription-auth requests instead of returning 413
- add regression coverage for both client classification and the Responses API timeout path

Fixes #632.

## Testing
- `.\.venv313\Scripts\python.exe -m pytest tests/test_request_outcome.py -k classify_client -q`
- `.\.venv313\Scripts\python.exe -m pytest tests/test_openai_codex_routing.py -k timeout_fails_open -q`
- `.\.venv313\Scripts\python.exe -m pytest tests/test_proxy/test_compression_failure_action.py -q`
- `.\.venv313\Scripts\python.exe -m ruff check headroom/proxy/auth_mode.py tests/test_request_outcome.py tests/test_openai_codex_routing.py`
- `git diff --check`