### PR TITLE
docs: add dashboard and persistent install entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Using `pipx`? Choose a supported interpreter explicitly:
 pipx install --python python3.13 "headroom-ai[all]"
 ```
 
-→ [Installation guide](https://headroom-docs.vercel.app/docs/installation) — Docker tags, persistent service, PowerShell, devcontainers.
+→ [Installation guide](https://headroom-docs.vercel.app/docs/installation) · [Persistent installs](https://headroom-docs.vercel.app/docs/persistent-installs) · [Docker-native install](https://headroom-docs.vercel.app/docs/docker-install).
 
 ## headroom learn
 
@@ -252,6 +252,7 @@ pipx install --python python3.13 "headroom-ai[all]"
 |-------------------------------------------------------------------------------|------------------------------------------------------------------------------------|
 | [Quickstart](https://headroom-docs.vercel.app/docs/quickstart)                | [Architecture](https://headroom-docs.vercel.app/docs/architecture)                 |
 | [Proxy](https://headroom-docs.vercel.app/docs/proxy)                          | [How compression works](https://headroom-docs.vercel.app/docs/how-compression-works) |
+| [Dashboard](https://headroom-docs.vercel.app/docs/dashboard)                  | [Persistent installs](https://headroom-docs.vercel.app/docs/persistent-installs)     |
 | [MCP tools](https://headroom-docs.vercel.app/docs/mcp)                        | [CCR — reversible compression](https://headroom-docs.vercel.app/docs/ccr)          |
 | [Memory](https://headroom-docs.vercel.app/docs/memory)                        | [Cache optimization](https://headroom-docs.vercel.app/docs/cache-optimization)     |
 | [Failure learning](https://headroom-docs.vercel.app/docs/failure-learning)    | [Benchmarks](https://headroom-docs.vercel.app/docs/benchmarks)                    |

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,11 +28,14 @@ In the project, you can see:
 | `app/docs`                | The documentation layout and pages.                    |
 | `app/api/search/route.ts` | The Route Handler for search.                          |
 
-### Fumadocs MDX
+### Content
 
-A `source.config.ts` config file has been included, you can customise different options like frontmatter schema.
+Documentation pages live in `content/docs`. The docs home page is
+`content/docs/index.mdx`, and navigation order is controlled by
+`content/docs/meta.json`.
 
-Read the [Introduction](https://fumadocs.dev/docs/mdx) for further details.
+When adding a user-facing page, add it to both the MDX docs tree and the
+`../wiki` mirror when the same topic exists there.
 
 ## Learn More
 

--- a/docs/content/docs/dashboard.mdx
+++ b/docs/content/docs/dashboard.mdx
@@ -1,0 +1,108 @@
+---
+title: Dashboard
+description: Use the local Headroom dashboard to inspect live proxy health, compression savings, request history, and exportable savings history.
+---
+
+The Headroom proxy serves a local dashboard at:
+
+```bash
+http://localhost:8787/dashboard
+```
+
+Start the proxy first:
+
+```bash
+headroom proxy
+```
+
+Then open the dashboard in your browser:
+
+```bash
+open http://localhost:8787/dashboard
+```
+
+On Windows:
+
+```powershell
+start http://localhost:8787/dashboard
+```
+
+## What it shows
+
+The dashboard is the human-facing view for proxy observability. It shows:
+
+- live proxy health
+- current-session requests, tokens, cache hits, failures, and savings
+- durable lifetime savings loaded from local state
+- hourly, daily, weekly, and monthly savings history
+- recent transformed/compressed request events
+- export buttons for savings history
+
+It is served by the same proxy process and does not require a separate web
+server.
+
+## Data sources
+
+The dashboard reads the same HTTP endpoints you can query directly:
+
+| Endpoint | Used for |
+|---|---|
+| `GET /health` | proxy readiness and runtime status |
+| `GET /stats?cached=1` | short-TTL dashboard stats snapshot |
+| `GET /stats-history` | durable history and chart rollups |
+| `GET /transformations/feed?limit=50` | recent compression/transformation events |
+
+If the dashboard looks empty, check these endpoints first:
+
+```bash
+curl http://localhost:8787/health
+curl http://localhost:8787/stats
+curl http://localhost:8787/stats-history
+curl "http://localhost:8787/transformations/feed?limit=5"
+```
+
+## Durable history
+
+Savings history is stored locally and survives proxy restarts. By default, the
+proxy stores it under the Headroom workspace state directory:
+
+```text
+~/.headroom/proxy_savings.json
+```
+
+You can override the file directly:
+
+```bash
+HEADROOM_SAVINGS_PATH=/path/to/proxy_savings.json headroom proxy
+```
+
+Or relocate the whole state root:
+
+```bash
+HEADROOM_WORKSPACE_DIR=/path/to/headroom-state headroom proxy
+```
+
+See [Filesystem Contract](/docs/filesystem-contract) for the full path rules.
+
+## Export history
+
+The dashboard export buttons use `/stats-history` under the hood. The same data
+is available from the CLI:
+
+```bash
+curl "http://localhost:8787/stats-history?format=csv&series=daily"
+curl "http://localhost:8787/stats-history?format=csv&series=weekly"
+curl "http://localhost:8787/stats-history?format=csv&series=monthly"
+curl "http://localhost:8787/stats-history?history_mode=full"
+```
+
+## Persistent proxy
+
+For an always-on proxy that keeps the dashboard available across terminal
+sessions, install a persistent service:
+
+```bash
+headroom install apply --preset persistent-service --providers auto
+```
+
+See [Persistent Installs](/docs/persistent-installs).

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -168,6 +168,22 @@ docker run -p 8787:8787 ghcr.io/chopratejas/headroom:latest
 If you want a host `headroom` CLI that keeps Headroom itself inside a container — with mounted state, a one-line installer, and a persistent Docker lifecycle — see [Docker-Native Install](/docs/docker-install).
 </Callout>
 
+## Persistent service
+
+If you want Headroom to keep running after the terminal closes, use the native
+persistent install flow:
+
+```bash
+pip install "headroom-ai[all]"
+headroom install apply --preset persistent-service --providers auto
+headroom install status
+```
+
+This installs a local background service, preserves proxy state under the
+Headroom workspace directory, and keeps `/dashboard` available while the
+service is running. See [Persistent Installs](/docs/persistent-installs) for
+service, task, and Docker lifecycle commands.
+
 ### Image tags
 
 | Tag | Extras | Base image | Description |
@@ -232,6 +248,7 @@ These variables configure Headroom at runtime. Set them in your shell, `.env` fi
 <Cards>
   <Card title="Quickstart" href="/docs/quickstart" />
   <Card title="Proxy Server" href="/docs/proxy" />
+  <Card title="Persistent Installs" href="/docs/persistent-installs" />
+  <Card title="Dashboard" href="/docs/dashboard" />
   <Card title="Configuration" href="/docs/configuration" />
-  <Card title="Vercel AI SDK" href="/docs/vercel-ai-sdk" />
 </Cards>

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -37,6 +37,7 @@
     "configuration",
     "filesystem-contract",
     "---Observability---",
+    "dashboard",
     "metrics",
     "simulation",
     "---API Reference---",

--- a/docs/content/docs/metrics.mdx
+++ b/docs/content/docs/metrics.mdx
@@ -59,6 +59,13 @@ curl "http://localhost:8787/stats-history?format=csv&series=daily"
 curl "http://localhost:8787/stats-history?format=csv&series=monthly"
 ```
 
