### PR TITLE
fix(tools): report pypi binaries from venv scripts

### DIFF
--- a/headroom/binaries.py
+++ b/headroom/binaries.py
@@ -502,13 +502,20 @@ def status() -> list[dict[str, Any]]:
             "path": None,
             "state": "missing",
         }
-        # Honor PATH.
-        on_path = shutil.which(name) or (
-            shutil.which(entry["binary"]) if entry.get("binary") else None
-        )
+        # Honor PATH and this interpreter's Scripts/bin directory for PyPI
+        # console scripts when the venv is not activated.
+        on_path = _path_lookup(name)
         if on_path:
-            row["path"] = on_path
+            row["path"] = str(on_path)
             row["state"] = "on-path"
+            out.append(row)
+            continue
+        if _is_pypi_tool(name):
+            row["state"] = "missing"
+            row["detail"] = (
+                f"{name}: distributed via PyPI only; expected `{entry.get('binary', name)}` "
+                "on PATH or in this interpreter's Scripts/bin directory."
+            )
             out.append(row)
             continue
         try:

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -10,6 +10,7 @@ import io
 import sys
 import tarfile
 import zipfile
+from pathlib import Path
 
 import pytest
 
@@ -352,3 +353,19 @@ def test_status_reports_every_registered_tool(monkeypatch):
     assert {"difft", "scc", "ast-grep"} <= names
     for r in rows:
         assert r["state"] in ("on-path", "cached", "missing", "unsupported-platform")
+
+
+def test_status_uses_interpreter_script_lookup_for_pypi_tools(monkeypatch):
+    _set_platform(monkeypatch, sys_plat="win32", machine="AMD64")
+    fake_path = Path("C:/venv/Scripts/ast-grep.exe")
+    monkeypatch.setattr(binaries.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        binaries,
+        "_path_lookup",
+        lambda name: fake_path if name == "ast-grep" else None,
+    )
+
+    rows = {row["tool"]: row for row in binaries.status()}
+
+    assert rows["ast-grep"]["state"] == "on-path"
+    assert rows["ast-grep"]["path"] == str(fake_path)


### PR DESCRIPTION
This fixes a misleading `headroom tools doctor` status for PyPI-provided tools such as `ast-grep`.

`binaries.which(ast-grep)` already checks both PATH and this interpreter's Scripts/bin directory, which is important when a venv is not activated. `binaries.status()` used a narrower lookup, so it could report `ast-grep` as `unsupported-platform` even though the executable was available in the current venv.

Changes:
- make `status()` use the same `_path_lookup()` helper as `which()`
- report missing PyPI-only tools as `missing`, not `unsupported-platform`
- add a regression test for the non-activated venv case

Verified locally on Windows / Python 3.13:
- `python -m pytest tests\test_binaries.py -q --basetemp=.pytest-tmp`
- `python -m pytest tests\test_cli_tools.py::test_tools_doctor_json_and_table_modes -q --basetemp=.pytest-tmp2`
- `python -m ruff check headroom\binaries.py tests\test_binaries.py`