### PR TITLE
fix(windows): avoid Magika detection hang in Python binding

### DIFF
--- a/crates/headroom-py/src/lib.rs
+++ b/crates/headroom-py/src/lib.rs
@@ -18,6 +18,8 @@ use std::collections::BTreeMap;
 use headroom_core::signals::{
     ImportanceCategory, ImportanceContext, KeywordDetector, KeywordRegistry, LineImportanceDetector,
 };
+#[cfg(not(windows))]
+use headroom_core::transforms::detect as rust_detect_chain;
 use headroom_core::transforms::smart_crusher::compaction::DocumentCompactor;
 use headroom_core::transforms::smart_crusher::{
     CrushResult as RustCrushResult, SmartCrusher as RustSmartCrusher,
@@ -29,7 +31,8 @@ use headroom_core::transforms::tag_protector::{
 };
 use headroom_core::transforms::{
     compress_openai_responses_live_zone as rust_compress_openai_responses_live_zone,
-    detect as rust_detect_chain, is_json_array_of_dicts as rust_is_json_array_of_dicts,
+    detect_content_type as rust_regex_detect_content_type,
+    is_json_array_of_dicts as rust_is_json_array_of_dicts,
     summarize_openai_responses_no_change_reason as rust_summarize_openai_responses_no_change_reason,
     AuthMode as RustLiveZoneAuthMode, ContentType as RustContentType,
     DetectionResult as RustDetectionResult, DiffCompressionResult, DiffCompressor,
@@ -58,6 +61,42 @@ fn type_name(v: &serde_json::Value) -> &'static str {
         serde_json::Value::Array(_) => "array",
         serde_json::Value::Object(_) => "object",
     }
+}
+
+#[cfg(not(windows))]
+fn chain_detection_result(content: &str) -> RustDetectionResult {
+    let content_type = rust_detect_chain(content);
+    RustDetectionResult {
+        content_type,
+        confidence: 1.0,
+        metadata: serde_json::Map::new(),
+    }
+}
+
+#[cfg(not(windows))]
+fn structural_detection_fast_path(content: &str) -> Option<RustDetectionResult> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with('[') {
+        return None;
+    }
+
+    let detected = rust_regex_detect_content_type(content);
+    if detected.content_type == RustContentType::JsonArray {
+        Some(detected)
+    } else {
+        None
+    }
+}
+
+#[cfg(windows)]
+fn binding_detection_result(content: &str) -> RustDetectionResult {
+    // Avoid first-call ONNX/Magika hangs observed in Windows direct/MCP compression.
+    rust_regex_detect_content_type(content)
+}
+
+#[cfg(not(windows))]
+fn binding_detection_result(content: &str) -> RustDetectionResult {
+    structural_detection_fast_path(content).unwrap_or_else(|| chain_detection_result(content))
 }
 
 /// Build the dict returned by `SmartCrusher.crush_array_json`. Kept
