### PR TITLE
fix(ccr): tag proactive expansion blocks

### DIFF
--- a/headroom/ccr/context_tracker.py
+++ b/headroom/ccr/context_tracker.py
@@ -31,6 +31,10 @@ from ..cache.compression_store import get_compression_store
 
 logger = logging.getLogger(__name__)
 
+PROACTIVE_EXPANSION_TAG = "headroom_proactive_expansion"
+PROACTIVE_EXPANSION_OPEN_TAG = f"<{PROACTIVE_EXPANSION_TAG}>"
+PROACTIVE_EXPANSION_CLOSE_TAG = f"</{PROACTIVE_EXPANSION_TAG}>"
+
 
 @dataclass
 class CompressedContext:
@@ -574,7 +578,7 @@ class ContextTracker:
         if workspace_label:
             header += f" | workspace: {workspace_label}"
         header += "]"
-        parts = [header]
+        parts = [PROACTIVE_EXPANSION_OPEN_TAG, header]
 
         for exp in expansions:
             if exp["type"] == "full":
@@ -588,6 +592,7 @@ class ContextTracker:
                     parts.append(str(exp["content"]))
 
         parts.append("\n[End Proactive Expansion]")
+        parts.append(PROACTIVE_EXPANSION_CLOSE_TAG)
 
         return "\n".join(parts)
 

--- a/tests/test_ccr_context_tracker.py
+++ b/tests/test_ccr_context_tracker.py
@@ -547,6 +547,26 @@ class TestExpansionFormatting:
         assert "Expanded from earlier" in formatted
         assert '[{"id": 1}, {"id": 2}]' in formatted
 
+    def test_format_full_expansion_wraps_provenance_tag(self):
+        """Wrap proactive expansions so downstream consumers can strip them."""
+        tracker = ContextTracker()
+
+        expansions = [
+            {
+                "hash": "abc123",
+                "type": "full",
+                "content": "expanded content",
+                "item_count": 1,
+                "reason": "relevant to query",
+            }
+        ]
+
+        formatted = tracker.format_expansions_for_context(expansions)
+
+        assert formatted.startswith("<headroom_proactive_expansion>\n[Proactive Context Expansion")
+        assert formatted.endswith("\n</headroom_proactive_expansion>")
+        assert "[End Proactive Expansion]" in formatted
+
     def test_format_search_expansion(self):
         """Format search expansion for LLM context."""
         tracker = ContextTracker()

--- a/tests/test_proxy_anthropic_cache_stability.py
+++ b/tests/test_proxy_anthropic_cache_stability.py
@@ -12,6 +12,7 @@ pytest.importorskip("fastapi")
 
 from fastapi.testclient import TestClient
 
+from headroom.ccr.context_tracker import ContextTracker
 from headroom.proxy.handlers.anthropic import AnthropicHandlerMixin
 from headroom.proxy.server import ProxyConfig, create_app
 
@@ -288,6 +289,46 @@ def test_append_context_does_not_touch_previous_turns_if_last_message_not_user()
         frozen_message_count=0,
     )
     assert result[0]["content"] == "previous user turn"
+
+
+def test_proactive_expansion_append_keeps_peer_turn_attribution_separable() -> None:
+    tracker = ContextTracker()
+    expansion_text = tracker.format_expansions_for_context(
+        [
+            {
+                "hash": "ctx-1",
+                "type": "full",
+                "content": "expanded context that Headroom injected",
+                "item_count": 1,
+                "reason": "matched query",
+            }
+        ]
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": '<peer_turn from="AgentX">actual peer content</peer_turn>',
+                }
+            ],
+        }
+    ]
+
+    result = AnthropicHandlerMixin._append_context_to_latest_non_frozen_user_turn(
+        messages,
+        expansion_text,
+        frozen_message_count=0,
+    )
+
+    text = result[0]["content"][0]["text"]
+    assert '<peer_turn from="AgentX">actual peer content</peer_turn>' in text
+    assert "\n\n<headroom_proactive_expansion>" in text
+    peer_text, expansion = text.split("\n\n<headroom_proactive_expansion>", 1)
+    assert peer_text == '<peer_turn from="AgentX">actual peer content</peer_turn>'
+    assert "expanded context that Headroom injected" in expansion
+    assert expansion.rstrip().endswith("</headroom_proactive_expansion>")
 
 
 def test_token_mode_freeze_is_capped_by_prefix_tracker() -> None:


### PR DESCRIPTION
Fixes #503

This wraps CCR proactive expansion text in `<headroom_proactive_expansion>` while keeping the existing `[Proactive Context Expansion ...]` header inside the block.

The injection still targets the latest non-frozen user turn, so the cache hot-zone behavior stays the same. The only behavior change is that Headroom-owned proactive context is now clearly separate from surrounding user text such as `<peer_turn from=AgentX>...</peer_turn>`.

Tests:
- `.venv313\Scripts\python.exe -m pytest tests\test_ccr_context_tracker.py tests\test_proxy_anthropic_cache_stability.py -q`
- `.venv313\Scripts\python.exe -m ruff check headroom\ccr\context_tracker.py tests\test_ccr_context_tracker.py tests\test_proxy_anthropic_cache_stability.py`
- `.venv313\Scripts\python.exe -m ruff format --check headroom\ccr\context_tracker.py tests\test_ccr_context_tracker.py tests\test_proxy_anthropic_cache_stability.py`
- `git diff --check`