### PR TITLE
fix(memory): close sqlite graph connections after use

### DIFF
--- a/headroom/memory/adapters/sqlite_graph.py
+++ b/headroom/memory/adapters/sqlite_graph.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections import deque
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from threading import RLock
@@ -71,11 +73,13 @@ class SQLiteGraphStore:
         self._lock = RLock()
         self._init_db()
 
-    def _get_conn(self) -> sqlite3.Connection:
-        """Get a new database connection (thread-safe pattern).
+    @contextmanager
+    def _get_conn(self) -> Iterator[sqlite3.Connection]:
+        """Open a short-lived database connection.
 
         Returns:
-            A new SQLite connection with row factory configured.
+            A SQLite connection with row factory configured. The connection is
+            closed when the context exits.
         """
         conn = sqlite3.connect(str(self.db_path))
         conn.row_factory = sqlite3.Row
@@ -87,7 +91,11 @@ class SQLiteGraphStore:
         # Enable foreign keys
         conn.execute("PRAGMA foreign_keys = ON")
 
-        return conn
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
 
     def _init_db(self) -> None:
         """Initialize the database schema with indexes."""

--- a/tests/test_sqlite_graph_store.py
+++ b/tests/test_sqlite_graph_store.py
@@ -14,16 +14,46 @@ Tests verify:
 from __future__ import annotations
 
 import os
+import sqlite3
 import tempfile
 
 import pytest
 
+import headroom.memory.adapters.sqlite_graph as sqlite_graph_adapter
 from headroom.memory.adapters.graph_models import (
     Entity,
     Relationship,
     RelationshipDirection,
 )
 from headroom.memory.adapters.sqlite_graph import SQLiteGraphStore
+
+
+def test_connection_context_closes_sqlite_connection(tmp_path, monkeypatch):
+    """The per-operation connection context must release the database file."""
+    closed_connections = []
+    real_connect = sqlite3.connect
+
+    class TrackingConnection(sqlite3.Connection):
+        def close(self):
+            closed_connections.append(self)
+            super().close()
+
+    def tracking_connect(*args, **kwargs):
+        kwargs["factory"] = TrackingConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite_graph_adapter.sqlite3, "connect", tracking_connect)
+
+    store = SQLiteGraphStore(db_path=tmp_path / "graph.db")
+    assert closed_connections
+    closed_connections.clear()
+
+    with store._get_conn() as conn:
+        conn.execute("SELECT 1").fetchone()
+
+    assert closed_connections == [conn]
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")
 
 
 class TestSQLiteGraphStoreEntityOperations:


### PR DESCRIPTION
## Summary
- Make `SQLiteGraphStore._get_conn()` a real short-lived connection context manager that closes the SQLite connection after each operation.
- Keep the existing sqlite transaction behavior by still entering the connection context before yielding it.
- Add a regression test that verifies the connection is closed after the context exits.

This fixes Windows teardown failures where temporary graph DB files could not be deleted because the SQLite connection still held the file open.

## Checks
- `python -m pytest tests/test_sqlite_graph_store.py::test_connection_context_closes_sqlite_connection -q --basetemp=.pytest-tmp-sqlite-graph-unit`
- `python -m pytest tests/test_sqlite_graph_store.py -q --basetemp=.pytest-tmp-sqlite-graph`
- `python -m ruff check headroom/memory/adapters/sqlite_graph.py tests/test_sqlite_graph_store.py`