### PR TITLE
fix(memory): close sqlite store connections after use

### DIFF
--- a/headroom/memory/adapters/fts5.py
+++ b/headroom/memory/adapters/fts5.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import re
 import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -67,15 +69,21 @@ class FTS5TextIndex:
         self.db_path = Path(db_path)
         self._init_db()
 
-    def _get_conn(self) -> sqlite3.Connection:
-        """Get a new database connection (thread-safe pattern).
+    @contextmanager
+    def _get_conn(self) -> Iterator[sqlite3.Connection]:
+        """Open a short-lived database connection.
 
         Returns:
-            A new SQLite connection with row factory configured.
+            A SQLite connection with row factory configured. The connection is
+            closed when the context exits.
         """
         conn = sqlite3.connect(str(self.db_path))
         conn.row_factory = sqlite3.Row
-        return conn
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
 
     def _init_db(self) -> None:
         """Initialize the FTS5 virtual table schema."""

--- a/headroom/memory/adapters/sqlite.py
+++ b/headroom/memory/adapters/sqlite.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -73,15 +75,21 @@ class SQLiteMemoryStore:
         self.db_path = Path(db_path)
         self._init_db()
 
-    def _get_conn(self) -> sqlite3.Connection:
-        """Get a new database connection (thread-safe pattern).
+    @contextmanager
+    def _get_conn(self) -> Iterator[sqlite3.Connection]:
+        """Open a short-lived database connection.
 
         Returns:
-            A new SQLite connection with row factory configured.
+            A SQLite connection with row factory configured. The connection is
+            closed when the context exits.
         """
         conn = sqlite3.connect(str(self.db_path))
         conn.row_factory = sqlite3.Row
-        return conn
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
 
     def _init_db(self) -> None:
         """Initialize the database schema with indexes."""

--- a/tests/test_memory/test_hierarchical.py
+++ b/tests/test_memory/test_hierarchical.py
@@ -21,6 +21,7 @@ import os
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 import asyncio
+import sqlite3
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -28,6 +29,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+import headroom.memory.adapters.fts5 as fts5_adapter
+import headroom.memory.adapters.sqlite as sqlite_adapter
 from headroom.memory.adapters.cache import LRUMemoryCache
 from headroom.memory.adapters.fts5 import FTS5TextIndex
 from headroom.memory.adapters.sqlite import SQLiteMemoryStore
@@ -68,6 +71,23 @@ def sample_embedding():
 # =============================================================================
 # Memory Model Tests
 # =============================================================================
+
+
+def _track_sqlite_connection_closes(module, monkeypatch):
+    closed_connections = []
+    real_connect = sqlite3.connect
+
+    class TrackingConnection(sqlite3.Connection):
+        def close(self):
+            closed_connections.append(self)
+            super().close()
+
+    def tracking_connect(*args, **kwargs):
+        kwargs["factory"] = TrackingConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(module.sqlite3, "connect", tracking_connect)
+    return closed_connections
 
 
 class TestMemoryModel:
@@ -158,6 +178,21 @@ class TestSQLiteMemoryStore:
     def store(self, temp_db_path):
         """Create a SQLite store for testing."""
         return SQLiteMemoryStore(temp_db_path)
+
+    def test_connection_context_closes_sqlite_connection(self, tmp_path, monkeypatch):
+        """The per-operation connection context must release the database file."""
+        closed_connections = _track_sqlite_connection_closes(sqlite_adapter, monkeypatch)
+
+        store = SQLiteMemoryStore(tmp_path / "memory.db")
+        assert closed_connections
+        closed_connections.clear()
+
+        with store._get_conn() as conn:
+            conn.execute("SELECT 1").fetchone()
+
+        assert closed_connections == [conn]
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
 
     @pytest.mark.asyncio
     async def test_save_and_get(self, store, sample_memory):
@@ -421,6 +456,21 @@ class TestFTS5TextIndex:
     def text_index(self, temp_db_path):
         """Create a FTS5 text index for testing."""
         return FTS5TextIndex(temp_db_path)
+
+    def test_connection_context_closes_sqlite_connection(self, tmp_path, monkeypatch):
+        """The per-operation connection context must release the database file."""
+        closed_connections = _track_sqlite_connection_closes(fts5_adapter, monkeypatch)
+
+        text_index = FTS5TextIndex(tmp_path / "memory.db")
+        assert closed_connections
+        closed_connections.clear()
+
+        with text_index._get_conn() as conn:
+            conn.execute("SELECT 1").fetchone()
+
+        assert closed_connections == [conn]
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
 
     def test_index_and_search(self, text_index):
         """Test indexing and searching text."""


### PR DESCRIPTION
## Summary
- Close short-lived SQLite connections in `SQLiteMemoryStore` and `FTS5TextIndex` after each operation.
- Preserve the existing sqlite transaction behavior by entering the connection context before yielding it.
- Add regression tests that verify both adapters really close their connection context.

This fixes Windows temp DB cleanup failures where the memory DB stayed locked after proxy memory stats tests.

## Checks
- `python -m pytest tests/test_memory/test_hierarchical.py::TestSQLiteMemoryStore::test_connection_context_closes_sqlite_connection tests/test_memory/test_hierarchical.py::TestFTS5TextIndex::test_connection_context_closes_sqlite_connection -q --basetemp=.pytest-tmp-memory-sqlite-context`
- `python -m pytest tests/test_proxy_memory_integration.py::TestMemoryStats::test_health_endpoint_works_with_memory tests/test_proxy_memory_integration.py::TestMemoryStats::test_stats_endpoint_works_with_memory -q --basetemp=.pytest-tmp-proxy-memory-stats`
- `python -m pytest tests/test_security_validations.py::TestSQLiteMetadataFilteringIntegration::test_malicious_metadata_filter_is_skipped -q --basetemp=.pytest-tmp-security-sqlite`
- `python -m pytest tests/test_memory/test_hierarchical.py::TestSQLiteMemoryStore tests/test_memory/test_hierarchical.py::TestFTS5TextIndex -q --basetemp=.pytest-tmp-memory-sqlite-classes`
- `python -m ruff check headroom/memory/adapters/sqlite.py headroom/memory/adapters/fts5.py tests/test_memory/test_hierarchical.py`