### PR TITLE
fix(proxy): suppress LiteLLM pricing noise

### DIFF
--- a/headroom/proxy/_litellm_logging.py
+++ b/headroom/proxy/_litellm_logging.py
@@ -1,0 +1,12 @@
+"""LiteLLM logging configuration for proxy internals."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def suppress_litellm_debug_output(litellm_module: Any) -> Any:
+    """Disable LiteLLM's provider-list banner and verbose debug output."""
+    litellm_module.suppress_debug_info = True
+    litellm_module.set_verbose = False
+    return litellm_module

--- a/headroom/proxy/cost.py
+++ b/headroom/proxy/cost.py
@@ -14,6 +14,7 @@ from collections import deque
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from headroom.proxy._litellm_logging import suppress_litellm_debug_output
 from headroom.proxy.modes import PROXY_MODE_CACHE
 
 if TYPE_CHECKING:
@@ -30,6 +31,7 @@ def _get_litellm_module() -> Any | None:
     if not LITELLM_AVAILABLE:
         return None
     if litellm is not None:
+        suppress_litellm_debug_output(litellm)
         return litellm
 
     try:
@@ -37,7 +39,7 @@ def _get_litellm_module() -> Any | None:
     except ImportError:
         return None
 
-    litellm = imported_litellm
+    litellm = suppress_litellm_debug_output(imported_litellm)
     return litellm
 
 

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from headroom import paths as _paths
+from headroom.proxy._litellm_logging import suppress_litellm_debug_output
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ def _get_litellm_module() -> Any | None:
     if not LITELLM_AVAILABLE:
         return None
     if litellm is not None:
+        suppress_litellm_debug_output(litellm)
         return litellm
 
     try:
@@ -50,7 +52,7 @@ def _get_litellm_module() -> Any | None:
     except ImportError:
         return None
 
-    litellm = imported_litellm
+    litellm = suppress_litellm_debug_output(imported_litellm)
     return litellm
 
 

--- a/tests/test_startup_log_noise.py
+++ b/tests/test_startup_log_noise.py
@@ -4,6 +4,7 @@ Covers the fixes in:
 - headroom/memory/adapters/embedders.py (HF env vars, httpx logger)
 - headroom/providers/anthropic.py (warn=False suppresses tiktoken warning)
 - headroom/providers/litellm.py (suppress_debug_info, set_verbose)
+- headroom/proxy/cost.py and savings_tracker.py (LiteLLM pricing lookup noise)
 - headroom/transforms/html_extractor.py (trafilatura logger CRITICAL)
 """
 
@@ -133,6 +134,50 @@ class TestLiteLLMLogSuppression:
         assert litellm.set_verbose is False, (
             "litellm.set_verbose must be False to suppress verbose debug output"
         )
+
+    def test_proxy_cost_lookup_does_not_print_provider_list(self, capsys):
+        """Proxy cost lookups must not leak LiteLLM's provider-list banner."""
+        litellm = pytest_importorskip_litellm()
+        if litellm is None:
+            return
+
+        litellm.suppress_debug_info = False
+        litellm.set_verbose = True
+
+        import headroom.proxy.cost as cost_mod
+
+        cost_mod.litellm = None
+        cost_mod.CostTracker._resolved_model_cache.clear()
+
+        tracker = cost_mod.CostTracker()
+        assert tracker.estimate_cost("deepseek-v4-flash", 100, 10) is None
+
+        captured = capsys.readouterr()
+        assert "Provider List" not in captured.out
+        assert "Provider List" not in captured.err
+        assert litellm.suppress_debug_info is True
+        assert litellm.set_verbose is False
+
+    def test_proxy_savings_lookup_does_not_print_provider_list(self, capsys):
+        """Savings price lookups must not leak LiteLLM's provider-list banner."""
+        litellm = pytest_importorskip_litellm()
+        if litellm is None:
+            return
+
+        litellm.suppress_debug_info = False
+        litellm.set_verbose = True
+
+        import headroom.proxy.savings_tracker as savings_mod
+
+        savings_mod.litellm = None
+
+        assert savings_mod._estimate_input_cost_usd("deepseek-v4-flash", 100) == 0.0
+
+        captured = capsys.readouterr()
+        assert "Provider List" not in captured.out
+        assert "Provider List" not in captured.err
+        assert litellm.suppress_debug_info is True
+        assert litellm.set_verbose is False
 
 
 def pytest_importorskip_litellm():


### PR DESCRIPTION
Fixes #613.

## What changed

- Applies LiteLLM's `suppress_debug_info` / `set_verbose = False` settings when proxy pricing modules lazy-import LiteLLM.
- Covers both request cost tracking and persistent savings price lookups.
- Adds regression tests that turn LiteLLM noise back on, run unknown DeepSeek pricing lookups, and assert the `Provider List` banner does not reach stdout/stderr.

## Why

`headroom.providers.litellm` already suppresses LiteLLM startup noise, but the proxy cost paths import LiteLLM separately. For unknown unprefixed models like `deepseek-v4-flash`, `litellm.cost_per_token(...)` printed the provider-list banner while Headroom was only trying to read pricing metadata.

This keeps the pricing fallback behavior the same; it only prevents LiteLLM's debug banner from leaking into proxy logs.

## Tests

- `.venv313\Scripts\python.exe -m pytest tests\test_startup_log_noise.py::TestLiteLLMLogSuppression -q`
- `.venv313\Scripts\python.exe -m pytest tests\test_startup_log_noise.py -q`
- `.venv313\Scripts\python.exe -m pytest tests\test_proxy_streaming_resilience.py::TestModelResolutionCaching tests\test_proxy_streaming_resilience.py::TestCostTrackingAccuracy tests\test_proxy_savings_history.py -q --basetemp .pytest-tmp\pr613`
- `.venv313\Scripts\ruff.exe check headroom\proxy\_litellm_logging.py headroom\proxy\cost.py headroom\proxy\savings_tracker.py tests\test_startup_log_noise.py`
- `.venv313\Scripts\ruff.exe format --check headroom\proxy\_litellm_logging.py headroom\proxy\cost.py headroom\proxy\savings_tracker.py tests\test_startup_log_noise.py`
- `git diff --check`