### PR TITLE
fix(streaming): bound upstream first-byte stalls

### DIFF
--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -167,6 +167,17 @@ def _selected_context_tool() -> str:
     help="Upstream connection timeout in seconds (default: 10)",
 )
 @click.option(
+    "--stream-first-byte-timeout-seconds",
+    type=float,
+    default=None,
+    envvar="HEADROOM_STREAM_FIRST_BYTE_TIMEOUT_SECONDS",
+    help=(
+        "Timeout for the first byte of an upstream streaming response "
+        "(default: 60.0 seconds; <=0 disables). "
+        "Env: HEADROOM_STREAM_FIRST_BYTE_TIMEOUT_SECONDS."
+    ),
+)
+@click.option(
     "--anthropic-pre-upstream-concurrency",
     type=int,
     default=None,
@@ -451,6 +462,7 @@ def proxy(
     subscription_poll_interval: int | None,
     retry_max_attempts: int | None,
     connect_timeout_seconds: int | None,
+    stream_first_byte_timeout_seconds: float | None,
     anthropic_pre_upstream_concurrency: int | None,
     anthropic_pre_upstream_acquire_timeout_seconds: float | None,
     anthropic_pre_upstream_memory_context_timeout_seconds: float | None,
@@ -617,6 +629,11 @@ def proxy(
         connect_timeout_seconds=connect_timeout_seconds
         if connect_timeout_seconds is not None
         else 10,
+        stream_first_byte_timeout_seconds=(
+            stream_first_byte_timeout_seconds
+            if stream_first_byte_timeout_seconds is not None
+            else 60.0
+        ),
         max_connections=max_connections,
         max_keepalive_connections=max_keepalive_connections,
         log_file=None if is_stateless else log_file,

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -26,6 +26,34 @@ from headroom.copilot_auth import apply_copilot_api_auth
 logger = logging.getLogger("headroom.proxy")
 
 
+class _FirstByteTimeoutError(TimeoutError):
+    """Raised when upstream stream headers arrive but the first body byte stalls."""
+
+    def __init__(self, timeout_seconds: float):
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"upstream stream did not send a first byte within {timeout_seconds:g}s")
+
+
+async def _aiter_bytes_with_first_byte_timeout(byte_iter: Any, timeout_seconds: float):
+    """Apply a timeout only to the first upstream stream chunk."""
+    if timeout_seconds <= 0:
+        async for chunk in byte_iter:
+            yield chunk
+        return
+
+    try:
+        first_chunk = await asyncio.wait_for(anext(byte_iter), timeout=timeout_seconds)
+    except StopAsyncIteration:
+        return
+    except TimeoutError as exc:
+        raise _FirstByteTimeoutError(timeout_seconds) from exc
+
+    yield first_chunk
+
+    async for chunk in byte_iter:
+        yield chunk
+
+
 def _parse_completion_tokens_from_sse_chunk(chunk_bytes: bytes) -> int | None:
     """Extract `usage.completion_tokens` from a single SSE chunk if present.
 
@@ -1071,7 +1099,13 @@ class StreamingMixin:
             try:
                 async with contextlib.aclosing(upstream_response) as response:
                     sse_chunk_index = 0
-                    async for chunk in response.aiter_bytes():
+                    first_byte_timeout_seconds = float(
+                        getattr(self.config, "stream_first_byte_timeout_seconds", 60.0)
+                    )
+                    async for chunk in _aiter_bytes_with_first_byte_timeout(
+                        response.aiter_bytes(),
+                        first_byte_timeout_seconds,
+                    ):
                         sse_chunk_index += 1
                         # Record TTFB on first chunk
                         if stream_state["ttfb_ms"] is None:
@@ -1245,6 +1279,24 @@ class StreamingMixin:
                     "error": {
                         "type": "connection_error",
                         "message": f"Failed to connect to upstream API: {e}",
+                    },
+                }
+                yield f"event: error\ndata: {json.dumps(error_event)}\n\n".encode()
+            except _FirstByteTimeoutError as e:
+                logger.error(
+                    "[%s] Upstream stream first-byte timeout after %.3fs: %s",
+                    request_id,
+                    e.timeout_seconds,
+                    url,
+                )
+                error_event = {
+                    "type": "error",
+                    "error": {
+                        "type": "upstream_first_byte_timeout",
+                        "message": (
+                            "Upstream API did not send the first streaming byte "
+                            f"within {e.timeout_seconds:g}s"
+                        ),
                     },
                 }
                 yield f"event: error\ndata: {json.dumps(error_event)}\n\n".encode()

--- a/headroom/proxy/models.py
+++ b/headroom/proxy/models.py
@@ -200,6 +200,9 @@ class ProxyConfig:
     # Timeouts
     request_timeout_seconds: int = 300
     connect_timeout_seconds: int = 10
+    # Bound how long a streaming upstream response may stay silent after
+    # headers are received. Set to <= 0 to disable the first-byte guard.
+    stream_first_byte_timeout_seconds: float = 60.0
 
     # Connection pool
     max_connections: int = 500

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -1619,6 +1619,9 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                 ),
                 "codex_ws_gated": False,
             },
+            "streaming": {
+                "first_byte_timeout_seconds": proxy.config.stream_first_byte_timeout_seconds,
+            },
             "compression_executor": {
                 "max_workers": proxy.compression_max_workers,
                 "queued": _comp_queued,

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -283,6 +283,8 @@ class TestCLIProxyEnvVars:
                     "1",
                     "--connect-timeout-seconds",
                     "3",
+                    "--stream-first-byte-timeout-seconds",
+                    "7.5",
                 ],
                 catch_exceptions=False,
             )
@@ -290,6 +292,25 @@ class TestCLIProxyEnvVars:
         assert result.exit_code == 0, result.output
         assert captured_config["config"].retry_max_attempts == 1
         assert captured_config["config"].connect_timeout_seconds == 3
+        assert captured_config["config"].stream_first_byte_timeout_seconds == 7.5
+
+    def test_stream_first_byte_timeout_from_env(self, runner):
+        """Streaming first-byte timeout can be tuned with an env var."""
+        captured_config = {}
+
+        def mock_run_server(config, **kwargs):
+            captured_config["config"] = config
+
+        with patch("headroom.proxy.server.run_server", mock_run_server):
+            result = runner.invoke(
+                main,
+                ["proxy"],
+                env={"HEADROOM_STREAM_FIRST_BYTE_TIMEOUT_SECONDS": "12.5"},
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured_config["config"].stream_first_byte_timeout_seconds == 12.5
 
     def test_production_scaling_env_vars(self, runner):
         captured = {}

--- a/tests/test_proxy_healthchecks.py
+++ b/tests/test_proxy_healthchecks.py
@@ -57,6 +57,7 @@ def test_readyz_reports_core_subsystem_checks(client):
     assert runtime["anthropic_pre_upstream"]["compression_timeout_seconds"] == 30.0
     assert runtime["anthropic_pre_upstream"]["memory_context_timeout_seconds"] == 2.0
     assert runtime["anthropic_pre_upstream"]["codex_ws_gated"] is False
+    assert runtime["streaming"]["first_byte_timeout_seconds"] == 60.0
     assert runtime["websocket_sessions"]["active_sessions"] == 0
     assert runtime["websocket_sessions"]["active_relay_tasks"] == 0
 

--- a/tests/test_proxy_streaming_ratelimit_headers.py
+++ b/tests/test_proxy_streaming_ratelimit_headers.py
@@ -8,6 +8,7 @@ via dict(response.headers), but streaming responses used StreamingResponse
 without passing any upstream headers — silently dropping ratelimit info.
 """
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -47,6 +48,7 @@ class TestStreamingRatelimitHeaderForwarding:
         proxy._config.retry_max_attempts = 3
         proxy._config.retry_base_delay_ms = 0
         proxy._config.retry_max_delay_ms = 0
+        proxy._config.stream_first_byte_timeout_seconds = 60.0
         proxy.config = proxy._config
         proxy._parse_sse_usage_from_buffer = MagicMock(return_value=None)
         proxy.memory_handler = None
@@ -397,3 +399,53 @@ class TestStreamingRatelimitHeaderForwarding:
 
         assert attempts["count"] == 2
         assert chunks
+
+    @pytest.mark.asyncio
+    async def test_first_byte_timeout_returns_sse_error_and_closes_response(self):
+        """A stalled upstream stream should not leave the client waiting forever."""
+        proxy = self._create_mock_proxy()
+        proxy.config.stream_first_byte_timeout_seconds = 0.01
+        mock_response = self._create_mock_upstream_response()
+
+        async def stalled_before_first_byte():
+            await asyncio.sleep(10)
+            yield b'event: message_start\ndata: {"type":"message_start"}\n\n'
+
+        mock_response.aiter_bytes = stalled_before_first_byte
+
+        mock_request = MagicMock()
+        proxy.http_client.build_request = MagicMock(return_value=mock_request)
+        proxy.http_client.send = AsyncMock(return_value=mock_response)
+
+        result = await proxy._stream_response(
+            url="https://api.anthropic.com/v1/messages",
+            headers={"x-api-key": "sk-test"},
+            body={
+                "model": "claude-sonnet-4-20250514",
+                "max_tokens": 100,
+                "stream": True,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            request_id="test-first-byte-timeout",
+            original_tokens=10,
+            optimized_tokens=10,
+            tokens_saved=0,
+            transforms_applied=[],
+            tags={},
+            optimization_latency=0.0,
+        )
+
+        async def collect_chunks():
+            return [chunk async for chunk in result.body_iterator]
+
+        chunks = await asyncio.wait_for(collect_chunks(), timeout=0.5)
+
+        assert len(chunks) == 1
+        raw = chunks[0].decode("utf-8")
+        assert "event: error" in raw
+        error_data = json.loads(raw.split("data: ")[1].strip())
+        assert error_data["error"]["type"] == "upstream_first_byte_timeout"
+        assert "first streaming byte" in error_data["error"]["message"]
+        mock_response.aclose.assert_awaited_once()


### PR DESCRIPTION
Fixes #258.

This adds a first-byte guard for upstream streaming responses. Today the proxy opens the upstream response before returning `StreamingResponse`, but the first `aiter_bytes()` read can still stall indefinitely. When that happens Claude Code waits for the first SSE byte and the request has no bounded failure path.

What changed:
- wrap only the first upstream stream chunk in a configurable timeout
- return an SSE `upstream_first_byte_timeout` error instead of leaving the client hanging
- close the upstream response through the existing `aclosing` path
- expose the timeout in `/readyz` runtime diagnostics
- add CLI/env config via `--stream-first-byte-timeout-seconds` / `HEADROOM_STREAM_FIRST_BYTE_TIMEOUT_SECONDS`

The default is 60s, with `<=0` disabling the guard for users who need the old behavior.

Tests:
- `.venv313\Scripts\python.exe -m pytest tests\test_proxy_streaming_ratelimit_headers.py -q`
- `$env:TMP='.tmp\pytest-temp'; $env:TEMP='.tmp\pytest-temp'; .venv313\Scripts\python.exe -m pytest tests\test_cli_proxy_env.py tests\test_proxy_healthchecks.py -q`
- `.venv313\Scripts\python.exe -m pytest tests\test_proxy_streaming_resilience.py tests\test_proxy_streaming_request_logger.py -q`
- `.venv313\Scripts\python.exe -m ruff check headroom\proxy\handlers\streaming.py headroom\proxy\models.py headroom\cli\proxy.py tests\test_proxy_streaming_ratelimit_headers.py tests\test_cli_proxy_env.py tests\test_proxy_healthchecks.py`
- `.venv313\Scripts\python.exe -m ruff format --check headroom\proxy\handlers\streaming.py headroom\proxy\models.py headroom\cli\proxy.py tests\test_proxy_streaming_ratelimit_headers.py tests\test_cli_proxy_env.py tests\test_proxy_healthchecks.py`
- `git diff --check`

I also ran `tests\test_openai_streaming_backend.py`; its local mocked tests passed, but the direct real-API smoke failed with 401 because this environment has `OPENAI_API_KEY=local`.