@@ -902,29 +941,23 @@ impl PyDetectionResult {
 /// Detect the type of `content`. Returns a `DetectionResult` with the
 /// same field surface as Python's dataclass.
 ///
-/// Stage-3d (PR5) wired this through the magika→unidiff→PlainText
-/// detection chain — the regex `content_detector` is no longer on
-/// the production path. The chain returns a `ContentType` only;
-/// we synthesize the legacy `DetectionResult` shape here with
-/// `confidence = 1.0` (the chain doesn't surface a probabilistic
-/// score) and an empty metadata bag (no production caller reads
-/// metadata from this binding today — see audit notes in
-/// `headroom/transforms/content_router.py`).
+/// On non-Windows platforms, Stage-3d (PR5) still uses the
+/// magika->unidiff->PlainText detection chain after a cheap JSON-array
+/// structural fast path. The chain returns a `ContentType` only, so the
+/// binding synthesizes the legacy `DetectionResult` shape for that path.
 ///
-/// Releases the GIL while detecting — magika inference and unidiff
-/// parsing can be substantial on large bodies, and freeing the GIL
-/// lets other Python threads make progress in the meantime.
+/// On Windows, direct/MCP compression avoids the ONNX-backed Magika tier
+/// because first-call session initialization can hang inside the runtime.
+/// The binding uses the deterministic Rust detector instead, preserving
+/// JSON/search/log/diff/code routing without blocking the caller.
+///
+/// Releases the GIL while detecting so large bodies do not block other
+/// Python threads.
 #[pyfunction]
 fn detect_content_type(py: Python<'_>, content: &str) -> PyDetectionResult {
     let owned = content.to_string();
-    let content_type = py.allow_threads(move || rust_detect_chain(&owned));
-    PyDetectionResult {
-        inner: RustDetectionResult {
-            content_type,
-            confidence: 1.0,
-            metadata: serde_json::Map::new(),
-        },
-    }
+    let detected = py.allow_threads(move || binding_detection_result(&owned));
+    PyDetectionResult { inner: detected }
 }
 
 /// Quick check: is `content` a JSON array of dictionaries (the format

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -111,14 +111,13 @@ def _detect_content(content: str) -> DetectionResult:
     """Detect content type via the Rust detection chain.
 
     Stage-3d (PR5) wired this through `headroom._core.detect_content_type`,
-    which runs the magika→unidiff→PlainText chain. The Python-side
-    Magika+regex fallback path was retired here — single detection
-    surface, no parallel paths. The Rust extension is a hard dep
-    (no Python fallback) per `feedback_no_silent_fallbacks.md`.
+    which keeps the detection surface in the Rust extension. On Linux/macOS
+    it uses the magika→unidiff→PlainText chain after cheap structural
+    shortcuts; on Windows the binding uses the deterministic Rust detector
+    to avoid first-call ONNX runtime hangs in direct/MCP compression.
 
-    The Rust binding returns the legacy `DetectionResult` shape with
-    `confidence=1.0` and an empty metadata dict. Existing callers
-    only consumed `.content_type` from it; the strategy mapping in
+    `_detect_content` keeps returning the Python `DetectionResult` type.
+    Existing callers only consume `.content_type`; the strategy mapping in
     `_strategy_from_detection` keys off that field alone.
     """
     from headroom._core import detect_content_type as _rust_detect

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -101,10 +102,7 @@ def test_router_result_helpers_and_summary() -> None:
 
 
 def test_content_signature_and_detection_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stage-3d (PR5) wired `_detect_content` through the Rust chain
-    (`headroom._core.detect_content_type` → magika → unidiff →
-    PlainText). The pre-PR5 Python-side `_get_magika_detector`
-    fallback path is gone.
+    """Stage-3d (PR5) wired `_detect_content` through the Rust binding.
 
     This test asserts the new contract:
     1. The detection helper delegates to the Rust binding.
@@ -131,6 +129,36 @@ def test_content_signature_and_detection_helpers(monkeypatch: pytest.MonkeyPatch
     assert result.content_type is ContentType.SOURCE_CODE
     assert result.confidence == 1.0
     assert result.metadata == {}
+
+
+def test_core_detect_content_type_uses_json_fast_path() -> None:
+    import headroom._core as _core
+
+    payload = "[" + ",".join(f'{{"id":{i},"status":"OK"}}' for i in range(50)) + "]"
+
+    result = _core.detect_content_type(payload)
+
+    assert result.content_type == "json_array"
+    assert result.confidence == 1.0
+    assert result.metadata == {"item_count": 50, "is_dict_array": True}
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows regression path")
+def test_core_detect_content_type_uses_windows_deterministic_detector() -> None:
+    import headroom._core as _core
+
+    search_output = "\n".join(
+        [
+            "src/app.py:10:def main():",
+            "src/app.py:20:print('hello')",
+            "README.md:5:usage docs",
+        ]
+    )
+
+    result = _core.detect_content_type(search_output)
+
+    assert result.content_type == "search"
+    assert result.metadata == {"matching_lines": 3, "total_lines": 3}
 
 
 def test_mixed_content_section_splitting_and_json_extraction() -> None:


### PR DESCRIPTION
## Summary
- avoid the ONNX/Magika detection path in the Python binding on Windows
- keep the existing Magika detection chain on non-Windows platforms, with a cheap JSON-array fast path first
- add regression coverage for the JSON fast path and the Windows deterministic detector path

## Notes
This fixes the first-call `headroom._core.detect_content_type` hang from #575.

It also addresses the direct/MCP compression hang part of #600 for large JSON payloads on Windows. The proxy `/mcp` routing behavior mentioned in #600 is separate and is not changed here.

## Verification
- `cargo fmt --check`
- `.\.venv313\Scripts\python.exe -m pytest tests\test_transforms_content_router.py tests\test_transforms_content_detection.py -q` -> 31 passed
- `$env:PYO3_PYTHON=(Resolve-Path .\.venv313\Scripts\python.exe).Path; cargo check -p headroom-py`
- `cargo test -p headroom-core content_detector --lib` -> 21 passed
- `.\.venv313\Scripts\ruff.exe check headroom/transforms/content_router.py tests/test_transforms_content_router.py`
- `.\.venv313\Scripts\ruff.exe format --check headroom/transforms/content_router.py tests/test_transforms_content_router.py`
- 2000-row JSON repro from #600 now returns on Windows: `input_chars=374878`, `elapsed_sec=38.775`, `tokens_before=117184`, `tokens_after=17880`, `tokens_saved=99304`