### PR TITLE
test(image): skip image classify test without pillow

### DIFF
--- a/tests/test_image_compression.py
+++ b/tests/test_image_compression.py
@@ -247,6 +247,7 @@ class TestOnnxRouter:
         tech, _ = router.classify_query("Count every item in this image carefully")
         assert tech in (Technique.PRESERVE, Technique.FULL_LOW)
 
+    @needs_pillow
     def test_full_classify_with_image(self):
         """Full classification with query + image analysis."""
         from headroom.image.onnx_router import OnnxTechniqueRouter


### PR DESCRIPTION
## Summary
- Mark the ONNX image-classification test with the existing `needs_pillow` skip marker.
- Keep the query-only ONNX router tests running without Pillow.

## Why
`test_full_classify_with_image` creates a PNG fixture with `PIL.Image`, but Pillow is an optional dependency in the base test environment. Without the marker, the test fails with `ModuleNotFoundError: No module named 'PIL'` instead of being skipped like the other image-fixture tests.

## Verification
- `python -m pytest tests/test_image_compression.py::TestOnnxRouter::test_full_classify_with_image -q --basetemp=.pytest-tmp`
- `python -m pytest tests/test_image_compression.py -q --basetemp=.pytest-tmp`
- `python -m ruff check tests/test_image_compression.py`