### PR TITLE
test(storage): close sqlite temp file before use

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,8 +187,9 @@ def mock_openai_client(mock_openai_response):
 def temp_sqlite_db():
     """Temporary SQLite database path."""
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-        yield f.name
-    Path(f.name).unlink(missing_ok=True)
+        db_path = f.name
+    yield db_path
+    Path(db_path).unlink(missing_ok=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Close the temporary SQLite file before yielding its path from the shared test fixture.
- This lets tests delete or recreate the database path on Windows, where an open `NamedTemporaryFile` cannot be unlinked.

## Tests
- `python -m pytest tests\test_storage\test_sqlite.py -q --basetemp=.pytest-tmp-storage-sqlite`
- `python -m pytest tests\test_storage -q --basetemp=.pytest-tmp-storage-suite`
- `python -m ruff check tests\conftest.py tests\test_storage\test_sqlite.py`
- `python -m ruff format --check tests\conftest.py tests\test_storage\test_sqlite.py`