### PR TITLE
docs(install): document Windows build prerequisites

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -6,8 +6,11 @@ description: Install Headroom via pip, npm, or Docker. Includes all Python extra
 ## Python
 
 Headroom requires **Python 3.10+** and is published as `headroom-ai` on PyPI.
-Current release wheels are built for Python **3.10 through 3.13**. If your
-installer is using a newer Python, force a supported interpreter.
+Current release wheels are built for Python **3.10 through 3.13** on Linux
+(manylinux_2_28 x86_64 / aarch64) and macOS (Apple Silicon). Other targets —
+**Windows** and **Intel macOS** — fall back to building the Rust extension
+from the sdist and need a working native toolchain. If your installer is
+using a newer Python, force a supported interpreter.
 
 ### Core package
 
@@ -47,6 +50,40 @@ You can combine extras:
 ```bash
 pip install "headroom-ai[proxy,langchain,ml]"
 ```
+
+### Windows
+
+There are no prebuilt Windows wheels yet, so `pip install headroom-ai`
+(and `uv tool install`, `pipx install`, …) will fall back to building the
+Rust extension from the sdist. The build needs the MSVC toolchain on
+`PATH`. Without it you'll see:
+
+```text
+error: linker `link.exe` not found
+note: please ensure that Visual Studio 2017 or later, or Build Tools for
+Visual Studio were installed with the Visual C++ option
+```
+
+To install the prerequisites:
+
+1. **MSVC toolchain** — install **[Build Tools for Visual Studio](https://visualstudio.microsoft.com/visual-cpp-build-tools/)**
+   and select the *"Desktop development with C++"* workload (this gives
+   you `link.exe`). VS Code on its own is not enough.
+2. **Rust** — install via [rustup](https://rustup.rs/). Choose the
+   `stable-x86_64-pc-windows-msvc` toolchain so Cargo uses the MSVC
+   linker you just installed.
+3. **Open a fresh PowerShell** so the installer's PATH updates take
+   effect, then run the install:
+
+   ```powershell
+   uv tool install --python 3.13 "headroom-ai[all]"
+   # or
+   pip install "headroom-ai[all]"
+   ```
+
+If you'd rather avoid the native toolchain entirely, run Headroom
+through Docker — see the [Docker](#docker) section below. Native
+Windows wheels are tracked in [#636](https://github.com/chopratejas/headroom/issues/636).
 
 ### pipx
 


### PR DESCRIPTION
## Summary

Addresses the reporter's first ask in #636 — document the Windows-from-source path so users who hit `error: linker \link.exe\ not found` have a clear fix.

There are no Windows wheels on PyPI for 0.23.0 (only `manylinux_2_28` x86_64/aarch64 and `macosx_11_0_arm64`), so `pip`/`uv`/`pipx` all fall back to building the Rust extension from the sdist. Without MSVC Build Tools the maturin build dies with the exact error in the issue.

Adds a short `### Windows` subsection to `docs/content/docs/installation.mdx` covering:

- Why the source build happens (no Windows wheels yet)
- The exact error users will see
- MSVC Build Tools + Rust (`stable-x86_64-pc-windows-msvc`) install steps
- Pointer to Docker as the no-toolchain alternative
- Link back to #636 for users tracking native Windows wheel support

Also tweaks the opening paragraph of `## Python` to call out Windows / Intel macOS as source-build targets — same caveat applies to Intel macOS per the `release.yml` comment about `ort-sys` (see #525).

This PR does **not** add Windows to the wheel matrix in `release.yml`. That's a real fix but a meaningfully bigger one — adds ~10 min per release, more CI cost, and the `ort-sys` situation on Intel macOS suggests there may be similar gotchas the maintainers haven't worked through yet. Happy to do a follow-up PR for the CI change if you want it.

## Testing

- Rendered locally is the visual goal; this is a content-only change to one MDX file so no code paths are exercised. Spot-checked that the anchor link `[Docker](#docker)` matches the existing `## Docker` heading.
- The error block and install commands are taken verbatim from the issue's repro output and from the official MSVC / rustup documentation.

Fixes #636 (documentation portion).