### PR TITLE
fix(memory): cap local embedder thread pools

### DIFF
--- a/headroom/memory/adapters/embedders.py
+++ b/headroom/memory/adapters/embedders.py
@@ -17,13 +17,45 @@ import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
-import numpy as np
-
-from headroom.models.config import ML_MODEL_DEFAULTS
-from headroom.onnx_runtime import create_cpu_session_options, hf_hub_download_local_first
-
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
+
+
+_THREAD_CAP_DISABLE_VALUES = {"0", "auto", "false", "none", "off"}
+_BLAS_THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "BLIS_NUM_THREADS",
+)
+
+
+def _memory_embed_thread_cap() -> int | None:
+    raw = os.environ.get("HEADROOM_MEMORY_EMBED_THREADS", "1").strip().lower()
+    if raw in _THREAD_CAP_DISABLE_VALUES:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return 1
+    return value if value > 0 else None
+
+
+_MEMORY_EMBED_THREAD_CAP = _memory_embed_thread_cap()
+if _MEMORY_EMBED_THREAD_CAP is not None:
+    for _thread_env_var in _BLAS_THREAD_ENV_VARS:
+        os.environ.setdefault(_thread_env_var, str(_MEMORY_EMBED_THREAD_CAP))
+
+# Thread env vars must be set before numpy/torch-backed libraries initialize pools.
+import numpy as np  # noqa: E402
+
+from headroom.models.config import ML_MODEL_DEFAULTS  # noqa: E402
+from headroom.onnx_runtime import (  # noqa: E402
+    create_cpu_session_options,
+    hf_hub_download_local_first,
+)
 
 # Suppress HuggingFace Hub warnings about missing tokens and rate limits.
 # These appear whenever hf_hub_download is called without HF_TOKEN set.
@@ -38,6 +70,23 @@ logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
+
+
+def _configure_torch_thread_cap(torch_module: Any) -> None:
+    """Apply the local embedder thread cap to torch if torch is already loaded."""
+    if _MEMORY_EMBED_THREAD_CAP is None:
+        return
+
+    for setter_name in ("set_num_threads", "set_num_interop_threads"):
+        setter = getattr(torch_module, setter_name, None)
+        if not callable(setter):
+            continue
+        try:
+            setter(_MEMORY_EMBED_THREAD_CAP)
+        except RuntimeError:
+            logger.debug(
+                "torch.%s already initialized; keeping existing thread setting", setter_name
+            )
 
 
 def _normalize_embedding(embedding: np.ndarray) -> np.ndarray:
@@ -141,6 +190,8 @@ class LocalEmbedder:
             Device string: "cuda", "mps", or "cpu".
         """
         import torch
+
+        _configure_torch_thread_cap(torch)
 
         if torch.cuda.is_available():
             logger.info("CUDA device detected, using GPU")

--- a/tests/test_startup_log_noise.py
+++ b/tests/test_startup_log_noise.py
@@ -9,8 +9,20 @@ Covers the fixes in:
 
 from __future__ import annotations
 
+import importlib
 import logging
+import os
 import warnings
+from types import SimpleNamespace
+
+_EMBEDDER_THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "BLIS_NUM_THREADS",
+)
 
 
 class TestAnthropicWarnParameter:
@@ -105,6 +117,52 @@ class TestEmbedderLogLevels:
 
         assert os.environ.get("HF_HUB_DISABLE_PROGRESS_BARS") == "1"
         assert os.environ.get("HF_HUB_DISABLE_IMPLICIT_TOKEN") == "1"
+
+
+class TestEmbedderThreadCaps:
+    """Local sentence-transformers embedding should not oversubscribe BLAS threads."""
+
+    def test_blas_thread_env_defaults_to_one(self, monkeypatch):
+        """Import-time defaults cap BLAS/OpenMP pools unless the user configured them."""
+        for name in (*_EMBEDDER_THREAD_ENV_VARS, "HEADROOM_MEMORY_EMBED_THREADS"):
+            monkeypatch.delenv(name, raising=False)
+
+        import headroom.memory.adapters.embedders as embedders
+
+        importlib.reload(embedders)
+
+        for name in _EMBEDDER_THREAD_ENV_VARS:
+            assert os.environ.get(name) == "1"
+
+    def test_blas_thread_env_respects_existing_values(self, monkeypatch):
+        """Existing BLAS/OpenMP env vars must win over Headroom defaults."""
+        for name in _EMBEDDER_THREAD_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("HEADROOM_MEMORY_EMBED_THREADS", "2")
+        monkeypatch.setenv("OMP_NUM_THREADS", "4")
+
+        import headroom.memory.adapters.embedders as embedders
+
+        importlib.reload(embedders)
+
+        assert os.environ["OMP_NUM_THREADS"] == "4"
+        assert os.environ["MKL_NUM_THREADS"] == "2"
+
+    def test_configure_torch_thread_cap_calls_torch_setters(self, monkeypatch):
+        """If torch is already imported, apply the same cap through torch APIs."""
+        import headroom.memory.adapters.embedders as embedders
+
+        calls: list[tuple[str, int]] = []
+        fake_torch = SimpleNamespace(
+            set_num_threads=lambda value: calls.append(("threads", value)),
+            set_num_interop_threads=lambda value: calls.append(("interop", value)),
+        )
+
+        monkeypatch.setattr(embedders, "_MEMORY_EMBED_THREAD_CAP", 2)
+
+        embedders._configure_torch_thread_cap(fake_torch)
+
+        assert calls == [("threads", 2), ("interop", 2)]
 
 
 class TestLiteLLMLogSuppression:


### PR DESCRIPTION
Fixes #198.

The local sentence-transformers embedder runs `model.encode()` in an executor, but the BLAS/OpenMP/Torch pools behind it can still fan out per request. Under concurrent memory workloads that can oversubscribe the host and make unrelated health checks noisy.

This PR caps the local memory embedder path to one compute thread by default:

- sets common BLAS/OpenMP env defaults before NumPy / ONNX / Torch-backed imports
- keeps any user-provided thread settings untouched
- supports `HEADROOM_MEMORY_EMBED_THREADS=0`, `auto`, `false`, `none`, or `off` to disable Headroom's cap
- applies Torch thread setters when Torch is imported, while tolerating already-initialized pools

This is intentionally a configuration-path fix, not a broad performance rewrite. The regression tests cover the defaults, user overrides, and Torch setter behavior that prevent the oversubscription described in the issue.

Verification:

- `python -m pytest tests\test_startup_log_noise.py::TestEmbedderThreadCaps -q --basetemp=.pytest-tmp-embedder-thread-caps2`
- `python -m pytest tests\test_startup_log_noise.py -q --basetemp=.pytest-tmp-startup-log-noise-threads`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy headroom\memory\adapters\embedders.py --ignore-missing-imports`
- `git diff --check`