### PR TITLE
fix(packaging): exclude unsupported Python 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ headroom proxy --port 8787              # drop-in proxy, zero code changes
 headroom perf
 ```
 
-Granular extras: `[proxy]`, `[mcp]`, `[ml]`, `[code]`, `[memory]`, `[relevance]`, `[image]`, `[agno]`, `[langchain]`, `[evals]`. Requires **Python 3.10+**.
+Granular extras: `[proxy]`, `[mcp]`, `[ml]`, `[code]`, `[memory]`, `[relevance]`, `[image]`, `[agno]`, `[langchain]`, `[evals]`. Requires **Python 3.10-3.13**.
 
 ## Proof
 
@@ -228,7 +228,7 @@ npm install headroom-ai                 # TypeScript / Node
 docker pull ghcr.io/chopratejas/headroom:latest
 ```
 
-Granular extras: `[proxy]`, `[mcp]`, `[ml]` (Kompress-base), `[code]`, `[memory]`, `[relevance]`, `[image]`, `[agno]`, `[langchain]`, `[evals]`. Requires **Python 3.10+**.
+Granular extras: `[proxy]`, `[mcp]`, `[ml]` (Kompress-base), `[code]`, `[memory]`, `[relevance]`, `[image]`, `[agno]`, `[langchain]`, `[evals]`. Requires **Python 3.10-3.13**.
 
 Using `pipx`? Choose a supported interpreter explicitly:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.23.0"
 description = "The Context Optimization Layer for LLM Applications - Cut costs by 50-90%"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 authors = [
     { name = "Headroom Contributors" }
 ]
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -7,6 +7,22 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 
 
+def test_python_metadata_excludes_python_314_until_pyo3_supports_it() -> None:
+    """PyO3 0.22 supports Python through 3.13; pip must reject 3.14 early."""
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - Python 3.10 only
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    project = pyproject["project"]
+    classifiers = set(project["classifiers"])
+
+    assert project["requires-python"] == ">=3.10,<3.14"
+    assert "Programming Language :: Python :: 3.13" in classifiers
+    assert "Programming Language :: Python :: 3.14" not in classifiers
+
+
 def test_docker_workflow_normalizes_repository_name_for_signing() -> None:
     content = (ROOT / ".github" / "workflows" / "docker.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- set `requires-python` to `>=3.10,<3.14`
- add the Python 3.13 classifier
- update README install notes to say Python 3.10-3.13
- add a metadata regression test so Python 3.14 is rejected before the PyO3 build path

## Notes
This fixes #593 by making pip reject Python 3.14 early instead of trying to compile the Rust extension and failing inside PyO3/maturin.

I left `uv.lock` untouched. Running `uv lock` currently rewrites thousands of unrelated lockfile lines with the newer uv format, which would make this PR much harder to review.

## Verification
- `.\.venv313\Scripts\python.exe -m pytest tests\test_release_workflows.py -q` -> 31 passed
- `.\.venv313\Scripts\ruff.exe check tests/test_release_workflows.py`
- `.\.venv313\Scripts\ruff.exe format --check tests/test_release_workflows.py`
- `git diff --check`