### PR TITLE
test(tools): run ast-grep fixture through stdin

### DIFF
--- a/tests/test_bundled_tools_savings.py
+++ b/tests/test_bundled_tools_savings.py
@@ -148,6 +148,7 @@ def test_ast_grep_slice_saves_tokens(repo: Path):
 
     # Extract just `process_payment` and `apply_promo` (the two functions an
     # agent would realistically need to reason about a promo-code bug).
+    # Use stdin so ast-grep does not skip pytest temp paths through ignore discovery.
     result = subprocess.run(
         [
             str(binaries.resolve("ast-grep")),
@@ -157,9 +158,11 @@ def test_ast_grep_slice_saves_tokens(repo: Path):
             "--lang",
             "python",
             "--json=stream",
-            str(repo / "payments.py"),
+            "--stdin",
         ],
+        input=full,
         capture_output=True,
+        encoding="utf-8",
         text=True,
         check=True,
     )


### PR DESCRIPTION
This fixes `test_ast_grep_slice_saves_tokens` on local pytest temp paths.

The test writes its sample repo under pytest's temporary directory and then asks ast-grep to scan that file path. With ast-grep 0.42.1 on Windows, that path can be skipped by ast-grep's file discovery/ignore handling, so the command exits successfully but returns no matches.

Passing the fixture source through `--stdin` avoids file discovery entirely and keeps the same AST pattern/output contract. I set the subprocess encoding to UTF-8 because the fixture contains non-ASCII text.

Verified locally on Windows / Python 3.13:
- `python -m pytest tests\test_bundled_tools_savings.py::test_ast_grep_slice_saves_tokens -q -s --basetemp=.pytest-tmp`
- `python -m ruff check tests\test_bundled_tools_savings.py`