+The local [Dashboard](/docs/dashboard) uses this endpoint for its historical
+charts and export buttons. Open it while the proxy is running:
+
+```bash
+open http://localhost:8787/dashboard
+```
+
 ### Prometheus Metrics
 
 ```bash

--- a/docs/content/docs/proxy.mdx
+++ b/docs/content/docs/proxy.mdx
@@ -130,6 +130,19 @@ curl http://localhost:8787/stats-history
 curl "http://localhost:8787/stats-history?format=csv&series=weekly"
 ```
 
+### `GET /dashboard`
+
+Browser UI for live proxy health, current-session stats, durable savings
+history, recent transformations, and CSV/JSON history exports.
+
+```bash
+open http://localhost:8787/dashboard
+```
+
+The dashboard is served by the proxy itself and reads `/health`,
+`/stats?cached=1`, `/stats-history`, and `/transformations/feed?limit=50`.
+See [Dashboard](/docs/dashboard).
+
 ### `GET /metrics`
 
 Prometheus-format metrics for monitoring.

--- a/wiki/dashboard.md
+++ b/wiki/dashboard.md
@@ -1,0 +1,105 @@
+# Dashboard
+
+The Headroom proxy serves a local dashboard at:
+
+```bash
+http://localhost:8787/dashboard
+```
+
+Start the proxy first:
+
+```bash
+headroom proxy
+```
+
+Then open the dashboard in your browser:
+
+```bash
+open http://localhost:8787/dashboard
+```
+
+On Windows:
+
+```powershell
+start http://localhost:8787/dashboard
+```
+
+## What it shows
+
+The dashboard is the human-facing view for proxy observability. It shows:
+
+- live proxy health
+- current-session requests, tokens, cache hits, failures, and savings
+- durable lifetime savings loaded from local state
+- hourly, daily, weekly, and monthly savings history
+- recent transformed/compressed request events
+- export buttons for savings history
+
+It is served by the same proxy process and does not require a separate web
+server.
+
+## Data sources
+
+The dashboard reads the same HTTP endpoints you can query directly:
+
+| Endpoint | Used for |
+|---|---|
+| `GET /health` | proxy readiness and runtime status |
+| `GET /stats?cached=1` | short-TTL dashboard stats snapshot |
+| `GET /stats-history` | durable history and chart rollups |
+| `GET /transformations/feed?limit=50` | recent compression/transformation events |
+
+If the dashboard looks empty, check these endpoints first:
+
+```bash
+curl http://localhost:8787/health
+curl http://localhost:8787/stats
+curl http://localhost:8787/stats-history
+curl "http://localhost:8787/transformations/feed?limit=5"
+```
+
+## Durable history
+
+Savings history is stored locally and survives proxy restarts. By default, the
+proxy stores it under the Headroom workspace state directory:
+
+```text
+~/.headroom/proxy_savings.json
+```
+
+You can override the file directly:
+
+```bash
+HEADROOM_SAVINGS_PATH=/path/to/proxy_savings.json headroom proxy
+```
+
+Or relocate the whole state root:
+
+```bash
+HEADROOM_WORKSPACE_DIR=/path/to/headroom-state headroom proxy
+```
+
+See [Filesystem Contract](filesystem-contract.md) for the full path rules.
+
+## Export history
+
+The dashboard export buttons use `/stats-history` under the hood. The same data
+is available from the CLI:
+
+```bash
+curl "http://localhost:8787/stats-history?format=csv&series=daily"
+curl "http://localhost:8787/stats-history?format=csv&series=weekly"
+curl "http://localhost:8787/stats-history?format=csv&series=monthly"
+curl "http://localhost:8787/stats-history?history_mode=full"
+```
+
+## Persistent proxy
+
+For an always-on proxy that keeps the dashboard available across terminal
+sessions, install a persistent service:
+
+```bash
+headroom install apply --preset persistent-service --providers auto
+```
+
+See [Persistent Installs](persistent-installs.md).

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -409,6 +409,8 @@ Requires Python 3.10+.
 ## Next Steps
 
 - **[Quickstart](quickstart.md)** — Running in 5 minutes
