### PR TITLE
fix(pipeline): keep large compression results on critical path

### DIFF
--- a/headroom/transforms/pipeline.py
+++ b/headroom/transforms/pipeline.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+MAX_WASTE_SIGNAL_DETECTION_TOKENS = 100_000
+
 
 class TransformPipeline:
     """
@@ -156,6 +158,10 @@ class TransformPipeline:
             Combined TransformResult.
         """
         record_metrics = kwargs.pop("record_metrics", True)
+        detect_waste_signals = kwargs.pop("detect_waste_signals", True)
+        waste_signal_token_limit = int(
+            kwargs.pop("waste_signal_token_limit", MAX_WASTE_SIGNAL_DETECTION_TOKENS)
+        )
         tokenizer = self._get_tokenizer(model)
         provider_name = self._provider_name()
 
@@ -354,7 +360,12 @@ class TransformPipeline:
 
             # Detect waste signals in original messages (only when significant compression)
             waste_signals: WasteSignals | None = None
-            if tokens_before > tokens_after and (tokens_before - tokens_after) > 100:
+            should_detect_waste_signals = (
+                detect_waste_signals
+                and tokens_before > tokens_after
+                and (tokens_before - tokens_after) > 100
+            )
+            if should_detect_waste_signals and tokens_before <= waste_signal_token_limit:
                 try:
                     from ..parser import parse_messages
 
@@ -363,6 +374,14 @@ class TransformPipeline:
                         waste_signals = None
                 except Exception:
                     pass
+            elif should_detect_waste_signals:
+                logger.debug(
+                    "%sSkipping waste-signal detection for %d-token request "
+                    "(limit=%d) to keep compression result on the critical path",
+                    log_prefix,
+                    tokens_before,
+                    waste_signal_token_limit,
+                )
 
             if pipeline_span is not None and pipeline_span.is_recording():
                 pipeline_span.set_attribute("headroom.tokens.after", tokens_after)

--- a/tests/test_anthropic_pre_upstream_backpressure.py
+++ b/tests/test_anthropic_pre_upstream_backpressure.py
@@ -711,6 +711,126 @@ def test_compression_is_not_bypassed_when_gated(stage_log_capture):
     assert sem._value == 2
 
 
