### PR TITLE
fix(learn): read Codex session files as UTF-8

### DIFF
--- a/headroom/learn/plugins/codex.py
+++ b/headroom/learn/plugins/codex.py
@@ -120,9 +120,9 @@ class CodexPlugin(LearnPlugin, ConversationScanner):
     def _scan_json_session(self, json_path: Path) -> SessionData | None:
         """Parse a single Codex session file."""
         try:
-            with open(json_path) as f:
+            with open(json_path, encoding="utf-8") as f:
                 data = json.load(f)
-        except (OSError, json.JSONDecodeError) as e:
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
             logger.debug("Failed to read Codex session %s: %s", json_path, e)
             return None
 
@@ -203,7 +203,7 @@ class CodexPlugin(LearnPlugin, ConversationScanner):
         msg_index = 0
 
         try:
-            with open(jsonl_path) as f:
+            with open(jsonl_path, encoding="utf-8") as f:
                 for line in f:
                     try:
                         entry = json.loads(line)
@@ -260,7 +260,7 @@ class CodexPlugin(LearnPlugin, ConversationScanner):
                         )
                     )
 
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             logger.debug("Failed to read Codex session %s: %s", jsonl_path, e)
             return None
 

--- a/tests/test_learn/test_integration.py
+++ b/tests/test_learn/test_integration.py
@@ -14,6 +14,8 @@ Key behaviors tested:
 
 from __future__ import annotations
 
+import builtins
+import json
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -113,6 +115,107 @@ class TestFalsePositiveFiltering:
             "FileNotFoundError: [Errno 2] No such file or directory: '/bad/path'"
         )
         assert is_error_content("bash: unknown_cmd: command not found")
+
+
+class TestCodexScanner:
+    def test_jsonl_sessions_are_read_as_utf8(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from headroom.learn.scanner import CodexScanner
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        session_file = sessions_dir / "session.jsonl"
+        session_file.write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {"type": "session_meta", "payload": {"id": "sess_utf8"}},
+                        ensure_ascii=False,
+                    ),
+                    json.dumps(
+                        {
+                            "type": "response_item",
+                            "payload": {
+                                "type": "function_call",
+                                "call_id": "call_1",
+                                "name": "shell",
+                                "arguments": json.dumps(
+                                    {"command": ["pwsh", "Write-Output 'done ✅'"]},
+                                    ensure_ascii=False,
+                                ),
+                            },
+                        },
+                        ensure_ascii=False,
+                    ),
+                    json.dumps(
+                        {
+                            "type": "response_item",
+                            "payload": {
+                                "type": "function_call_output",
+                                "call_id": "call_1",
+                                "output": "done ✅",
+                            },
+                        },
+                        ensure_ascii=False,
+                    ),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        real_open = builtins.open
+
+        def _cp1251_default_open(
+            file,
+            mode="r",
+            buffering=-1,
+            encoding=None,
+            errors=None,
+            newline=None,
+            closefd=True,
+            opener=None,
+        ):
+            if (
+                isinstance(file, (str, os.PathLike))
+                and Path(file) == session_file
+                and "r" in mode
+                and "b" not in mode
+                and encoding is None
+            ):
+                encoding = "cp1251"
+
+            if "b" in mode:
+                return real_open(
+                    file,
+                    mode,
+                    buffering=buffering,
+                    closefd=closefd,
+                    opener=opener,
+                )
+            return real_open(
+                file,
+                mode,
+                buffering=buffering,
+                encoding=encoding,
+                errors=errors,
+                newline=newline,
+                closefd=closefd,
+                opener=opener,
+            )
+
+        monkeypatch.setattr(builtins, "open", _cp1251_default_open)
+
+        scanner = CodexScanner(codex_dir=tmp_path)
+        project = ProjectInfo(name="codex", project_path=tmp_path, data_path=sessions_dir)
+
+        sessions = scanner.scan_project(project)
+
+        assert len(sessions) == 1
+        tool_call = sessions[0].tool_calls[0]
+        assert tool_call.name == "Bash"
+        assert tool_call.output == "done ✅"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Read Codex `.json` and `.jsonl` session files with explicit UTF-8 encoding.
- Treat `UnicodeDecodeError` like other unreadable/corrupt session-file failures and skip that file instead of aborting the scan.
- Add a regression test that emulates a Windows code-page default for one JSONL file, so the UTF-8 requirement is covered even on UTF-8 CI machines.

## Why
Codex session logs are JSON/JSONL and may contain unicode output. On Windows, `open(path)` uses the active code page by default, which can raise `UnicodeDecodeError` while scanning otherwise valid UTF-8 session files.

## Verification
- `python -m pytest tests/test_learn/test_integration.py::TestCodexScanner::test_jsonl_sessions_are_read_as_utf8 -q --basetemp=.pytest-tmp`
- `python -m pytest tests/test_learn/test_integration.py::TestCodexIntegration::test_full_pipeline -q --basetemp=.pytest-tmp`
- `python -m pytest tests/test_learn/test_integration.py -q --basetemp=.pytest-tmp` with API keys cleared
- `python -m ruff check headroom/learn/plugins/codex.py tests/test_learn/test_integration.py`