### PR TITLE
test(memory): skip bridge backend tests without local embedder extra

### DIFF
--- a/tests/test_memory_bridge.py
+++ b/tests/test_memory_bridge.py
@@ -256,6 +256,11 @@ def bridge_config(tmp_dir):
 @pytest.fixture
 async def backend(tmp_dir):
     """Create a LocalBackend with temp database."""
+    pytest.importorskip(
+        "sentence_transformers",
+        reason="Memory bridge backend tests require sentence-transformers",
+    )
+
     from headroom.memory.backends.local import LocalBackend, LocalBackendConfig
 
     config = LocalBackendConfig(db_path=str(tmp_dir / "test_memory.db"))


### PR DESCRIPTION
## Summary
- Skip memory bridge backend tests when `sentence-transformers` is not installed.
- Keep the pure markdown parser tests running in the base environment.

## Why
The bridge backend tests use `LocalBackend`, which saves memories through `LocalEmbedder`. Without the local embedding extra, imports fail inside the bridge path and the tests report failed imports/exports instead of a clear optional-dependency skip.

## Verification
- `python -m pytest tests/test_memory_bridge.py::TestMemoryBridgeImport::test_import_claude_code_memory -q --basetemp=.pytest-tmp`
- `python -m pytest tests/test_memory_bridge.py -q --basetemp=.pytest-tmp-bridge`
- `python -m ruff check tests/test_memory_bridge.py`