+def test_large_token_mode_request_forwards_compressed_result_without_waste_signal_delay(
+    monkeypatch,
+):
+    """Slow waste-signal parsing must not make token-mode discard compression.
+
+    Regression for #296: TransformPipeline logs "Pipeline complete" before
+    waste-signal detection. On huge Claude Code transcripts that diagnostic
+    pass can exceed the Anthropic compression timeout, causing the proxy to
+    fail open with the original request even though the compression result is
+    already available.
+    """
+
+    from headroom.config import HeadroomConfig, TransformResult
+    from headroom.transforms.base import Transform
+    from headroom.transforms.pipeline import TransformPipeline
+
+    class _LengthTokenizer:
+        def count_messages(self, messages) -> int:
+            total = 0
+            for message in messages:
+                content = message.get("content", "")
+                if isinstance(content, str):
+                    total += len(content)
+                elif isinstance(content, list):
+                    total += sum(
+                        len(part.get("text", "")) for part in content if isinstance(part, dict)
+                    )
+            return total
+
+        def count_text(self, text) -> int:
+            return len(str(text))
+
+    class _ShrinkTransform(Transform):
+        name = "test_shrink"
+
+        def apply(self, messages, tokenizer, **kwargs):
+            optimized = [dict(message) for message in messages]
+            optimized[-1] = {**optimized[-1], "content": "compressed"}
+            return TransformResult(
+                messages=optimized,
+                tokens_before=tokenizer.count_messages(messages),
+                tokens_after=tokenizer.count_messages(optimized),
+                transforms_applied=["test:shrink"],
+            )
+
+    tokenizer = _LengthTokenizer()
+    monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda _model: tokenizer)
+    monkeypatch.setattr("headroom.proxy.helpers.COMPRESSION_TIMEOUT_SECONDS", 0.05)
+
+    import headroom.parser as parser_mod
+
+    parse_called = False
+
+    def _slow_parse_messages(messages, tokenizer):
+        nonlocal parse_called
+        parse_called = True
+        time.sleep(0.2)
+        return [], {}, None
+
+    monkeypatch.setattr(parser_mod, "parse_messages", _slow_parse_messages)
+
+    sem = asyncio.Semaphore(1)
+    handler = _DummyAnthropicHandler(anthropic_pre_upstream_sem=sem)
+    handler.config = ProxyConfig(
+        optimize=True,
+        image_optimize=False,
+        retry_max_attempts=1,
+        retry_base_delay_ms=1,
+        retry_max_delay_ms=1,
+        connect_timeout_seconds=10,
+        mode="token",
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        fallback_enabled=False,
+        fallback_provider=None,
+        prefix_freeze_enabled=False,
+        memory_enabled=False,
+        anthropic_pre_upstream_concurrency=1,
+    )
+    handler.anthropic_pipeline = TransformPipeline(
+        config=HeadroomConfig(),
+        transforms=[_ShrinkTransform()],
+    )
+
+    captured: dict[str, dict] = {}
+
+    async def _capture_retry(
+        method,
+        url,
+        headers,
+        body,
+        *,
+        original_body_bytes=None,
+        body_mutated=True,
+        mutation_reasons=None,
+        request_id=None,
+        forwarder_name="test_dummy",
+        path_for_log=None,
+    ):
+        del method, url, headers, original_body_bytes, body_mutated
+        del mutation_reasons, request_id, forwarder_name, path_for_log
+        captured["body"] = body
+        return _ResponseStub()
+
+    handler._retry_request = _capture_retry
+    request = _build_request(
+        {
+            "model": "claude-3-5-sonnet-latest",
+            "messages": [{"role": "user", "content": "x" * 120_000}],
+        },
+        {"authorization": "Bearer sk-ant-api-test"},
+    )
+
+    anyio.run(handler.handle_anthropic_messages, request)
+
+    assert captured["body"]["messages"][0]["content"] == "compressed"
+    assert parse_called is False
+    assert sem._value == 1
+
+
 # --------------------------------------------------------------------------- #
 # CLI: --anthropic-pre-upstream-concurrency plumbs into ProxyConfig.           #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Description

Fixes #296.

Large Anthropic token-mode requests could finish the compression pipeline, log `Pipeline complete`, and then still hit the outer compression timeout before the pipeline returned. The expensive step was post-compression waste-signal parsing on the original huge transcript, so the proxy failed open and forwarded the uncompressed request even though the compressed messages were already available.

This keeps waste-signal detection out of the critical path for very large requests. Normal-sized requests still get waste-signal parsing; large requests keep the compression result and skip that diagnostic pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement

## Changes Made

- Add a `MAX_WASTE_SIGNAL_DETECTION_TOKENS` guard in `TransformPipeline.apply()`.
- Preserve existing waste-signal detection below the guard.
- Add an Anthropic token-mode regression test where slow waste-signal parsing would previously make the proxy discard an already-compressed result.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check` on touched files)
- [x] New tests added for the bug fix

## Test Output

```text
.venv313\Scripts\python.exe -m pytest tests\test_anthropic_pre_upstream_backpressure.py::test_large_token_mode_request_forwards_compressed_result_without_waste_signal_delay -q
# 1 passed

.venv313\Scripts\python.exe -m pytest tests\test_anthropic_pre_upstream_backpressure.py tests\test_anthropic_stage_timings.py tests\test_proxy_compression_executor.py -q
# 33 passed

TMP=.tmp/pytest-temp TEMP=.tmp/pytest-temp .venv313\Scripts\python.exe -m pytest tests\test_canonical_pipeline.py tests\test_acceptance.py -q
# 18 passed

.venv313\Scripts\python.exe -m ruff check headroom\transforms\pipeline.py tests\test_anthropic_pre_upstream_backpressure.py
# All checks passed

.venv313\Scripts\python.exe -m ruff format --check headroom\transforms\pipeline.py tests\test_anthropic_pre_upstream_backpressure.py
# 2 files already formatted

git diff --check
# passed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

The first run of `tests/test_canonical_pipeline.py tests/test_acceptance.py` hit a Windows temp-directory permission error under `C:\Users\Japar\AppData\Local\Temp\pytest-of-Japar`. Re-running the same tests with `TMP`/`TEMP` pointed at the repo-local `.tmp\pytest-temp` directory passed.