### PR TITLE
test(dashboard): compare asset text with normalized newlines

### DIFF
--- a/tests/test_owned_asset_encoding.py
+++ b/tests/test_owned_asset_encoding.py
@@ -42,8 +42,9 @@ def test_get_dashboard_html_reads_as_utf8(monkeypatch) -> None:
 
     assert captured["encoding"] == "utf-8"
     assert html  # non-empty
-    # Content must equal an explicit UTF-8 decode of the raw template.
-    expected = (TEMPLATES_DIR / "dashboard.html").read_bytes().decode("utf-8")
+    # Content must equal an explicit UTF-8 text read of the template. Use the
+    # original Path.read_text so the spy above only observes get_dashboard_html.
+    expected = original(TEMPLATES_DIR / "dashboard.html", encoding="utf-8")
     assert html == expected
 
 


### PR DESCRIPTION
## Summary
- Keep the dashboard UTF-8 regression test intact, but compare against the same text-reading behavior used by the production helper.
- This avoids a Windows-only false negative where `Path.read_text()` normalizes CRLF to LF, while `read_bytes().decode(utf-8)` keeps CRLF bytes as-is.

## Checks
- `python -m pytest tests/test_owned_asset_encoding.py -q --basetemp=.pytest-tmp-asset`
- `python -m ruff check tests/test_owned_asset_encoding.py`