### PR TITLE
test(toin): compare default path portably

### DIFF
--- a/tests/test_toin_full_integration.py
+++ b/tests/test_toin_full_integration.py
@@ -82,9 +82,9 @@ class TestTOINDefaultStoragePath:
         assert config.storage_path, "TOINConfig should have a default storage_path"
 
         # Verify it points to expected location
-        expected_suffix = ".headroom/toin.json"
-        assert config.storage_path.endswith(expected_suffix), (
-            f"Default path should end with {expected_suffix}, got: {config.storage_path}"
+        expected_suffix = (".headroom", "toin.json")
+        assert Path(config.storage_path).parts[-2:] == expected_suffix, (
+            f"Default path should end with {Path(*expected_suffix)}, got: {config.storage_path}"
         )
 
         # Verify the get_default_toin_storage_path function works
@@ -149,7 +149,7 @@ class TestTOINDefaultStoragePath:
             print(f"get_default_toin_storage_path(): {default_path}")
 
             # Should fall back to default ~/.headroom/toin.json
-            assert ".headroom/toin.json" in default_path, (
+            assert Path(default_path).parts[-2:] == (".headroom", "toin.json"), (
                 f"Empty env var should use default, got: {default_path}"
             )
 


### PR DESCRIPTION
## Summary
- Compare the default TOIN storage path with `Path(...).parts` instead of a hard-coded POSIX string suffix.
- Keeps the same expected location while allowing Windows native separators.

## Tests
- `python -m pytest tests\test_toin_full_integration.py::TestTOINDefaultStoragePath -q --basetemp=.pytest-tmp-toin-default-path`
- `python -m pytest tests\test_toin_full_integration.py -q --basetemp=.pytest-tmp-toin-full`
- `python -m ruff check tests\test_toin_full_integration.py`
- `python -m ruff format --check tests\test_toin_full_integration.py`