+- **[Dashboard](dashboard.md)** - Local proxy UI for health, savings history, and exports
+- **[Persistent Installs](persistent-installs.md)** - Keep the proxy running as a local service/task
 - **[Integration Guide](integration-guide.md)** — Every way to add Headroom to your stack
 - **[Architecture](ARCHITECTURE.md)** — How the pipeline works under the hood
 - **[Benchmarks](benchmarks.md)** — Accuracy and latency data

--- a/wiki/metrics.md
+++ b/wiki/metrics.md
@@ -154,6 +154,13 @@ curl "http://localhost:8787/stats-history?history_mode=full"
 CSV exports are available for `history`, `hourly`, `daily`, `weekly`, and
 `monthly`. Plain JSON remains the default response format.
 
+The local [Dashboard](dashboard.md) uses this endpoint for its historical
+charts and export buttons. Open it while the proxy is running:
+
+```bash
+open http://localhost:8787/dashboard
+```
+
 ### Prometheus Metrics
 
 ```bash

--- a/wiki/proxy.md
+++ b/wiki/proxy.md
@@ -252,6 +252,17 @@ curl "http://localhost:8787/stats-history?format=csv&series=monthly"
 curl "http://localhost:8787/stats-history?history_mode=full"
 ```
 
+### Dashboard
+
+```bash
+open http://localhost:8787/dashboard
+```
+
+`/dashboard` is the browser UI served by the proxy. It shows live health,
+current-session stats, durable savings history, recent transformations, and
+history exports. It reads `/health`, `/stats?cached=1`, `/stats-history`, and
+`/transformations/feed?limit=50`. See [Dashboard](dashboard.md).
+
 ### Prometheus Metrics
 
 ```bash


### PR DESCRIPTION
Fixes #207.

This cleans up the docs paths that were hard to discover:

- adds a dedicated Dashboard page for `/dashboard`
- explains which proxy endpoints the dashboard reads (`/health`, `/stats?cached=1`, `/stats-history`, `/transformations/feed`)
- links dashboard and persistent installs from the docs nav, installation page, README, proxy docs, and metrics docs
- mirrors the dashboard page and links in `wiki/`
- replaces the generated Fumadocs boilerplate link in `docs/README.md` with repo-specific docs layout notes

Verification:
- `npm --prefix docs ci` passed; Fumadocs MDX generation completed during postinstall
- custom internal-link check for the changed docs/wiki files passed
- `git diff --check` passed

I also tried the full docs checks:
- `npm --prefix docs run types:check`
- `npm --prefix docs run build`

Both currently fail before this docs content is involved because the docs app references missing existing modules such as `@/lib/source`, `@/lib/layout.shared`, `@/lib/shared`, `@/lib/cn`, and `@/lib/telemetry`. On Windows, the build also reports a missing `lightningcss.win32-x64-msvc.node` optional package.