### PR TITLE
test(otel): skip sdk-specific observability tests without extra

### DIFF
--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -6,15 +6,25 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import pytest
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 from headroom.observability import HeadroomOtelMetrics, reset_otel_metrics, set_otel_metrics
 from headroom.proxy.prometheus_metrics import PrometheusMetrics
 from headroom.transforms.pipeline import TransformPipeline
 
 
-def _collect_metrics(reader: InMemoryMetricReader) -> dict[str, Any]:
+def _otel_metrics_sdk() -> tuple[Any, Any]:
+    metrics_sdk = pytest.importorskip(
+        "opentelemetry.sdk.metrics",
+        reason="headroom-ai[otel] extra is not installed",
+    )
+    metrics_export = pytest.importorskip(
+        "opentelemetry.sdk.metrics.export",
+        reason="headroom-ai[otel] extra is not installed",
+    )
+    return metrics_sdk.MeterProvider, metrics_export.InMemoryMetricReader
+
+
+def _collect_metrics(reader: Any) -> dict[str, Any]:
     data = reader.get_metrics_data()
     collected: dict[str, Any] = {}
 
@@ -34,6 +44,7 @@ def _find_point(metric: Any, **expected_attributes: Any) -> Any:
 
 
 def test_headroom_otel_metrics_records_proxy_and_pipeline_metrics() -> None:
+    MeterProvider, InMemoryMetricReader = _otel_metrics_sdk()
     reader = InMemoryMetricReader()
     provider = MeterProvider(metric_readers=[reader])
     otel_metrics = HeadroomOtelMetrics(meter_provider=provider)
@@ -164,6 +175,7 @@ def test_transform_pipeline_simulate_skips_metric_recording() -> None:
 
 
 def test_proxy_failure_and_rate_limit_metrics_include_provider_labels() -> None:
+    MeterProvider, InMemoryMetricReader = _otel_metrics_sdk()
     reader = InMemoryMetricReader()
     provider = MeterProvider(metric_readers=[reader])
     otel_metrics = HeadroomOtelMetrics(meter_provider=provider)

--- a/tests/test_observability_tracing.py
+++ b/tests/test_observability_tracing.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from headroom.observability import (
     HeadroomTracer,
@@ -16,6 +14,31 @@ from headroom.observability import (
     set_headroom_tracer,
 )
 from headroom.transforms.pipeline import TransformPipeline
+
+
+def _otel_trace_sdk() -> tuple[Any, Any, Any, Any]:
+    resources = pytest.importorskip(
+        "opentelemetry.sdk.resources",
+        reason="headroom-ai[otel] extra is not installed",
+    )
+    trace_sdk = pytest.importorskip(
+        "opentelemetry.sdk.trace",
+        reason="headroom-ai[otel] extra is not installed",
+    )
+    trace_export = pytest.importorskip(
+        "opentelemetry.sdk.trace.export",
+        reason="headroom-ai[otel] extra is not installed",
+    )
+    in_memory_export = pytest.importorskip(
+        "opentelemetry.sdk.trace.export.in_memory_span_exporter",
+        reason="headroom-ai[otel] extra is not installed",
+    )
+    return (
+        resources.Resource,
+        trace_sdk.TracerProvider,
+        trace_export.SimpleSpanProcessor,
+        in_memory_export.InMemorySpanExporter,
+    )
 
 
 def test_langfuse_tracing_config_builds_trace_endpoint() -> None:
@@ -34,6 +57,7 @@ def test_langfuse_tracing_config_builds_trace_endpoint() -> None:
 
 
 def test_transform_pipeline_emits_trace_spans() -> None:
+    Resource, TracerProvider, SimpleSpanProcessor, InMemorySpanExporter = _otel_trace_sdk()
     exporter = InMemorySpanExporter()
     provider = TracerProvider(resource=Resource.create({"service.name": "headroom-test"}))
     provider.add_span_processor(SimpleSpanProcessor(exporter))


### PR DESCRIPTION
This fixes a collection-time failure on a normal install without the optional OTEL extra.

Right now `pytest tests` can stop during collection because the observability tests import `opentelemetry.sdk` at module import time. The runtime code already treats the SDK/exporter packages as optional and asks users to install `headroom-ai[otel]` when managed OTEL export is enabled, so the tests should follow the same contract.

Changes:
- move OTEL SDK imports behind `pytest.importorskip`
- skip only the tests that need in-memory SDK providers/exporters
- keep the config/no-op observability tests running without `headroom-ai[otel]`

Verified locally on Windows / Python 3.13 without `opentelemetry-sdk` installed:
- `python -m pytest tests\test_observability_metrics.py tests\test_observability_tracing.py -q --basetemp=.pytest-tmp`
- `python -m ruff check tests\test_observability_metrics.py tests\test_observability_tracing.py`

I also re-ran a wider offline suite with API keys cleared. Collection gets past these files now; the next failures are the existing Windows storage URL normalization cases and bundled-tool environment checks, not observability imports.