### PR TITLE
docs: clarify dashboard and persistent install entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ Using `pipx`? Choose a supported interpreter explicitly:
 pipx install --python python3.13 "headroom-ai[all]"
 ```
 
-→ [Installation guide](https://headroom-docs.vercel.app/docs/installation) — Docker tags, persistent service, PowerShell, devcontainers.
+- [Installation guide](https://headroom-docs.vercel.app/docs/installation) — Python, npm, Docker tags, PowerShell, and native build prerequisites.
+- [Persistent installs](https://headroom-docs.vercel.app/docs/persistent-installs) — background services, scheduled watchdog tasks, and restartable Docker deployments.
 
 ## headroom learn
 

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -168,6 +168,10 @@ docker run -p 8787:8787 ghcr.io/chopratejas/headroom:latest
 If you want a host `headroom` CLI that keeps Headroom itself inside a container — with mounted state, a one-line installer, and a persistent Docker lifecycle — see [Docker-Native Install](/docs/docker-install).
 </Callout>
 
+<Callout type="info" title="Need an always-on local proxy?">
+Use [Persistent Installs](/docs/persistent-installs) for background service, scheduled watchdog task, and restartable Docker profiles managed by `headroom install`.
+</Callout>
+
 ### Image tags
 
 | Tag | Extras | Base image | Description |

--- a/docs/content/docs/proxy.mdx
+++ b/docs/content/docs/proxy.mdx
@@ -121,6 +121,14 @@ Live session statistics plus durable `persistent_savings` totals. Stored at `~/.
 curl http://localhost:8787/stats
 ```
 
+### `GET /dashboard`
+
+Browser dashboard for live request activity, token savings, cost estimates, subscription windows, and durable history charts.
+
+```text
+http://localhost:8787/dashboard
+```
+
 ### `GET /stats-history`
 
 Durable history with hourly, daily, weekly, and monthly rollups. Powers the `/dashboard` view.


### PR DESCRIPTION
Fixes #207.

This tightens two docs entry points that were easy to miss:

- splits the README install link into separate installation and persistent-install links
- adds a persistent-install callout to the installation page
- documents the `/dashboard` endpoint in the proxy API section instead of only mentioning it under `/stats-history`

Checked locally:

- `npx fumadocs-mdx`
- `npx next typegen`
- `git diff --check`

I also tried `npm run types:check`; it currently fails on pre-existing docs app imports for `@/lib/source`, `@/lib/shared`, `@/lib/layout.shared`, etc. The `docs/lib` folder is absent on current `main`, and this PR only touches README/MDX content.