### PR TITLE
fix(storage): normalize Windows file URIs

### DIFF
--- a/headroom/storage/__init__.py
+++ b/headroom/storage/__init__.py
@@ -1,5 +1,8 @@
 """Storage modules for Headroom SDK."""
 
+import os
+from urllib.parse import unquote
+
 from .base import Storage
 from .jsonl import JSONLStorage
 from .sqlite import SQLiteStorage
@@ -9,6 +12,16 @@ __all__ = [
     "SQLiteStorage",
     "JSONLStorage",
 ]
+
+
+def _path_from_storage_url(
+    store_url: str,
+    scheme: str,
+) -> str:
+    path = unquote(store_url.replace(f"{scheme}://", "", 1))
+    if os.name == "nt" and len(path) >= 3 and path[0] == "/" and path[2] == ":":
+        return path[1:]
+    return path
 
 
 def create_storage(store_url: str) -> Storage:
@@ -29,15 +42,10 @@ def create_storage(store_url: str) -> Storage:
         Storage instance.
     """
     if store_url.startswith("sqlite://"):
-        path = store_url.replace("sqlite://", "")
-        # Handle sqlite:/// (3 slashes for absolute path)
-        if path.startswith("/"):
-            path = path  # Already absolute
+        path = _path_from_storage_url(store_url, "sqlite")
         return SQLiteStorage(path)
     elif store_url.startswith("jsonl://"):
-        path = store_url.replace("jsonl://", "")
-        if path.startswith("/"):
-            path = path
+        path = _path_from_storage_url(store_url, "jsonl")
         return JSONLStorage(path)
     else:
         # Unknown scheme: try entry point headroom.storage_backend[name=scheme]

--- a/tests/test_storage_backends.py
+++ b/tests/test_storage_backends.py
@@ -143,6 +143,31 @@ def test_create_storage_builtin_entrypoint_and_fallback(monkeypatch, tmp_path: P
     plain.close()
 
 
+def test_create_storage_normalizes_windows_drive_file_uri_paths(monkeypatch) -> None:
+    import headroom.storage as storage_module
+
+    sqlite_paths: list[str] = []
+    jsonl_paths: list[str] = []
+
+    class FakeSQLiteStorage:
+        def __init__(self, db_path: str) -> None:
+            sqlite_paths.append(db_path)
+
+    class FakeJSONLStorage:
+        def __init__(self, file_path: str) -> None:
+            jsonl_paths.append(file_path)
+
+    monkeypatch.setattr(storage_module.os, "name", "nt")
+    monkeypatch.setattr("headroom.storage.SQLiteStorage", FakeSQLiteStorage)
+    monkeypatch.setattr("headroom.storage.JSONLStorage", FakeJSONLStorage)
+
+    create_storage("sqlite:///C:/Users/test/headroom.db")
+    create_storage("jsonl:///C:/Users/test/headroom%20requests.jsonl")
+
+    assert sqlite_paths == ["C:/Users/test/headroom.db"]
+    assert jsonl_paths == ["C:/Users/test/headroom requests.jsonl"]
+
+
 def test_jsonl_storage_round_trip_query_count_and_summary(tmp_path: Path) -> None:
     storage = JSONLStorage(str(tmp_path / "metrics.jsonl"))
     now = datetime(2026, 4, 23, 12, 0, 0)


### PR DESCRIPTION
## Summary
- Normalize built-in storage file URIs before handing paths to SQLite/JSONL backends.
- Strip the extra leading slash from Windows drive-letter URIs like `sqlite:///C:/Users/...`, which otherwise becomes an invalid `\C:\...`-style path on Windows.
- Add a regression test for Windows drive-letter storage URIs, including URL-decoded JSONL paths.

## Why
While running the adapter hook tests on Windows, `create_storage(fsqlite:///{tmp_path}/test.db)` and the JSONL equivalent failed before the backend could initialize. The factory was preserving the URI slash before the drive letter, so `Path()` received an invalid Windows path.

## Verification
- `python -m pytest tests/test_storage_backends.py tests/test_adapter_hooks.py -q --basetemp=.pytest-tmp`
- `ruff check headroom/storage/__init__.py tests/test_storage_backends.py tests/test_adapter_hooks.py`
- `ruff format --check headroom/storage/__init__.py tests/test_storage_backends.py tests/test_adapter_hooks.py`
- `python -m mypy headroom/storage/__init__.py --ignore-missing-imports`

## Note
I also tried `tests/test_storage/test_sqlite.py` on Windows. It has a separate temp-file handle issue in `TestSQLiteStorageInit.test_creates_db_file`, so I left that out of this PR to keep the scope focused.