### PR TITLE
docs: clarify Intel macOS install support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,8 +252,10 @@ jobs:
           # ML compression backend) does not provide prebuilt ONNX Runtime
           # binaries for `x86_64-apple-darwin`, and building ORT from
           # source would add CMake + ~5 minutes per build. Apple Silicon
-          # macOS is fully covered below; Intel-mac users install the
-          # platform-independent sdist (also produced by this matrix).
+          # macOS is fully covered below; Intel-mac users should use the
+          # Docker-native install or proxy container until backend support
+          # changes. The sdist still has to build the same Rust extension
+          # and is not a reliable Intel-mac workaround.
           # Tracked as a follow-up: switch to `ort-tract` or upstream a
           # request for x86_64 macOS prebuilts.
           - os: macos-14

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,9 +80,8 @@ jobs:
         # Runtime binaries for `x86_64-apple-darwin`; building from source
         # in CI is a multi-hour cmake job. Apple Silicon has been the
         # default macOS target since 2020 and is sufficient for the wheels
-        # we ship. If a customer needs Intel macOS, build from source
-        # locally (the toolchain works; only prebuilt distribution skips
-        # this target).
+        # we ship. If a customer needs Intel macOS today, use the
+        # Docker-native install or proxy container until ORT support changes.
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -7,10 +7,14 @@ description: Install Headroom via pip, npm, or Docker. Includes all Python extra
 
 Headroom requires **Python 3.10+** and is published as `headroom-ai` on PyPI.
 Current release wheels are built for Python **3.10 through 3.13** on Linux
-(manylinux_2_28 x86_64 / aarch64) and macOS (Apple Silicon). Other targets —
-**Windows** and **Intel macOS** — fall back to building the Rust extension
-from the sdist and need a working native toolchain. If your installer is
-using a newer Python, force a supported interpreter.
+(manylinux_2_28 x86_64 / aarch64) and macOS (Apple Silicon). **Windows**
+falls back to building the Rust extension from the sdist and needs a working
+native toolchain. **Intel macOS** (`x86_64-apple-darwin`) is not a supported
+native Python install target today because `ort-sys` does not provide
+prebuilt ONNX Runtime binaries for that target. Use the Docker-native install
+or run the proxy container instead.
+
+If your installer is using a newer Python, force a supported interpreter.
 
 ### Core package
 
@@ -84,6 +88,22 @@ To install the prerequisites:
 If you'd rather avoid the native toolchain entirely, run Headroom
 through Docker — see the [Docker](#docker) section below. Native
 Windows wheels are tracked in [#636](https://github.com/chopratejas/headroom/issues/636).
+
+### Intel macOS
+
+Headroom does not currently ship native Python wheels for Intel Macs
+(`x86_64-apple-darwin`). Building from the sdist is also not a reliable
+workaround because the Rust extension depends on `ort-sys`, and that crate
+does not publish prebuilt ONNX Runtime binaries for Intel macOS.
+
+Use one of these paths instead:
+
+- [Docker-Native Install](/docs/docker-install), which keeps Headroom inside Docker while exposing a host `headroom` wrapper.
+- A direct proxy container:
+
+```bash
+docker run --rm -p 8787:8787 ghcr.io/chopratejas/headroom:latest
+```
 
 ### pipx
 

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -208,6 +208,12 @@ apt-get install -y build-essential && pip install headroom-ai
 xcode-select --install && pip install headroom-ai
 ```
 
+On Intel macOS (`x86_64-apple-darwin`), Xcode Command Line Tools are not
+enough for current Headroom releases because `ort-sys` does not provide
+prebuilt ONNX Runtime binaries for that target. Use the
+[Docker-Native Install](/docs/docker-install) or run the proxy container
+instead.
+
 For Docker, install and remove build tools in one layer:
 
 ```dockerfile

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -281,8 +281,8 @@ def test_build_wheels_matrix_excludes_intel_macos() -> None:
     """`ort-sys 2.0.0-rc.12` (transitive via the ML compression backend)
     has no prebuilt ONNX Runtime binaries for `x86_64-apple-darwin`.
     Building ORT from source would add CMake + ~5 minutes per build.
-    Apple Silicon macOS is fully covered; Intel-mac users install from
-    the platform-independent sdist this matrix also produces.
+    Apple Silicon macOS is fully covered; Intel-mac users should use Docker
+    until the native backend support changes.
 
     We assert against the actual matrix entry shape (`target: <triple>`
     on a non-comment line) so explanatory comments mentioning the
@@ -323,6 +323,30 @@ def test_build_wheels_matrix_excludes_intel_macos() -> None:
         if stripped.startswith("os:"):
             matrix_os.append(stripped.split(":", 1)[1].strip())
     assert "macos-15-intel" not in matrix_os
+
+
+def test_install_docs_do_not_send_intel_macos_users_to_sdist() -> None:
+    """Intel macOS users should not be told that the sdist is the fallback.
+
+    The sdist builds the same Rust extension, and `ort-sys` still lacks
+    prebuilt ONNX Runtime binaries for `x86_64-apple-darwin`.
+    """
+
+    installation = (ROOT / "docs" / "content" / "docs" / "installation.mdx").read_text(
+        encoding="utf-8"
+    )
+    troubleshooting = (ROOT / "docs" / "content" / "docs" / "troubleshooting.mdx").read_text(
+        encoding="utf-8"
+    )
+    release_yml = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    rust_yml = (ROOT / ".github" / "workflows" / "rust.yml").read_text(encoding="utf-8")
+    combined = "\n".join([installation, troubleshooting, release_yml, rust_yml])
+
+    assert "x86_64-apple-darwin" in combined
+    assert "Docker-Native Install" in installation
+    assert "Docker-Native Install" in troubleshooting
+    assert "platform-independent sdist" not in combined
+    assert "build from source locally" not in combined
 
 
 def test_aarch64_wheel_uses_native_arm64_runner() -> None:


### PR DESCRIPTION
﻿Fixes #525.

This updates the install docs to match the actual release matrix:

- Apple Silicon macOS wheels are supported
- Windows can still fall back to an sdist/native-toolchain build
- Intel macOS (`x86_64-apple-darwin`) should not be presented as an sdist fallback today, because the Rust extension still depends on `ort-sys` and `ort-sys` has no prebuilt ONNX Runtime binaries for that target
- points Intel Mac users at the Docker-native install or direct proxy container instead

I also updated the matching workflow comments and added a small regression test so we do not accidentally reintroduce the misleading sdist guidance for Intel macOS.

Checked locally:

- `.venv313\\Scripts\\python.exe -m pytest tests\\test_release_workflows.py -q`
- `.venv313\\Scripts\\ruff.exe check tests\\test_release_workflows.py`
- `.venv313\\Scripts\\ruff.exe format --check tests\\test_release_workflows.py`
- `npx fumadocs-mdx`
- `npx next typegen`
- `git diff --check`
