### PR TITLE
fix(observability): keep enabled config in stats without otel extra

### DIFF
--- a/headroom/observability/metrics.py
+++ b/headroom/observability/metrics.py
@@ -504,6 +504,19 @@ def configure_otel_metrics(config: OTelMetricsConfig | None = None) -> HeadroomO
             "OpenTelemetry SDK/exporter packages are not installed. "
             "Install headroom-ai[otel] to enable managed OTEL metric export."
         )
+        previous_provider = None
+        with _metrics_lock:
+            previous_provider = _owned_meter_provider
+            _owned_meter_provider = None
+            _owned_metrics_config = resolved
+            _global_metrics = None
+
+        if previous_provider is not None:
+            try:
+                previous_provider.shutdown()
+            except Exception:
+                logger.debug("Failed to shut down previous OTEL metrics provider", exc_info=True)
+
         return get_otel_metrics()
 
     exporter: Any

--- a/headroom/observability/tracing.py
+++ b/headroom/observability/tracing.py
@@ -167,9 +167,7 @@ def configure_langfuse_tracing(
             try:
                 previous_provider.shutdown()
             except Exception:
-                logger.debug(
-                    "Failed to shut down previous Langfuse tracer provider", exc_info=True
-                )
+                logger.debug("Failed to shut down previous Langfuse tracer provider", exc_info=True)
 
         return get_headroom_tracer()
 

--- a/headroom/observability/tracing.py
+++ b/headroom/observability/tracing.py
@@ -156,6 +156,21 @@ def configure_langfuse_tracing(
             "OpenTelemetry SDK/exporter packages are not installed. "
             "Install headroom-ai[otel] to enable Langfuse OTLP tracing."
         )
+        previous_provider = None
+        with _tracing_lock:
+            previous_provider = _owned_tracer_provider
+            _owned_tracer_provider = None
+            _owned_langfuse_config = resolved
+            _global_tracer = None
+
+        if previous_provider is not None:
+            try:
+                previous_provider.shutdown()
+            except Exception:
+                logger.debug(
+                    "Failed to shut down previous Langfuse tracer provider", exc_info=True
+                )
+
         return get_headroom_tracer()
 
     resource = Resource.create(

--- a/tests/test_observability_optional_deps.py
+++ b/tests/test_observability_optional_deps.py
@@ -1,0 +1,86 @@
+"""Regression tests for observability status without optional OTEL extras."""
+
+from __future__ import annotations
+
+import builtins
+from typing import Any
+
+import pytest
+
+from headroom.observability import (
+    LangfuseTracingConfig,
+    OTelMetricsConfig,
+    configure_langfuse_tracing,
+    configure_otel_metrics,
+    get_langfuse_tracing_status,
+    get_otel_metrics_status,
+    reset_headroom_tracing,
+    reset_otel_metrics,
+)
+
+
+def _block_otel_sdk_imports(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import = builtins.__import__
+
+    def blocked_import(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name.startswith(("opentelemetry.exporter", "opentelemetry.sdk")):
+            raise ImportError(f"blocked optional OTEL dependency: {name}")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+
+def test_otel_metrics_status_keeps_enabled_config_without_exporter_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_otel_metrics()
+    _block_otel_sdk_imports(monkeypatch)
+
+    try:
+        configure_otel_metrics(
+            OTelMetricsConfig(
+                enabled=True,
+                service_name="headroom-proxy",
+                exporter="console",
+            )
+        )
+
+        status = get_otel_metrics_status()
+        assert status["configured"] is True
+        assert status["enabled"] is True
+        assert status["service_name"] == "headroom-proxy"
+        assert status["exporter"] == "console"
+    finally:
+        reset_otel_metrics()
+
+
+def test_langfuse_status_keeps_enabled_config_without_exporter_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_headroom_tracing()
+    _block_otel_sdk_imports(monkeypatch)
+
+    try:
+        configure_langfuse_tracing(
+            LangfuseTracingConfig(
+                enabled=True,
+                public_key="pk-lf-test",
+                secret_key="sk-lf-test",
+                base_url="https://cloud.langfuse.com",
+                service_name="headroom-proxy",
+            )
+        )
+
+        status = get_langfuse_tracing_status()
+        assert status["configured"] is True
+        assert status["enabled"] is True
+        assert status["service_name"] == "headroom-proxy"
+        assert status["endpoint"] == "https://cloud.langfuse.com/api/public/otel/v1/traces"
+    finally:
+        reset_headroom_tracing()


### PR DESCRIPTION
## Summary
- Preserve the enabled OTEL metrics config in `/stats` even when the optional `headroom-ai[otel]` exporter packages are not installed.
- Do the same for Langfuse tracing when the Langfuse env config is complete but the OTLP exporter extra is missing.
- Add regression tests that force the optional OTEL SDK/exporter imports to fail, so this behavior is covered even on CI jobs that happen to install the extra.

## Checks
- `python -m pytest tests/test_proxy_cache_ttl_metrics.py::test_stats_endpoint_reports_otel_configuration tests/test_proxy_cache_ttl_metrics.py::test_stats_endpoint_reports_langfuse_configuration -q --basetemp=.pytest-tmp-stats-config`
- `python -m pytest tests/test_observability_optional_deps.py -q --basetemp=.pytest-tmp-observability-optional`
- `python -m ruff check headroom/observability/metrics.py headroom/observability/tracing.py tests/test_observability_optional_deps.py`