### PR TITLE
test(learn): skip POSIX home decode case on Windows

### DIFF
--- a/tests/test_learn/test_scanner.py
+++ b/tests/test_learn/test_scanner.py
@@ -366,7 +366,7 @@ class TestDecodeProjectPath:
         import shutil
 
         home = Path.home()
-        if len(home.parts) < 3 or home.parts[1] not in ("Users", "home"):
+        if home.drive or len(home.parts) < 3 or home.parts[1] not in ("Users", "home"):
             pytest.skip("decoder branch only activates under /Users or /home")
 
         base = home / f"pytest_headroom_{uuid4().hex}"


### PR DESCRIPTION
## Summary
- Skip the POSIX home-directory decode regression on Windows hosts.

## Why
`test_home_dir_username_stays_single_component` is explicitly about the `/Users/...` and `/home/...` decoder branch. On Windows, `Path.home()` is typically `C:\Users\...`; the old guard still let the test run because the second path component is `Users`, then it built an encoded name that does not match the POSIX branch the test is meant to exercise.

## Verification
- `python -m pytest tests/test_learn/test_scanner.py::TestDecodeProjectPath::test_home_dir_username_stays_single_component -q --basetemp=.pytest-tmp`
- `python -m pytest tests/test_learn/test_scanner.py -q --basetemp=.pytest-tmp`
- `python -m ruff check tests/test_learn/test_scanner.py`