### PR TITLE
test(storage): avoid open SQLite temp files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import os
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 import json
-import tempfile
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock
@@ -184,19 +183,19 @@ def mock_openai_client(mock_openai_response):
 
 # Storage fixtures
 @pytest.fixture
-def temp_sqlite_db():
+def temp_sqlite_db(tmp_path: Path):
     """Temporary SQLite database path."""
-    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-        yield f.name
-    Path(f.name).unlink(missing_ok=True)
+    db_path = tmp_path / "test.db"
+    yield str(db_path)
+    db_path.unlink(missing_ok=True)
 
 
 @pytest.fixture
-def temp_jsonl_file():
+def temp_jsonl_file(tmp_path: Path):
     """Temporary JSONL file path."""
-    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
-        yield f.name
-    Path(f.name).unlink(missing_ok=True)
+    file_path = tmp_path / "test.jsonl"
+    yield str(file_path)
+    file_path.unlink(missing_ok=True)
 
 
 # Provider fixtures


### PR DESCRIPTION
## Summary
- Stop using `NamedTemporaryFile` for the shared SQLite/JSONL storage fixtures.
- Return paths under pytest's `tmp_path` instead, so tests can create/delete the files themselves without an open file handle.
- Keep teardown cleanup for tests that leave the file behind.

## Why
On Windows, `NamedTemporaryFile` keeps the file handle open while the fixture yields. `tests/test_storage/test_sqlite.py::TestSQLiteStorageInit::test_creates_db_file` intentionally unlinks the path first to verify that `SQLiteStorage` creates the database file, but Windows rejects that unlink with `PermissionError: [WinError 32]`.

Using `tmp_path` gives the tests a real temporary path without pre-opening the file, which matches what the storage layer actually needs.

## Verification
- `python -m pytest tests/test_storage/test_sqlite.py::TestSQLiteStorageInit::test_creates_db_file -q --basetemp=.pytest-tmp`
- `python -m pytest tests/test_storage/test_sqlite.py -q --basetemp=.pytest-tmp`
- `ruff check tests/conftest.py tests/test_storage/test_sqlite.py`
- `ruff format --check tests/conftest.py tests/test_storage/test_sqlite.py`