### PR TITLE
fix(rust): upgrade pyo3 for rustsec advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,9 +3199,9 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -3217,9 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3227,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3249,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4082,9 +4082,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 axum = "0.7"
 tower = "0.5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-pyo3 = "0.22"
+pyo3 = "0.24.1"
 # Phase D PR-D1: AWS SigV4 signing for native Bedrock InvokeModel route.
 # `aws-sigv4` provides the canonical-request + signing-key implementation;
 # `aws-config` resolves credentials from the standard provider chain

--- a/crates/headroom-py/src/lib.rs
+++ b/crates/headroom-py/src/lib.rs
@@ -41,7 +41,8 @@ use headroom_core::transforms::{
     SearchCompressorConfig as RustSearchConfig, SearchCompressorStats as RustSearchStats,
 };
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict, PyString};
+use pyo3::types::{PyBytes, PyDict};
+use pyo3::IntoPyObjectExt;
 
 /// Identity stub used by the Python smoke test to verify linkage.
 #[pyfunction]
@@ -65,7 +66,7 @@ fn type_name(v: &serde_json::Value) -> &'static str {
 /// fail when keys are static str literals and values are owned String /
 /// Option<String> / Option<&'static str>) without tripping the
 /// `clippy::useless_conversion` false positive that fires inside the
-/// pyo3 0.22 method-attribute macro.
+/// PyO3 method-attribute macro.
 fn build_crush_array_dict<'py>(
     py: Python<'py>,
     kept_json: String,
@@ -75,7 +76,7 @@ fn build_crush_array_dict<'py>(
     compacted: Option<String>,
     compaction_kind: Option<&'static str>,
 ) -> Bound<'py, PyDict> {
-    let dict = PyDict::new_bound(py);
+    let dict = PyDict::new(py);
     dict.set_item("items", kept_json).unwrap();
     dict.set_item("ccr_hash", ccr_hash).unwrap();
     dict.set_item("dropped_summary", dropped_summary).unwrap();
@@ -859,30 +860,30 @@ impl PyDetectionResult {
     /// the underlying Rust value.
     #[getter]
     fn metadata<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         for (k, v) in &self.inner.metadata {
             // Convert each JSON value into the closest Python primitive.
             // Detection metadata is always a flat dict of scalars (ints,
             // bools, strings) so we don't need to recurse.
             let py_value: PyObject = match v {
-                serde_json::Value::Bool(b) => b.into_py(py),
+                serde_json::Value::Bool(b) => b.into_py_any(py)?,
                 serde_json::Value::Number(n) => {
                     if let Some(i) = n.as_u64() {
-                        i.into_py(py)
+                        i.into_py_any(py)?
                     } else if let Some(i) = n.as_i64() {
-                        i.into_py(py)
+                        i.into_py_any(py)?
                     } else if let Some(f) = n.as_f64() {
-                        f.into_py(py)
+                        f.into_py_any(py)?
                     } else {
                         py.None()
                     }
                 }
-                serde_json::Value::String(s) => PyString::new_bound(py, s).into_py(py),
+                serde_json::Value::String(s) => s.into_py_any(py)?,
                 serde_json::Value::Null => py.None(),
                 // Detection never emits arrays / objects in metadata
                 // today; if it ever does, fall through to JSON-string for
                 // visibility rather than silently dropping.
-                other => PyString::new_bound(py, &other.to_string()).into_py(py),
+                other => other.to_string().into_py_any(py)?,
             };
             dict.set_item(k, py_value)?;
         }
@@ -957,7 +958,7 @@ fn shared_keyword_detector() -> &'static KeywordDetector {
 }
 
 /// Returns `Some(ctx)` for known names and `None` otherwise — caller
