### PR TITLE
feat(telemetry): list observable surfaces

### DIFF
--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -38,6 +38,7 @@
     "filesystem-contract",
     "---Observability---",
     "metrics",
+    "telemetry-surfaces",
     "simulation",
     "---API Reference---",
     "api-reference",

--- a/docs/content/docs/telemetry-surfaces.mdx
+++ b/docs/content/docs/telemetry-surfaces.mdx
@@ -1,0 +1,82 @@
+---
+title: Telemetry Surfaces
+description: A single inventory of the data Headroom can expose, persist, or export while the proxy is running.
+---
+
+Headroom has several observability surfaces: anonymous aggregate telemetry,
+local metrics, durable savings history, dashboard endpoints, optional OTEL
+export, optional Langfuse tracing, TOIN aggregation, request logs, and debug
+captures. Use this page and the CLI inventory when reviewing what Headroom can
+emit or store.
+
+```bash
+headroom telemetry list
+headroom telemetry list --json
+```
+
+The CLI command inspects local environment variables and canonical paths only.
+It does not start the proxy, call the proxy, contact an external endpoint, or
+create files.
+
+## Inventory
+
+| Surface | Emits | Default | Prompt content | Leaves host | Observe / export | Retention | Controls |
+|---|---|---|---|---|---|---|---|
+| `HEADROOM_TELEMETRY` beacon | Anonymous aggregate proxy stats: version, platform, install mode, request counts, token savings, cache/latency and strategy aggregates | On | No | Yes, when enabled | Startup banner, `/stats` `anon_telemetry_shipping`; posts to Headroom anonymous telemetry endpoint | Remote service controlled; not persisted locally by the beacon | `HEADROOM_TELEMETRY=off`, `headroom proxy --no-telemetry` |
+| Prometheus `/metrics` | Request, token, cache, latency, compression, subscription and health metrics | On when proxy runs | No | No active export; reachable if the proxy is exposed | `GET /metrics`; Prometheus or compatible scrape | In-memory counters for the running proxy process | Proxy host/port binding, network policy |
+| OTEL metrics | Operational counters and histograms from the proxy metrics facade | Off | No | Yes when enabled with OTLP/HTTP exporter; no for console exporter | Collector output or console exporter | Exporter controlled | `HEADROOM_OTEL_METRICS_ENABLED`, `HEADROOM_OTEL_METRICS_EXPORTER`, `HEADROOM_OTEL_METRICS_ENDPOINT`, `HEADROOM_OTEL_METRICS_HEADERS` |
+| Langfuse tracing | Compression pipeline spans with model/provider, token counts and transform names | Off | No by default | Yes when enabled and keys are present | Langfuse dashboard or `/stats` `langfuse` block | Langfuse controlled | `HEADROOM_LANGFUSE_ENABLED`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_OTEL_HOST` |
+| Savings tracker | Durable token/cost savings totals and bounded history rollups | On | No | No | `GET /stats-history`, `/dashboard`, JSON/CSV export, savings JSON file | Bounded history plus lifetime totals until the file is removed | `HEADROOM_SAVINGS_PATH`, `HEADROOM_WORKSPACE_DIR` |
+| Dashboard | Live proxy, savings, request, cache, quota, TOIN and subscription views | On when proxy runs | No by default | No active export; reachable if the proxy is exposed | `GET /dashboard`; reads `/stats` and `/stats-history` | Browser/session only; backed by runtime stats and savings history | Proxy host/port binding, network policy |
+| Stats endpoints | Live stats, durable history, quotas, request metadata and subsystem status | On when proxy runs | No by default | No active export; reachable if the proxy is exposed | `GET /stats`, `/stats-history`, `/quota` | In-memory stats plus savings ledger for history | Proxy host/port binding, network policy |
+| TOIN aggregation | Aggregated tool-output compression/retrieval patterns and strategy outcomes | On | No raw values; structure and outcome aggregates only | No unless a custom backend points outside the host | `GET /v1/toin/stats`, filesystem JSON, or custom backend | Backend controlled; filesystem data remains until removed | `HEADROOM_TOIN_BACKEND`, `HEADROOM_TOIN_PATH`, `HEADROOM_TOIN_URL`, `HEADROOM_TOIN_TENANT_PREFIX` |
+| Proxy request log | Recent request metadata, outcomes, tags, token counts, model/provider and timings | Metadata in memory; file off unless configured | No by default; opt in with `HEADROOM_LOG_MESSAGES=true` or `--log-messages` | No | `/stats` `recent_requests`, `/transformations/feed`, optional JSONL file | Up to 10,000 in-memory entries; file retention is operator controlled | `HEADROOM_LOG_FILE`, `--log-file`, `HEADROOM_LOG_MESSAGES`, `--log-messages` |
+| HTTP 400 debug dumps | Full local diagnostic JSON for upstream errors, including sent/original messages and system prompt | On for upstream error diagnostics | Yes, on upstream 4xx error dumps | No | Files under `${HEADROOM_WORKSPACE_DIR}/logs/debug_400/` | Until files are removed by the operator | `HEADROOM_WORKSPACE_DIR` controls location; no dedicated off switch is currently exposed |
+| Codex wire debug captures | Opt-in Codex wire snapshots and matching proxy log frame traces | Off | Yes when explicitly enabled; secrets are redacted | No | Files under `${HEADROOM_WORKSPACE_DIR}/logs/codex_wire/` or `HEADROOM_CODEX_WIRE_DEBUG_DIR` | Until files are removed by the operator | `HEADROOM_CODEX_WIRE_DEBUG`, `HEADROOM_CODEX_WIRE_DEBUG_DIR`, `--codex-wire-debug`, `--codex-wire-debug-dir` |
+
+## Content Handling
+
+Most surfaces expose aggregate metrics or request metadata only. The important
+exceptions are local diagnostic surfaces:
+
+| Surface | When content can appear |
+|---|---|
+| HTTP 400 debug dumps | On upstream 4xx errors, Headroom writes a local JSON diagnostic dump containing the sent/original messages, tools, and system prompt. |
+| Proxy request log | Only when `HEADROOM_LOG_MESSAGES=true` or `--log-messages` is enabled. |
+| Codex wire debug captures | Only when `HEADROOM_CODEX_WIRE_DEBUG=true` or `--codex-wire-debug` is enabled. Secrets are redacted, but wire payload content can still be present. |
+
+## Common Checks
+
+Disable the anonymous aggregate beacon:
+
+```bash
+HEADROOM_TELEMETRY=off headroom proxy
+headroom proxy --no-telemetry
+```
+
+Inspect the current local policy as JSON:
+
+```bash
+headroom telemetry list --json
+```
+
+Run with OTEL metrics export:
+
+```bash
+HEADROOM_OTEL_METRICS_ENABLED=true \
+HEADROOM_OTEL_METRICS_ENDPOINT=http://collector:4318/v1/metrics \
+headroom proxy
+```
+
+Keep request content out of logs and live feed:
+
+```bash
+unset HEADROOM_LOG_MESSAGES
+headroom proxy
+```
+
+Relocate local state for managed deployments:
+
+```bash
+HEADROOM_WORKSPACE_DIR=/var/lib/headroom headroom proxy
+```

--- a/headroom/cli/__init__.py
+++ b/headroom/cli/__init__.py
@@ -20,6 +20,7 @@ from . import (  # noqa: F401
     mcp,
     perf,
     proxy,
+    telemetry,
     tools,
     wrap,
 )

--- a/headroom/cli/main.py
+++ b/headroom/cli/main.py
@@ -43,6 +43,7 @@ def _register_commands() -> None:
         mcp,  # noqa: F401
         perf,  # noqa: F401
         proxy,  # noqa: F401
+        telemetry,  # noqa: F401
         tools,  # noqa: F401
         wrap,  # noqa: F401
     )

--- a/headroom/cli/telemetry.py
+++ b/headroom/cli/telemetry.py
@@ -1,0 +1,51 @@
+"""Telemetry transparency CLI commands."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from .main import main
+
+
+@main.group("telemetry")
+def telemetry_group() -> None:
+    """Inspect Headroom telemetry and observability surfaces."""
+
+
+@telemetry_group.command("list")
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON instead of a table.")
+def telemetry_list_cmd(json_output: bool) -> None:
+    """List every known telemetry/observability surface."""
+
+    from rich.console import Console
+    from rich.table import Table
+
+    from headroom.telemetry.surfaces import collect_telemetry_surface_dicts
+
+    rows = collect_telemetry_surface_dicts()
+    if json_output:
+        click.echo(json.dumps(rows, indent=2))
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Surface", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Leaves host")
+    table.add_column("Prompt content")
+    table.add_column("Target")
+    table.add_column("Controls")
+
+    for row in rows:
+        controls = ", ".join(str(control) for control in row["controls"])
+        table.add_row(
+            str(row["name"]),
+            str(row["status"]),
+            str(row["leaves_host"]),
+            str(row["prompt_content"]),
+            str(row["target"]),
+            controls,
+        )
+
+    Console(width=180).print(table)

--- a/headroom/cli/telemetry.py
+++ b/headroom/cli/telemetry.py
@@ -22,11 +22,11 @@ def telemetry_list_cmd(json_output: bool) -> None:
     from rich.console import Console
     from rich.table import Table
 
-    from headroom.telemetry.surfaces import collect_telemetry_surface_dicts
+    from headroom.telemetry.surfaces import collect_telemetry_surfaces
 
-    rows = collect_telemetry_surface_dicts()
+    rows = collect_telemetry_surfaces()
     if json_output:
-        click.echo(json.dumps(rows, indent=2))
+        click.echo(json.dumps([row.as_dict() for row in rows], indent=2))
         return
 
     table = Table(show_header=True, header_style="bold")
@@ -38,13 +38,13 @@ def telemetry_list_cmd(json_output: bool) -> None:
     table.add_column("Controls")
 
     for row in rows:
-        controls = ", ".join(str(control) for control in row["controls"])
+        controls = ", ".join(row.controls)
         table.add_row(
-            str(row["name"]),
-            str(row["status"]),
-            str(row["leaves_host"]),
-            str(row["prompt_content"]),
-            str(row["target"]),
+            row.name,
+            row.status,
+            row.leaves_host,
+            row.prompt_content,
+            row.target,
             controls,
         )
 

--- a/headroom/telemetry/surfaces.py
+++ b/headroom/telemetry/surfaces.py
@@ -1,0 +1,359 @@
+"""Runtime inventory for Headroom telemetry and observability surfaces."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from headroom import paths
+
+_OFF_VALUES = frozenset(("off", "false", "0", "no", "disable", "disabled"))
+_ON_VALUES = frozenset(("on", "true", "1", "yes", "enable", "enabled"))
+
+
+@dataclass(frozen=True, slots=True)
+class TelemetrySurface:
+    """A single place a Headroom operator can observe or export runtime data."""
+
+    id: str
+    name: str
+    status: str
+    default: str
+    emits: str
+    observe: str
+    export: str
+    retention: str
+    prompt_content: str
+    leaves_host: str
+    target: str
+    controls: tuple[str, ...]
+    notes: str = ""
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable representation."""
+
+        return {
+            "id": self.id,
+            "name": self.name,
+            "status": self.status,
+            "default": self.default,
+            "emits": self.emits,
+            "observe": self.observe,
+            "export": self.export,
+            "retention": self.retention,
+            "prompt_content": self.prompt_content,
+            "leaves_host": self.leaves_host,
+            "target": self.target,
+            "controls": list(self.controls),
+            "notes": self.notes,
+        }
+
+
+def _env(env: Mapping[str, str], name: str, default: str = "") -> str:
+    return env.get(name, default).strip()
+
+
+def _env_bool(env: Mapping[str, str], name: str, *, default: bool = False) -> bool:
+    raw = _env(env, name)
+    if not raw:
+        return default
+    value = raw.lower()
+    if value in _ON_VALUES:
+        return True
+    if value in _OFF_VALUES:
+        return False
+    return default
+
+
+def _telemetry_beacon_enabled(env: Mapping[str, str]) -> bool:
+    value = _env(env, "HEADROOM_TELEMETRY", "on").lower()
+    return value not in _OFF_VALUES
+
+
+def _proxy_base_url(env: Mapping[str, str]) -> str:
+    host = _env(env, "HEADROOM_HOST", "127.0.0.1") or "127.0.0.1"
+    port = _env(env, "HEADROOM_PORT", "8787") or "8787"
+    return f"http://{host}:{port}"
+
+
+def _langfuse_endpoint(env: Mapping[str, str]) -> str:
+    base_url = (
+        _env(env, "LANGFUSE_BASE_URL")
+        or _env(env, "LANGFUSE_OTEL_HOST")
+        or "https://cloud.langfuse.com"
+    )
+    return f"{base_url.rstrip('/')}/api/public/otel/v1/traces"
+
+
+def _otel_exporter(env: Mapping[str, str]) -> str:
+    exporter = _env(env, "HEADROOM_OTEL_METRICS_EXPORTER", "otlp_http")
+    normalized = exporter.lower().replace("-", "_")
+    return normalized if normalized in {"console", "otlp_http"} else "otlp_http"
+
+
+def _toin_status_and_target(env: Mapping[str, str]) -> tuple[str, str, str]:
+    backend = _env(env, "HEADROOM_TOIN_BACKEND").lower()
+    stateless = _env_bool(env, "HEADROOM_STATELESS", default=False)
+    path = str(paths.toin_path())
+
+    if backend == "none" or stateless:
+        return (
+            "off-requested",
+            "memory only",
+            "HEADROOM_TOIN_BACKEND=none is the intended in-memory/stateless control.",
+        )
+    if backend and backend != "filesystem":
+        target = _env(env, "HEADROOM_TOIN_URL") or f"entry point backend: {backend}"
+        return (
+            "on",
+            target,
+            "Storage is provided by the registered headroom.toin_backend entry point.",
+        )
+    return "on", path, "Uses the filesystem backend unless a custom backend is configured."
+
+
+def collect_telemetry_surfaces(
+    env: Mapping[str, str] | None = None,
+) -> list[TelemetrySurface]:
+    """Return Headroom telemetry surfaces using only local environment state.
+
+    This function intentionally does not contact the proxy, start background
+    tasks, import the FastAPI server, or create any filesystem paths.
+    """
+
+    resolved_env = env or os.environ
+    base_url = _proxy_base_url(resolved_env)
+
+    telemetry_on = _telemetry_beacon_enabled(resolved_env)
+    otel_enabled = _env_bool(resolved_env, "HEADROOM_OTEL_METRICS_ENABLED", default=False)
+    otel_exporter = _otel_exporter(resolved_env)
+    otel_endpoint = _env(resolved_env, "HEADROOM_OTEL_METRICS_ENDPOINT")
+    langfuse_enabled = _env_bool(resolved_env, "HEADROOM_LANGFUSE_ENABLED", default=False)
+    langfuse_complete = bool(
+        _env(resolved_env, "LANGFUSE_PUBLIC_KEY") and _env(resolved_env, "LANGFUSE_SECRET_KEY")
+    )
+    log_messages = _env_bool(resolved_env, "HEADROOM_LOG_MESSAGES", default=False)
+    log_file = _env(resolved_env, "HEADROOM_LOG_FILE")
+    codex_wire_debug = _env_bool(resolved_env, "HEADROOM_CODEX_WIRE_DEBUG", default=False)
+    toin_status, toin_target, toin_notes = _toin_status_and_target(resolved_env)
+
+    if otel_exporter == "console":
+        otel_target = "stdout"
+        otel_leaves_host = "no"
+    else:
+        otel_target = otel_endpoint or "OTLP/HTTP exporter default endpoint"
+        otel_leaves_host = "yes" if otel_enabled else "no"
+
+    if langfuse_enabled and langfuse_complete:
+        langfuse_status = "on"
+        langfuse_target = _langfuse_endpoint(resolved_env)
+        langfuse_leaves_host = "yes"
+    elif langfuse_enabled:
+        langfuse_status = "incomplete"
+        langfuse_target = _langfuse_endpoint(resolved_env)
+        langfuse_leaves_host = "no"
+    else:
+        langfuse_status = "off"
+        langfuse_target = "-"
+        langfuse_leaves_host = "no"
+
+    request_log_target = "memory"
+    if log_file:
+        request_log_target = log_file
+
+    return [
+        TelemetrySurface(
+            id="anonymous_beacon",
+            name="HEADROOM_TELEMETRY beacon",
+            status="on" if telemetry_on else "off",
+            default="on",
+            emits=(
+                "Anonymous aggregate proxy stats: version, Python/OS, install mode, "
+                "request counts, token savings, cache/latency and strategy aggregates."
+            ),
+            observe="Startup banner and /stats anon_telemetry_shipping.",
+            export="Headroom Supabase REST endpoint when enabled.",
+            retention="Remote service controlled; not persisted locally by the beacon.",
+            prompt_content="no",
+            leaves_host="yes" if telemetry_on else "no",
+            target="Headroom anonymous telemetry endpoint" if telemetry_on else "-",
+            controls=("HEADROOM_TELEMETRY=off", "headroom proxy --no-telemetry"),
+            notes="The beacon reads local /stats and silently skips on network failures.",
+        ),
+        TelemetrySurface(
+            id="prometheus_metrics",
+            name="Prometheus /metrics",
+            status="on",
+            default="on when proxy runs",
+            emits="Request, token, cache, latency, compression, subscription and health metrics.",
+            observe=f"GET {base_url}/metrics",
+            export="Prometheus scrape or any compatible collector.",
+            retention="In-memory counters for the running proxy process.",
+            prompt_content="no",
+            leaves_host="no active export; reachable if the proxy is exposed",
+            target="/metrics",
+            controls=("Proxy host/port binding", "Network/firewall policy"),
+        ),
+        TelemetrySurface(
+            id="otel_metrics",
+            name="OpenTelemetry metrics",
+            status="on" if otel_enabled else "off",
+            default="off",
+            emits="The same operational counters/histograms as the proxy metrics facade.",
+            observe="/stats otel block, collector output, or console exporter.",
+            export="OTLP/HTTP or console exporter.",
+            retention="Exporter controlled.",
+            prompt_content="no",
+            leaves_host=otel_leaves_host,
+            target=otel_target if otel_enabled else "-",
+            controls=(
+                "HEADROOM_OTEL_METRICS_ENABLED",
+                "HEADROOM_OTEL_METRICS_EXPORTER",
+                "HEADROOM_OTEL_METRICS_ENDPOINT",
+                "HEADROOM_OTEL_METRICS_HEADERS",
+            ),
+        ),
+        TelemetrySurface(
+            id="langfuse_tracing",
+            name="Langfuse tracing",
+            status=langfuse_status,
+            default="off",
+            emits="Compression pipeline spans with model/provider, token counts and transform names.",
+            observe="/stats langfuse block or the Langfuse dashboard.",
+            export="Langfuse OTLP trace endpoint.",
+            retention="Langfuse controlled.",
+            prompt_content="no by default",
+            leaves_host=langfuse_leaves_host,
+            target=langfuse_target,
+            controls=(
+                "HEADROOM_LANGFUSE_ENABLED",
+                "LANGFUSE_PUBLIC_KEY",
+                "LANGFUSE_SECRET_KEY",
+                "LANGFUSE_BASE_URL",
+                "LANGFUSE_OTEL_HOST",
+            ),
+            notes="Status is incomplete until both Langfuse keys are present.",
+        ),
+        TelemetrySurface(
+            id="savings_tracker",
+            name="Savings tracker",
+            status="on",
+            default="on",
+            emits="Durable token/cost savings totals and bounded history rollups.",
+            observe=f"GET {base_url}/stats-history or read the JSON file.",
+            export="/stats-history JSON/CSV or the configured file path.",
+            retention="Bounded history plus lifetime totals until the file is removed.",
+            prompt_content="no",
+            leaves_host="no",
+            target=str(paths.savings_path()),
+            controls=("HEADROOM_SAVINGS_PATH", "HEADROOM_WORKSPACE_DIR"),
+            notes="HEADROOM_SAVINGS_PATH relocates the ledger; there is no dedicated off switch.",
+        ),
+        TelemetrySurface(
+            id="dashboard",
+            name="Dashboard",
+            status="on",
+            default="on when proxy runs",
+            emits="Live proxy, savings, request, cache, quota, TOIN and subscription views.",
+            observe=f"GET {base_url}/dashboard",
+            export="Browser view; reads /stats and /stats-history.",
+            retention="Browser/session only; backed by runtime stats and savings history.",
+            prompt_content="no by default",
+            leaves_host="no active export; reachable if the proxy is exposed",
+            target="/dashboard",
+            controls=("Proxy host/port binding", "Network/firewall policy"),
+        ),
+        TelemetrySurface(
+            id="stats_endpoints",
+            name="Stats endpoints",
+            status="on",
+            default="on when proxy runs",
+            emits="Live stats, durable history, quotas, request metadata and subsystem status.",
+            observe=f"GET {base_url}/stats, /stats-history, /quota",
+            export="/stats JSON and /stats-history JSON/CSV.",
+            retention="In-memory stats plus savings ledger for history.",
+            prompt_content="no by default",
+            leaves_host="no active export; reachable if the proxy is exposed",
+            target="/stats, /stats-history, /quota",
+            controls=("Proxy host/port binding", "Network/firewall policy"),
+        ),
+        TelemetrySurface(
+            id="toin_aggregation",
+            name="TOIN aggregation",
+            status=toin_status,
+            default="on",
+            emits="Aggregated tool-output compression/retrieval patterns and strategy outcomes.",
+            observe=f"GET {base_url}/v1/toin/stats or inspect the configured backend.",
+            export="Filesystem JSON by default; custom headroom.toin_backend entry points when enabled.",
+            retention="Backend controlled; filesystem data remains until removed.",
+            prompt_content="no raw values; structure and outcome aggregates only",
+            leaves_host="no unless a custom backend points outside the host",
+            target=toin_target,
+            controls=(
+                "HEADROOM_TOIN_BACKEND",
+                "HEADROOM_TOIN_PATH",
+                "HEADROOM_TOIN_URL",
+                "HEADROOM_TOIN_TENANT_PREFIX",
+            ),
+            notes=toin_notes,
+        ),
+        TelemetrySurface(
+            id="proxy_request_log",
+            name="Proxy request log",
+            status="on",
+            default="metadata in memory; file off unless configured",
+            emits="Recent request metadata, outcomes, tags, token counts, model/provider and timings.",
+            observe="/stats recent_requests, /transformations/feed, or the JSONL file.",
+            export="In-memory feed and optional HEADROOM_LOG_FILE/--log-file JSONL.",
+            retention="Up to 10,000 in-memory entries; file retention is operator controlled.",
+            prompt_content="opt-in" if log_messages else "no",
+            leaves_host="no",
+            target=request_log_target,
+            controls=("HEADROOM_LOG_FILE", "--log-file", "HEADROOM_LOG_MESSAGES", "--log-messages"),
+            notes="HEADROOM_LOG_MESSAGES stores request/response content for the live feed.",
+        ),
+        TelemetrySurface(
+            id="debug_400_dumps",
+            name="HTTP 400 debug dumps",
+            status="on for upstream 4xx",
+            default="on for upstream error diagnostics",
+            emits="Full local diagnostic JSON for upstream errors, including sent/original messages.",
+            observe=f"Read files under {paths.debug_400_dir()}.",
+            export="Local filesystem only.",
+            retention="Until files are removed by the operator.",
+            prompt_content="yes, on upstream 4xx error dumps",
+            leaves_host="no",
+            target=str(paths.debug_400_dir()),
+            controls=("HEADROOM_WORKSPACE_DIR",),
+            notes="No dedicated off switch is currently exposed for these diagnostic dumps.",
+        ),
+        TelemetrySurface(
+            id="codex_wire_debug",
+            name="Codex wire debug captures",
+            status="on" if codex_wire_debug else "off",
+            default="off",
+            emits="Opt-in Codex wire snapshots and matching proxy log frame traces.",
+            observe=f"Read files under {paths.codex_wire_debug_dir()} or HEADROOM_CODEX_WIRE_DEBUG_DIR.",
+            export="Local filesystem only.",
+            retention="Until files are removed by the operator.",
+            prompt_content="yes, when explicitly enabled; secrets are redacted",
+            leaves_host="no",
+            target=_env(resolved_env, "HEADROOM_CODEX_WIRE_DEBUG_DIR")
+            or str(paths.codex_wire_debug_dir()),
+            controls=(
+                "HEADROOM_CODEX_WIRE_DEBUG",
+                "HEADROOM_CODEX_WIRE_DEBUG_DIR",
+                "--codex-wire-debug",
+                "--codex-wire-debug-dir",
+            ),
+        ),
+    ]
+
+
+def collect_telemetry_surface_dicts(
+    env: Mapping[str, str] | None = None,
+) -> list[dict[str, object]]:
+    """Return telemetry surfaces as dictionaries for CLI JSON output."""
+
+    return [surface.as_dict() for surface in collect_telemetry_surfaces(env)]

--- a/tests/test_telemetry_surfaces_cli.py
+++ b/tests/test_telemetry_surfaces_cli.py
@@ -1,0 +1,126 @@
+"""Regression tests for the telemetry surface inventory CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+from headroom.telemetry.surfaces import collect_telemetry_surface_dicts
+
+_ENV_VARS = (
+    "HEADROOM_CODEX_WIRE_DEBUG",
+    "HEADROOM_CODEX_WIRE_DEBUG_DIR",
+    "HEADROOM_HOST",
+    "HEADROOM_LANGFUSE_ENABLED",
+    "HEADROOM_LOG_FILE",
+    "HEADROOM_LOG_MESSAGES",
+    "HEADROOM_OTEL_METRICS_ENABLED",
+    "HEADROOM_OTEL_METRICS_ENDPOINT",
+    "HEADROOM_OTEL_METRICS_EXPORTER",
+    "HEADROOM_PORT",
+    "HEADROOM_SAVINGS_PATH",
+    "HEADROOM_STATELESS",
+    "HEADROOM_TELEMETRY",
+    "HEADROOM_TOIN_BACKEND",
+    "HEADROOM_TOIN_PATH",
+    "HEADROOM_TOIN_TENANT_PREFIX",
+    "HEADROOM_TOIN_URL",
+    "HEADROOM_WORKSPACE_DIR",
+    "LANGFUSE_BASE_URL",
+    "LANGFUSE_OTEL_HOST",
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+)
+
+
+def _clear_env(monkeypatch) -> None:  # noqa: ANN001
+    for name in _ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _by_id(rows: list[dict[str, object]]) -> dict[str, dict[str, object]]:
+    return {str(row["id"]): row for row in rows}
+
+
+def test_collect_telemetry_surfaces_defaults(monkeypatch, tmp_path: Path) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HEADROOM_WORKSPACE_DIR", str(tmp_path))
+
+    rows = _by_id(collect_telemetry_surface_dicts())
+
+    assert rows["anonymous_beacon"]["status"] == "on"
+    assert rows["anonymous_beacon"]["leaves_host"] == "yes"
+    assert rows["otel_metrics"]["status"] == "off"
+    assert rows["langfuse_tracing"]["status"] == "off"
+    assert rows["savings_tracker"]["target"] == str(tmp_path / "proxy_savings.json")
+    assert rows["debug_400_dumps"]["prompt_content"] == "yes, on upstream 4xx error dumps"
+    assert "HEADROOM_LOG_MESSAGES" in rows["proxy_request_log"]["controls"]
+
+
+def test_collect_telemetry_surfaces_env_overrides(monkeypatch, tmp_path: Path) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HEADROOM_WORKSPACE_DIR", str(tmp_path))
+    monkeypatch.setenv("HEADROOM_TELEMETRY", "off")
+    monkeypatch.setenv("HEADROOM_OTEL_METRICS_ENABLED", "1")
+    monkeypatch.setenv("HEADROOM_OTEL_METRICS_ENDPOINT", "http://collector:4318/v1/metrics")
+    monkeypatch.setenv("HEADROOM_LANGFUSE_ENABLED", "true")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk_test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk_test")
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "https://langfuse.example")
+    monkeypatch.setenv("HEADROOM_LOG_MESSAGES", "yes")
+    monkeypatch.setenv("HEADROOM_LOG_FILE", str(tmp_path / "proxy.jsonl"))
+    monkeypatch.setenv("HEADROOM_CODEX_WIRE_DEBUG", "on")
+    monkeypatch.setenv("HEADROOM_TOIN_BACKEND", "redis")
+    monkeypatch.setenv("HEADROOM_TOIN_URL", "redis://localhost:6379/0")
+
+    rows = _by_id(collect_telemetry_surface_dicts())
+
+    assert rows["anonymous_beacon"]["status"] == "off"
+    assert rows["anonymous_beacon"]["leaves_host"] == "no"
+    assert rows["otel_metrics"]["status"] == "on"
+    assert rows["otel_metrics"]["target"] == "http://collector:4318/v1/metrics"
+    assert rows["langfuse_tracing"]["status"] == "on"
+    assert rows["langfuse_tracing"]["target"] == (
+        "https://langfuse.example/api/public/otel/v1/traces"
+    )
+    assert rows["proxy_request_log"]["prompt_content"] == "opt-in"
+    assert rows["proxy_request_log"]["target"] == str(tmp_path / "proxy.jsonl")
+    assert rows["codex_wire_debug"]["status"] == "on"
+    assert rows["toin_aggregation"]["target"] == "redis://localhost:6379/0"
+
+
+def test_telemetry_list_json_cli(monkeypatch, tmp_path: Path) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HEADROOM_WORKSPACE_DIR", str(tmp_path))
+    monkeypatch.setenv("HEADROOM_TELEMETRY", "off")
+
+    result = CliRunner().invoke(main, ["telemetry", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.output)
+    by_id = _by_id(rows)
+    assert by_id["anonymous_beacon"]["status"] == "off"
+    assert by_id["prometheus_metrics"]["target"] == "/metrics"
+    assert by_id["debug_400_dumps"]["target"] == str(tmp_path / "logs" / "debug_400")
+
+
+def test_telemetry_list_table_cli(monkeypatch, tmp_path: Path) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HEADROOM_WORKSPACE_DIR", str(tmp_path))
+
+    result = CliRunner().invoke(main, ["telemetry", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "HEADROOM_TELEMETRY beacon" in result.output
+    assert "Prometheus /metrics" in result.output
+    assert "HTTP 400 debug dumps" in result.output
+
+
+def test_root_help_includes_telemetry_command() -> None:
+    result = CliRunner().invoke(main, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "telemetry" in result.output


### PR DESCRIPTION
## Summary

Closes #184.

This adds a single telemetry/observability inventory for operators and security-minded users:

- `headroom telemetry list` for a human-readable table
- `headroom telemetry list --json` for policy checks and scripts
- a docs page under Observability with the same surface inventory

The inventory covers the anonymous beacon, Prometheus, OTEL metrics, Langfuse tracing, savings history, dashboard/stats endpoints, TOIN, request logs, HTTP 400 debug dumps, and Codex wire debug captures. I called out the local surfaces that can include prompt/request content instead of burying those details in prose.

## Notes

The CLI command is intentionally local/static inspection only. It reads env vars and canonical paths; it does not start the proxy, call the proxy, contact external services, or create files.

## Verification

- `.venv313\Scripts\python.exe -m pytest tests/test_telemetry_surfaces_cli.py tests/test_telemetry_warning.py tests/test_cli/test_main_help_version.py -q --basetemp=.pytest-tmp`
- `.venv313\Scripts\python.exe -m ruff check headroom/telemetry/surfaces.py headroom/cli/telemetry.py headroom/cli/main.py headroom/cli/__init__.py tests/test_telemetry_surfaces_cli.py`
- `.venv313\Scripts\python.exe -m ruff format --check headroom/telemetry/surfaces.py headroom/cli/telemetry.py headroom/cli/main.py headroom/cli/__init__.py tests/test_telemetry_surfaces_cli.py`
- `.venv313\Scripts\python.exe -m json.tool docs/content/docs/meta.json > $null`
- `.venv313\Scripts\headroom.exe telemetry list --json`