### PR TITLE
fix(learn): render digest paths with forward slashes

### DIFF
--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -199,7 +199,7 @@ def _build_digest(project: ProjectInfo, sessions: list[SessionData]) -> str:
     lines: list[str] = []
 
     # Project header
-    lines.append(f"Project: {project.name} ({project.project_path})")
+    lines.append(f"Project: {project.name} ({project.project_path.as_posix()})")
     total_calls = sum(len(s.tool_calls) for s in sessions)
     total_failures = sum(s.failure_count for s in sessions)
     total_tokens_in = sum(s.total_input_tokens for s in sessions)


### PR DESCRIPTION
## Summary
- Render the project path in learn digests with `Path.as_posix()`.
- Keep the digest text stable across Windows, macOS, and Linux.

## Why
On Windows, `Path('/tmp/test-project')` renders as `\tmp\test-project`, which made the digest output differ by platform and broke the existing project-info assertion. The learn digest is text passed to an analyzer/LLM, so a stable slash-form path is easier to read and compare.

## Verification
- `python -m pytest tests/test_learn/test_analyzer.py::TestDigestBuilder::test_includes_project_info -q --basetemp=.pytest-tmp`
- `python -m pytest tests/test_learn/test_analyzer.py -q --basetemp=.pytest-tmp`
- `python -m ruff check headroom/learn/analyzer.py tests/test_learn/test_analyzer.py`