### PR TITLE
fix(subscription): type fcntl lock fallback

### DIFF
--- a/headroom/subscription/tracker.py
+++ b/headroom/subscription/tracker.py
@@ -110,6 +110,14 @@ def _validate_rtk_env_at_startup() -> None:
     _rtk_wiring_mode()
 
 
+def _import_fcntl() -> Any | None:
+    try:
+        import fcntl
+    except ImportError:
+        return None
+    return fcntl
+
+
 # Singleton on-demand poll floor (seconds): the dashboard may request a fresh
 # poll if the cached snapshot is stale, but we cap how often we will actually
 # hit Anthropic to avoid 429s / OAuth-token flagging. Bounded across users.
@@ -472,9 +480,8 @@ class SubscriptionTracker(QuotaTracker):
         if self._rtk_poll_owner is not None:
             return self._rtk_poll_owner
 
-        try:
-            import fcntl
-        except ImportError:
+        fcntl = _import_fcntl()
+        if fcntl is None:
             # Platform without fcntl (Windows). Every worker polls; log
             # loudly so the operator knows the multi-worker invariant is
             # weaker on this platform.
@@ -515,9 +522,9 @@ class SubscriptionTracker(QuotaTracker):
         if fd is None:
             return
         try:
-            import fcntl
-
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            fcntl = _import_fcntl()
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_UN)
         except Exception:
             pass
         try:

--- a/tests/test_subscription_tracker_rtk_wired.py
+++ b/tests/test_subscription_tracker_rtk_wired.py
@@ -603,6 +603,9 @@ def test_multi_worker_only_one_polls(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     own ``c.tokens_saved_rtk``, inflating dashboard savings by N× workers.
     """
 
+    if tracker_module._import_fcntl() is None:
+        pytest.skip("POSIX file-lock owner election requires fcntl")
+
     monkeypatch.delenv(tracker_module._RTK_WIRING_ENV, raising=False)
 
     # Both trackers share a state directory so they share the lock file.
@@ -635,3 +638,23 @@ def test_multi_worker_only_one_polls(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     # Cleanup so subsequent tests don't see a stale lock.
     tracker_a._release_rtk_poll_lock()
     tracker_b._release_rtk_poll_lock()
+
+
+def test_poll_lock_falls_back_when_fcntl_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Platforms without fcntl should poll and log the weaker invariant."""
+
+    monkeypatch.setattr(tracker_module, "_import_fcntl", lambda: None)
+    caplog.set_level(logging.WARNING, logger="headroom.subscription.tracker")
+
+    tracker = SubscriptionTracker(persist_path=tmp_path / "state.json", enabled=True)
+
+    assert tracker._try_acquire_rtk_poll_lock() is True
+    assert tracker._rtk_poll_owner is True
+    assert tracker._rtk_poll_lock_fd is None
+    assert any(
+        "event=subscription_rtk_poll_lock_unavailable" in rec.getMessage() for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- Move the optional `fcntl` import behind a small helper so the subscription tracker remains type-checkable on Windows.
- Keep the existing no-`fcntl` runtime behavior: Windows/no-fcntl platforms poll and emit the structured warning.
- Mark the POSIX owner-election test as POSIX-only, and add explicit coverage for the no-fcntl fallback path.

## Why
On Windows, `mypy headroom --ignore-missing-imports` failed on `fcntl.flock` / `LOCK_*` attributes even though the runtime path already catches `ImportError`. Running the full RTK tracker test file also exposed that the multi-worker file-lock test expected POSIX flock semantics on Windows, where the code intentionally falls back to polling.

## Verification
- `python -m pytest tests/test_subscription_tracker_rtk_wired.py -q --basetemp=.pytest-tmp`
- `python -m mypy headroom/subscription/tracker.py --ignore-missing-imports`
- `python -m mypy headroom --ignore-missing-imports`
- `ruff check headroom/subscription/tracker.py tests/test_subscription_tracker_rtk_wired.py`
- `ruff format --check headroom/subscription/tracker.py tests/test_subscription_tracker_rtk_wired.py`