### PR TITLE
fix(proxy): fill Anthropic stream input usage fallback

### DIFF
--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -72,6 +72,33 @@ class StreamingMixin:
             int(cache_creation.get("ephemeral_1h_input_tokens", 0) or 0),
         )
 
+    @staticmethod
+    def _fill_missing_anthropic_message_start_input_tokens(
+        event_data: dict[str, Any], input_tokens: int
+    ) -> bool:
+        """Fill zero message_start input usage with the proxy-side token count."""
+        if input_tokens <= 0 or event_data.get("type") != "message_start":
+            return False
+
+        message = event_data.get("message")
+        if not isinstance(message, dict):
+            return False
+
+        usage = message.get("usage")
+        if not isinstance(usage, dict):
+            usage = {}
+            message["usage"] = usage
+
+        try:
+            current_input_tokens = int(usage.get("input_tokens", 0) or 0)
+        except (TypeError, ValueError):
+            current_input_tokens = 0
+        if current_input_tokens > 0:
+            return False
+
+        usage["input_tokens"] = input_tokens
+        return True
+
     def _parse_sse_usage(self, chunk: bytes, provider: str) -> dict[str, int] | None:
         """Parse usage information from SSE chunk.
 
@@ -1357,9 +1384,17 @@ class StreamingMixin:
                     if stream_state["ttfb_ms"] is None:
                         stream_state["ttfb_ms"] = (time.time() - start_time) * 1000
 
+                    raw_sse = event.raw_sse
+                    if event.event_type == "message_start":
+                        filled_usage = self._fill_missing_anthropic_message_start_input_tokens(
+                            event.data, optimized_tokens
+                        )
+                        if filled_usage:
+                            raw_sse = None
+
                     # Format as SSE
-                    if event.raw_sse:
-                        yield event.raw_sse.encode()
+                    if raw_sse:
+                        yield raw_sse.encode()
                     else:
                         sse_line = f"event: {event.event_type}\ndata: {json.dumps(event.data)}\n\n"
                         yield sse_line.encode()

--- a/tests/test_backend_streaming_cache_metrics.py
+++ b/tests/test_backend_streaming_cache_metrics.py
@@ -241,6 +241,16 @@ def _sse_data(event_type: str, data: dict[str, Any]) -> str:
     return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
 
 
+def _sse_event_data(body: str, event_type: str) -> dict[str, Any]:
+    for block in body.split("\n\n"):
+        lines = block.splitlines()
+        if not lines or lines[0] != f"event: {event_type}":
+            continue
+        data_line = next(line for line in lines if line.startswith("data: "))
+        return json.loads(data_line.removeprefix("data: "))
+    raise AssertionError(f"missing SSE event {event_type!r} in response:\n{body[:500]}")
+
+
 def test_bedrock_streaming_emits_perf_with_message_start_cache_usage() -> None:
     """Bedrock streaming must surface cache_read + cache_write from message_start.
 
@@ -336,6 +346,77 @@ def test_bedrock_streaming_emits_perf_with_message_start_cache_usage() -> None:
     assert cw == 200, f"expected cache_write=200, got {cw}"
     # round(500 / (500 + 200) * 100) = round(71.43) = 71
     assert chp == 71, f"expected cache_hit_pct=71, got {chp}"
+
+
+def test_bedrock_streaming_fills_zero_message_start_input_usage() -> None:
+    """Claude Code context tracking consumes input usage from message_start.
+
+    Backend-routed Anthropic providers can stream ``input_tokens: 0`` in the
+    initial event even though Headroom already counted the proxied request. In
+    that case the client sees a zero-sized context window while ``/stats`` is
+    non-zero, so the SSE event needs the proxy-side input-token fallback.
+    """
+    config = ProxyConfig(
+        optimize=False,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        backend="anyllm",
+        anyllm_provider="anthropic",
+    )
+
+    message_start = {
+        "type": "message_start",
+        "message": {
+            "id": "msg_1",
+            "model": "claude-3-5-sonnet-20241022",
+            "role": "assistant",
+            "type": "message",
+            "content": [],
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        },
+    }
+    message_delta = {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn"},
+        "usage": {"output_tokens": 59},
+    }
+    message_stop = {"type": "message_stop"}
+
+    events = [
+        StreamEvent(
+            event_type=e["type"],
+            data=e,
+            raw_sse=_sse_data(e["type"], e),
+        )
+        for e in [message_start, message_delta, message_stop]
+    ]
+    backend = _make_bedrock_backend(events)
+
+    with patch("headroom.proxy.server.AnyLLMBackend", return_value=backend):
+        app = create_app(config)
+        with TestClient(app) as client:
+            resp = client.post(
+                "/v1/messages",
+                json={
+                    "model": "claude-3-5-sonnet-20241022",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Please answer this short question.",
+                        }
+                    ],
+                    "max_tokens": 64,
+                    "stream": True,
+                },
+                headers={
+                    "x-api-key": "sk-ant-test",
+                    "anthropic-version": "2023-06-01",
+                },
+            )
+
+    assert resp.status_code == 200, resp.text[:200]
+    streamed_start = _sse_event_data(resp.text, "message_start")
+    assert streamed_start["message"]["usage"]["input_tokens"] > 0
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #679.

## What changed

Backend-routed Anthropic streams can start with `message_start.message.usage.input_tokens` set to `0`. Claude Code appears to build its statusline context usage from that event, so `ccusage` shows a zero context window even though Headroom has already counted the request and `/stats` is non-zero.

This fills only the missing/zero `input_tokens` value on `message_start` with Headroom's already-counted optimized input token total before the SSE event is sent to the client. If the upstream backend reports a non-zero input token count, the proxy leaves it alone. Cache read/write fields are preserved as-is; this does not invent cache metrics.

The regression uses `raw_sse` on purpose, because that was the path forwarding the zero-valued event unchanged.

## Verification

- `python -m pytest tests\test_backend_streaming_cache_metrics.py::test_bedrock_streaming_fills_zero_message_start_input_usage -q --basetemp=.pytest-tmp-ccusage-green`
- `python -m pytest tests\test_backend_streaming_cache_metrics.py::test_bedrock_streaming_emits_perf_with_message_start_cache_usage -q --basetemp=.pytest-tmp-bedrock-cache-neighbor`
- `python -m pytest tests\test_backend_streaming_cache_metrics.py -q --basetemp=.pytest-tmp-backend-streaming-cache`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy headroom\proxy\handlers\streaming.py --ignore-missing-imports`