-/// converts to PyValueError. Avoids the pyo3-0.22 + clippy
+/// converts to PyValueError. Avoids a PyO3 macro + clippy
 /// `useless_conversion` false positive that fires when `?` propagates a
 /// `PyResult<_>` through another `PyResult<_>`.
 fn ctx_from_str(name: &str) -> Option<ImportanceContext> {
@@ -986,7 +987,7 @@ fn category_to_str(cat: ImportanceCategory) -> &'static str {
 /// contexts (`text|search|diff|log`) and `None` for an unknown context
 /// — the Python shim translates `None` into `ValueError` for the
 /// caller. Returning `Option` instead of `PyResult` dodges the
-/// pyo3-0.22 + clippy `useless_conversion` false positive that the
+/// PyO3 macro + clippy `useless_conversion` false positive that the
 /// `#[pyfunction]` macro triggers when its inner result-shape carries
 /// `PyErr`. The bridge layer is the right place for this conversion;
 /// keeping the Rust signature panic-free and `PyResult`-free is worth
@@ -1014,12 +1015,12 @@ fn content_has_error_indicators(text: &str) -> bool {
 /// shim can recompile the legacy `re.Pattern` objects without
 /// re-declaring keyword data on the Python side. Uses `.unwrap()` on
 /// `set_item` because keys are static str literals and values are
-/// `Vec<&'static str>`, which can't fail — and avoids the pyo3-0.22
+/// `Vec<&'static str>`, which can't fail — and avoids a PyO3 macro
 /// `useless_conversion` clippy false positive.
 #[pyfunction]
 fn keyword_registry_snapshot(py: Python<'_>) -> Py<PyDict> {
     let registry = KeywordRegistry::default_set();
-    let dict = PyDict::new_bound(py);
+    let dict = PyDict::new(py);
     for (key, words) in registry.as_map() {
         dict.set_item(key, words).unwrap();
     }
@@ -1130,7 +1131,7 @@ impl PySearchCompressionResult {
     }
     #[getter]
     fn summaries<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         for (k, v) in &self.inner.summaries {
             dict.set_item(k, v).unwrap();
         }
@@ -1330,7 +1331,7 @@ impl PyLogCompressionResult {
     }
     #[getter]
     fn stats<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         for (k, v) in &self.inner.stats {
             dict.set_item(k, v).unwrap();
         }
@@ -1522,7 +1523,7 @@ fn compress_openai_responses_live_zone(
                 .collect();
             let reason = rust_summarize_openai_responses_no_change_reason(&manifest).to_string();
             (
-                PyBytes::new_bound(py, body).unbind(),
+                PyBytes::new(py, body).unbind(),
                 false,
                 saved,
                 transforms,
@@ -1540,7 +1541,7 @@ fn compress_openai_responses_live_zone(
                 .map(String::from)
                 .collect();
             (
-                PyBytes::new_bound(py, bytes).unbind(),
+                PyBytes::new(py, bytes).unbind(),
                 true,
                 saved,
                 transforms,
@@ -1551,7 +1552,7 @@ fn compress_openai_responses_live_zone(
             // BodyNotJson / NoMessagesArray are non-fatal: nothing to
             // compress, fall through to passthrough byte-for-byte.
             (
-                PyBytes::new_bound(py, body).unbind(),
+                PyBytes::new(py, body).unbind(),
                 false,
                 0,
                 Vec::new(),

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+
+
+def _semver_tuple(version: str) -> tuple[int, int, int]:
+    parts = version.split(".", 2)
+    assert len(parts) == 3
+    return (int(parts[0]), int(parts[1]), int(parts[2]))
 
 
 def test_docker_workflow_normalizes_repository_name_for_signing() -> None:
@@ -36,6 +47,15 @@ def test_release_workflow_publishes_python_distributions_to_github_release() -> 
     )
     assert "Publish Node package tarballs to GitHub Release" in content
     assert 'gh release upload "$TAG" release-assets/*.tgz --clobber' in content
+
+
+def test_cargo_lock_keeps_pyo3_above_rustsec_2025_0020_floor() -> None:
+    """PyO3 < 0.24.1 is affected by RUSTSEC-2025-0020."""
+    cargo_lock = tomllib.loads((ROOT / "Cargo.lock").read_text(encoding="utf-8"))
+    pyo3_packages = [package for package in cargo_lock["package"] if package["name"] == "pyo3"]
+
+    assert len(pyo3_packages) == 1
+    assert _semver_tuple(pyo3_packages[0]["version"]) >= (0, 24, 1)
 
 
 def test_create_release_requires_successful_build_and_pypi_publish() -> None:


### PR DESCRIPTION
Fixes #335.

This upgrades the `headroom-py` PyO3 binding from the 0.22 line to PyO3 0.24.2, which clears the RUSTSEC-2025-0020 floor called out in the issue.

What changed:

- bumps the workspace `pyo3` requirement to `0.24.1` so Cargo resolves `0.24.2`
- updates the lockfile entries for `pyo3`, `pyo3-*`, and `target-lexicon`
- moves the small bits of bridge code that were still using deprecated 0.22-era helpers to the 0.24 APIs (`PyDict::new`, `PyBytes::new`, `IntoPyObjectExt::into_py_any`)
- adds a regression guard in `test_release_workflows.py` so the lockfile cannot drift back below PyO3 0.24.1 without a test failure

I kept this intentionally narrow: no compressor behavior changes, no Rust core refactor, and no unrelated dependency churn.

Verification:

- `cargo tree -p headroom-py -i pyo3` -> `pyo3 v0.24.2`
- `PYO3_PYTHON=.venv313/Scripts/python.exe cargo check -p headroom-py`
- `PYO3_PYTHON=.venv313/Scripts/python.exe cargo check -p headroom-py --features extension-module`
- `PYO3_PYTHON=.venv313/Scripts/python.exe cargo clippy -p headroom-py -- -D warnings`
- `PYO3_PYTHON=.venv313/Scripts/python.exe cargo clippy -p headroom-py --features extension-module -- -D warnings`
- `.venv313/Scripts/python.exe -m pip install -e .`
- `.venv313/Scripts/python.exe -m pytest tests/test_rust_core_smoke.py tests/test_signals_keyword_parity.py -q --basetemp=.pytest-tmp-pyo3-smoke`
- `.venv313/Scripts/python.exe -m pytest tests/test_responses_pyo3_compression.py tests/test_responses_ws_pyo3_compression.py -q --basetemp=.pytest-tmp-pyo3-responses`
- `.venv313/Scripts/python.exe -m pytest tests/test_release_workflows.py -q --basetemp=.pytest-tmp-release-workflows-pyo3`
- `.venv313/Scripts/python.exe -m ruff check tests/test_release_workflows.py`
- `.venv313/Scripts/python.exe -m ruff format --check tests/test_release_workflows.py`
- `cargo fmt --all -- --check`
- `cargo test -p headroom-py --lib`
- `git diff --check`

I also tried the broader `cargo test --workspace`; it did not fail, but it exceeded a 5 minute local timeout on this Windows machine, so I replaced it with the targeted Rust/Python bridge checks above.