### PR TITLE
fix(toin): honor in-memory backend selection

### DIFF
--- a/headroom/telemetry/toin.py
+++ b/headroom/telemetry/toin.py
@@ -68,7 +68,7 @@ import threading
 import time
 import warnings
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Final
 
 from .models import FieldSemantics, ToolSignature
@@ -1518,19 +1518,21 @@ _toin_lock = threading.Lock()
 
 # Environment variable for custom TOIN backend
 TOIN_BACKEND_ENV_VAR = "HEADROOM_TOIN_BACKEND"
+_IN_MEMORY_TOIN_BACKEND = object()
 
 
 def _create_default_toin_backend() -> Any:
     """Create a TOIN backend from env (e.g. HEADROOM_TOIN_BACKEND=redis).
 
     Loads adapters via setuptools entry point 'headroom.toin_backend'.
-    Returns None to use default FileSystemTOINBackend.
+    Returns None to use default FileSystemTOINBackend. Returns an internal
+    sentinel when the env var explicitly requests in-memory storage.
     """
     backend_type = (os.environ.get(TOIN_BACKEND_ENV_VAR) or "").strip().lower()
     if not backend_type or backend_type == "filesystem":
         return None
     if backend_type == "none":
-        return None  # Explicit in-memory-only (e.g. --stateless mode)
+        return _IN_MEMORY_TOIN_BACKEND
     try:
         from importlib.metadata import entry_points
 
@@ -1584,6 +1586,13 @@ def get_toin(config: TOINConfig | None = None) -> ToolIntelligenceNetwork:
     with _toin_lock:
         if _toin_instance is None:
             backend = _create_default_toin_backend()
+            if backend is _IN_MEMORY_TOIN_BACKEND:
+                backend = None
+                config = (
+                    replace(config, storage_path="")
+                    if config is not None
+                    else TOINConfig(storage_path="")
+                )
             _toin_instance = ToolIntelligenceNetwork(config, backend=backend)
         elif config is not None:
             # Warn when config is silently ignored

--- a/tests/test_adapter_hooks.py
+++ b/tests/test_adapter_hooks.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import threading
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -287,6 +288,28 @@ class TestTOINEntryPointLoading:
         assert toin is not None
         # Should use FileSystemTOINBackend since no HEADROOM_TOIN_BACKEND set
         assert toin._backend is not None
+
+    def test_backend_none_uses_in_memory_toin(self, monkeypatch, tmp_toin_path):
+        """HEADROOM_TOIN_BACKEND=none must not fall back to filesystem storage."""
+        monkeypatch.setenv("HEADROOM_TOIN_BACKEND", "none")
+        monkeypatch.setenv("HEADROOM_TOIN_PATH", tmp_toin_path)
+
+        toin = get_toin()
+
+        assert toin._backend is None
+        assert toin._config.storage_path == ""
+
+        toin.record_compression(
+            tool_signature=_make_tool_signature(),
+            original_count=5,
+            compressed_count=2,
+            original_tokens=100,
+            compressed_tokens=40,
+            strategy="smart_crusher",
+        )
+        toin.save()
+
+        assert not Path(tmp_toin_path).exists()
 
 
 # =============================================================================


### PR DESCRIPTION
﻿## Summary

`HEADROOM_TOIN_BACKEND=none` is documented in the code as the explicit in-memory/stateless TOIN mode, but the current path returns `None`, which is also the signal for "use the default filesystem backend". As a result, `get_toin()` can still create a `FileSystemTOINBackend` when `none` is selected.

This PR makes the `none` branch explicit:

- distinguishes "use default filesystem" from "force in-memory"
- clears `TOINConfig.storage_path` before constructing the singleton in in-memory mode
- adds a regression test that proves `HEADROOM_TOIN_BACKEND=none` does not create or write the configured `HEADROOM_TOIN_PATH`

## Verification

- `.venv313\Scripts\python.exe -m pytest tests/test_adapter_hooks.py::TestTOINEntryPointLoading tests/test_adapter_hooks.py::TestTOINBackendProtocol -q --basetemp=.pytest-tmp`
- `.venv313\Scripts\python.exe -m pytest tests/test_toin.py -q --basetemp=.pytest-tmp`
- `.venv313\Scripts\python.exe -m ruff check headroom/telemetry/toin.py tests/test_adapter_hooks.py`
- `.venv313\Scripts\python.exe -m ruff format --check headroom/telemetry/toin.py tests/test_adapter_hooks.py`

## Note

I also tried the full `tests/test_adapter_hooks.py` file on Windows, but two pre-existing storage URI tests fail before this change path because `sqlite:///{tmp_path}` / `jsonl:///{tmp_path}` parse to an invalid Windows path like `\\D:\...`. The TOIN entrypoint/backend tests above pass.
