### PR TITLE
docs(mcp): document supported integration APIs

### DIFF
--- a/headroom/integrations/mcp/server.py
+++ b/headroom/integrations/mcp/server.py
@@ -1,25 +1,21 @@
-"""Headroom MCP Integration: Compress tool outputs from MCP servers.
+"""Headroom MCP integration: compress tool outputs from MCP clients.
 
-This module provides multiple ways to integrate Headroom with MCP:
+This module provides three supported ways to use Headroom with MCP data:
 
-1. HeadroomMCPProxy - A proxy server that wraps upstream MCP servers
+1. HeadroomMCPCompressor - Core compression logic for MCP tool results
 2. compress_tool_result() - Standalone function for host applications
-3. HeadroomMCPMiddleware - Transport-level middleware
+3. HeadroomMCPClientWrapper - Client wrapper that compresses call_tool output
 
 The key insight: MCP tool outputs are the PERFECT use case for Headroom.
 They're often large (100s-1000s of items), structured (JSON), and contain
 mostly low-relevance data with a few critical items (errors, matches).
 
-Example - Proxy Server:
+For the ready-made Headroom MCP server, use the CLI:
     ```python
-    # Configure proxy to wrap your MCP servers
-    proxy = HeadroomMCPProxy(
-        upstream_servers=["slack", "database", "github"],
-        config=HeadroomConfig(),
-    )
-
-    # Run as MCP server - clients connect to this instead
-    proxy.run()
+    # Register the stdio MCP server with a supported client
+    # or run it directly for a custom MCP host.
+    #   headroom mcp install
+    #   headroom mcp serve
     ```
 
 Example - Standalone Function:
@@ -36,11 +32,13 @@ Example - Standalone Function:
     )
     ```
 
-Example - Middleware (for MCP client libraries):
+Example - Client Wrapper:
     ```python
-    # Wrap your MCP client's transport
-    middleware = HeadroomMCPMiddleware(config)
-    client = MCPClient(transport=middleware.wrap(base_transport))
+    from headroom.integrations.mcp import HeadroomMCPClientWrapper
+
+    base_client = MCPClient(transport)
+    client = HeadroomMCPClientWrapper(base_client)
+    result = await client.call_tool("search_logs", {"service": "api"})
     ```
 """
 
@@ -511,21 +509,22 @@ def create_headroom_mcp_proxy(
     upstream_servers: list[tuple[str, MCPServer]],
     config: HeadroomConfig | None = None,
 ) -> dict[str, Any]:
-    """Create configuration for a Headroom MCP proxy server.
+    """Create config pieces for custom MCP proxy implementations.
 
-    This returns a configuration dict that can be used to set up
-    a proxy server that wraps upstream MCP servers.
+    This helper does not start or return a runnable MCP server. It bundles
+    upstream server references with a Headroom compressor so an application can
+    build its own MCP proxy layer around them.
 
     Args:
         upstream_servers: List of (name, server) tuples.
         config: Headroom configuration.
 
     Returns:
-        Configuration dict for proxy server.
+        Configuration dict for custom proxy wiring.
 
     Example:
         ```python
-        # In your MCP server setup
+        # In your own MCP server setup
         proxy_config = create_headroom_mcp_proxy(
             upstream_servers=[
                 ("slack", slack_server),
@@ -533,7 +532,7 @@ def create_headroom_mcp_proxy(
             ]
         )
 
-        # Use proxy_config to initialize your proxy server
+        # Use proxy_config["compressor"] while forwarding upstream tool calls.
         ```
     """
     return {

--- a/tests/test_integrations/mcp/test_server.py
+++ b/tests/test_integrations/mcp/test_server.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
+import headroom.integrations.mcp.server as mcp_server_module
 from headroom.integrations.mcp import (
     HeadroomMCPClientWrapper,
     HeadroomMCPCompressor,
@@ -24,6 +25,18 @@ from headroom.transforms.smart_crusher import strip_ccr_sentinels
 # ============================================================================
 # Test Fixtures
 # ============================================================================
+
+
+def test_mcp_module_docstring_advertises_existing_public_apis():
+    """The module docs should not point users to missing proxy/middleware classes."""
+    doc = mcp_server_module.__doc__ or ""
+
+    assert "HeadroomMCPCompressor" in doc
+    assert "HeadroomMCPClientWrapper" in doc
+    assert "compress_tool_result()" in doc
+    assert "headroom mcp serve" in doc
+    assert "HeadroomMCPProxy(" not in doc
+    assert "HeadroomMCPMiddleware" not in doc
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #588.

## What changed

The MCP integration module docstring advertised two runnable integration surfaces that do not exist in the codebase: a proxy class and transport middleware. That sent users looking for an API they could not import or run.

This updates the module docs to describe the supported public APIs instead:

- `HeadroomMCPCompressor`
- `compress_tool_result()`
- `HeadroomMCPClientWrapper`
- the ready-made CLI path: `headroom mcp install` / `headroom mcp serve`

I also tightened the `create_headroom_mcp_proxy()` docstring so it is described as a config helper for custom wiring, not as a runnable MCP server.

## Regression coverage

Added a small guard test so the module docstring keeps advertising existing public APIs and does not reintroduce the missing proxy/middleware examples.

## Verification

- `python -m pytest tests\test_integrations\mcp\test_server.py::test_mcp_module_docstring_advertises_existing_public_apis -q --basetemp=.pytest-tmp-mcp-docs`
- `python -m pytest tests\test_integrations\mcp\test_server.py -q --basetemp=.pytest-tmp-mcp-server-file`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy headroom\integrations\mcp\server.py --ignore-missing-imports`