### PR TITLE
feat(cli): add local support bundle command

### DIFF
--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -5,6 +5,19 @@ description: Solutions for common Headroom issues including proxy startup, conne
 
 Solutions for common Headroom issues.
 
+## Sharing Diagnostics
+
+When a maintainer asks for logs or stats, generate a local support bundle:
+
+```bash
+headroom support bundle
+```
+
+The bundle includes version/platform metadata, proxy savings state, a perf
+report, and diagnostic proxy log lines. Full proxy log tails are not included
+by default because they can contain prompts or tool output. Add
+`--include-full-log-tail` only when a maintainer asks for it.
+
 ## Proxy Server Issues
 
 ### Proxy will not start

--- a/headroom/cli/__init__.py
+++ b/headroom/cli/__init__.py
@@ -20,6 +20,7 @@ from . import (  # noqa: F401
     mcp,
     perf,
     proxy,
+    support,
     tools,
     wrap,
 )

--- a/headroom/cli/main.py
+++ b/headroom/cli/main.py
@@ -43,6 +43,7 @@ def _register_commands() -> None:
         mcp,  # noqa: F401
         perf,  # noqa: F401
         proxy,  # noqa: F401
+        support,  # noqa: F401
         tools,  # noqa: F401
         wrap,  # noqa: F401
     )

--- a/headroom/cli/support.py
+++ b/headroom/cli/support.py
@@ -1,0 +1,289 @@
+"""Support diagnostics CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import sys
+import zipfile
+from collections import deque
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import click
+
+from headroom import paths
+
+from .main import main
+
+_SECRET_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+"), r"\1<redacted>"),
+    (re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{12,}"), r"\1<redacted>"),
+    (
+        re.compile(r"(?i)(api[_-]?key|token|secret|password)([\"']?\s*[:=]\s*[\"']?)[^\"'\s,;}]+"),
+        r"\1\2<redacted>",
+    ),
+    (re.compile(r"\b(sk-(?:ant-|proj-)?[A-Za-z0-9._-]{8,})\b"), "<redacted>"),
+    (re.compile(r"\b(ghp_[A-Za-z0-9_]{8,}|github_pat_[A-Za-z0-9_]{8,})\b"), "<redacted>"),
+)
+_DIAGNOSTIC_MARKERS = (
+    " PERF ",
+    "content_router:",
+    "Transform ",
+    "Pipeline complete:",
+    "TOIN:",
+)
+_ENV_KEYS = (
+    "HEADROOM_WORKSPACE_DIR",
+    "HEADROOM_CONFIG_DIR",
+    "HEADROOM_SAVINGS_PATH",
+    "HEADROOM_TOIN_PATH",
+    "HEADROOM_SUBSCRIPTION_STATE_PATH",
+    "HEADROOM_HOST",
+    "HEADROOM_PORT",
+    "HEADROOM_MODE",
+    "HEADROOM_BACKEND",
+    "HEADROOM_LOG_LEVEL",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%SZ")
+
+
+def _default_output_path() -> Path:
+    return Path.cwd() / f"headroom-support-{_utc_stamp()}.zip"
+
+
+def _redact_line(line: str) -> str:
+    redacted = line
+    for pattern, replacement in _SECRET_REPLACEMENTS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, Path):
+        return str(value)
+    return repr(value)
+
+
+def _write_json(zf: zipfile.ZipFile, arcname: str, payload: Any) -> None:
+    zf.writestr(
+        arcname,
+        json.dumps(payload, indent=2, sort_keys=True, default=_json_default) + "\n",
+    )
+
+
+def _write_text(zf: zipfile.ZipFile, arcname: str, payload: str) -> None:
+    zf.writestr(arcname, payload if payload.endswith("\n") else payload + "\n")
+
+
+def _file_info(path: Path) -> dict[str, Any]:
+    try:
+        stat = path.stat()
+    except OSError:
+        return {"path": str(path), "exists": False}
+    return {
+        "path": str(path),
+        "exists": True,
+        "size_bytes": stat.st_size,
+        "modified_at_utc": datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
+    }
+
+
+def _log_files() -> list[Path]:
+    log_dir = paths.log_dir()
+    if not log_dir.exists():
+        return []
+    return sorted(log_dir.glob("proxy.log*"), key=lambda p: p.stat().st_mtime)
+
+
+def _tail_log_lines(*, max_lines: int, diagnostic_only: bool) -> list[str]:
+    kept: deque[str] = deque(maxlen=max_lines)
+    for log_file in _log_files():
+        try:
+            with log_file.open(encoding="utf-8", errors="replace") as handle:
+                for raw in handle:
+                    line = raw.rstrip("\r\n")
+                    if diagnostic_only and not any(
+                        marker in line for marker in _DIAGNOSTIC_MARKERS
+                    ):
+                        continue
+                    kept.append(_redact_line(line))
+        except OSError:
+            continue
+    return list(kept)
+
+
+def _write_file_if_present(
+    zf: zipfile.ZipFile,
+    path: Path,
+    arcname: str,
+    *,
+    max_bytes: int = 2_000_000,
+) -> bool:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return False
+    if len(data) > max_bytes:
+        _write_text(
+            zf,
+            f"{arcname}.omitted.txt",
+            f"{path} is {len(data)} bytes; omitted because it exceeds {max_bytes} bytes.",
+        )
+        return False
+    zf.writestr(arcname, data)
+    return True
+
+
+def _perf_report(hours: float) -> str:
+    from headroom.perf import analyzer
+
+    original_log_dir = analyzer.LOG_DIR
+    analyzer.LOG_DIR = paths.log_dir()
+    try:
+        return analyzer.format_report(analyzer.parse_log_files(last_n_hours=hours))
+    finally:
+        analyzer.LOG_DIR = original_log_dir
+
+
+def _manifest(*, hours: float, max_lines: int, include_full_log_tail: bool) -> dict[str, Any]:
+    try:
+        from headroom._version import __version__
+    except ImportError:
+        __version__ = "unknown"
+
+    selected_env = {
+        key: _redact_line(value) for key in _ENV_KEYS if (value := os.environ.get(key, "").strip())
+    }
+    return {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "headroom_version": __version__,
+        "python": sys.version,
+        "platform": platform.platform(),
+        "options": {
+            "hours": hours,
+            "max_lines": max_lines,
+            "include_full_log_tail": include_full_log_tail,
+        },
+        "paths": {
+            "workspace_dir": str(paths.workspace_dir()),
+            "config_dir": str(paths.config_dir()),
+            "log_dir": str(paths.log_dir()),
+            "proxy_log": _file_info(paths.proxy_log_path()),
+            "savings": _file_info(paths.savings_path()),
+            "session_stats": _file_info(paths.session_stats_path()),
+        },
+        "selected_environment": selected_env,
+        "log_files": [_file_info(path) for path in _log_files()],
+    }
+
+
+def create_support_bundle(
+    *,
+    output: Path | None = None,
+    hours: float = 168.0,
+    max_lines: int = 2000,
+    include_full_log_tail: bool = False,
+) -> Path:
+    """Create a local diagnostics zip for issue reports."""
+
+    output_path = (output or _default_output_path()).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        _write_json(
+            zf,
+            "manifest.json",
+            _manifest(
+                hours=hours, max_lines=max_lines, include_full_log_tail=include_full_log_tail
+            ),
+        )
+        _write_text(zf, "perf-report.txt", _perf_report(hours))
+        _write_file_if_present(zf, paths.savings_path(), "state/proxy_savings.json")
+
+        session_lines = _tail_file(paths.session_stats_path(), max_lines=max_lines)
+        if session_lines:
+            _write_text(zf, "state/session_stats_tail.jsonl", "\n".join(session_lines))
+
+        diagnostic_lines = _tail_log_lines(max_lines=max_lines, diagnostic_only=True)
+        if diagnostic_lines:
+            _write_text(zf, "logs/proxy-diagnostics-tail.txt", "\n".join(diagnostic_lines))
+
+        if include_full_log_tail:
+            full_lines = _tail_log_lines(max_lines=max_lines, diagnostic_only=False)
+            if full_lines:
+                _write_text(zf, "logs/proxy-full-tail.redacted.txt", "\n".join(full_lines))
+        else:
+            _write_text(
+                zf,
+                "logs/full-log-tail-not-included.txt",
+                "Full proxy log tail is not included by default. Re-run with "
+                "`headroom support bundle --include-full-log-tail` if a maintainer asks for it.",
+            )
+
+    return output_path
+
+
+def _tail_file(path: Path, *, max_lines: int) -> list[str]:
+    kept: deque[str] = deque(maxlen=max_lines)
+    try:
+        with path.open(encoding="utf-8", errors="replace") as handle:
+            for raw in handle:
+                kept.append(_redact_line(raw.rstrip("\r\n")))
+    except OSError:
+        return []
+    return list(kept)
+
+
+@main.group("support")
+def support_group() -> None:
+    """Collect diagnostics for maintainers."""
+
+
+@support_group.command("bundle")
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(path_type=Path, dir_okay=False, writable=True),
+    default=None,
+    help="Where to write the zip file. Defaults to ./headroom-support-<timestamp>.zip.",
+)
+@click.option(
+    "--hours",
+    type=float,
+    default=168.0,
+    show_default=True,
+    help="Performance-report window to include.",
+)
+@click.option(
+    "--max-lines",
+    type=click.IntRange(1, 50_000),
+    default=2000,
+    show_default=True,
+    help="Maximum tail lines to include per bundled text artifact.",
+)
+@click.option(
+    "--include-full-log-tail",
+    is_flag=True,
+    help="Also include a redacted tail of proxy.log. Off by default because logs can contain prompts.",
+)
+def bundle(
+    output_path: Path | None, hours: float, max_lines: int, include_full_log_tail: bool
+) -> None:
+    """Create a local zip with logs and stats for an issue report."""
+
+    bundle_path = create_support_bundle(
+        output=output_path,
+        hours=hours,
+        max_lines=max_lines,
+        include_full_log_tail=include_full_log_tail,
+    )
+    click.echo(f"Created support bundle: {bundle_path}")
+    if not include_full_log_tail:
+        click.echo("Full proxy logs were not included. Use --include-full-log-tail only if needed.")

--- a/tests/test_cli_support.py
+++ b/tests/test_cli_support.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_proxy_log(workspace: Path, lines: list[str]) -> None:
+    log_dir = workspace / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "proxy.log").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_support_bundle_default_includes_diagnostics_not_full_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "headroom"
+    workspace.mkdir()
+    monkeypatch.setenv("HEADROOM_WORKSPACE_DIR", str(workspace))
+    monkeypatch.setenv("HEADROOM_PORT", "8787")
+    (workspace / "proxy_savings.json").write_text('{"tokens_saved": 123}\n', encoding="utf-8")
+    _write_proxy_log(
+        workspace,
+        [
+            "2026-03-07 13:38:31,009 - headroom.proxy - INFO - normal request line sk-secret123456",
+            (
+                "2026-03-07 13:38:32,009 - headroom.proxy - INFO - [hr_1] PERF "
+                "model=gpt-4o msgs=2 tok_before=100 tok_after=70 tok_saved=30 "
+                "cache_read=0 cache_write=0 cache_hit_pct=0 opt_ms=12 api_key=sk-secret123456 "
+                "transforms=content_router"
+            ),
+            "2026-03-07 13:38:33,009 - headroom.proxy - INFO - Pipeline complete: 100 -> 70 tokens (saved 30, 30.0% reduction)",
+        ],
+    )
+    output = tmp_path / "bundle.zip"
+
+    result = runner.invoke(
+        main, ["support", "bundle", "--output", str(output), "--max-lines", "10"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Created support bundle" in result.output
+    with zipfile.ZipFile(output) as zf:
+        names = set(zf.namelist())
+        assert "manifest.json" in names
+        assert "perf-report.txt" in names
+        assert "state/proxy_savings.json" in names
+        assert "logs/proxy-diagnostics-tail.txt" in names
+        assert "logs/full-log-tail-not-included.txt" in names
+        assert "logs/proxy-full-tail.redacted.txt" not in names
+
+        manifest = json.loads(zf.read("manifest.json"))
+        assert manifest["selected_environment"]["HEADROOM_PORT"] == "8787"
+        assert manifest["paths"]["savings"]["exists"] is True
+
+        diagnostics = zf.read("logs/proxy-diagnostics-tail.txt").decode()
+        assert "PERF" in diagnostics
+        assert "Pipeline complete" in diagnostics
+        assert "normal request line" not in diagnostics
+        assert "sk-secret123456" not in diagnostics
+        assert "<redacted>" in diagnostics
+
+
+def test_support_bundle_full_log_tail_is_opt_in_and_redacted(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "headroom"
+    workspace.mkdir()
+    monkeypatch.setenv("HEADROOM_WORKSPACE_DIR", str(workspace))
+    _write_proxy_log(
+        workspace,
+        [
+            "2026-03-07 13:38:31,009 - headroom.proxy - INFO - Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
+            "2026-03-07 13:38:32,009 - headroom.proxy - INFO - arbitrary non-diagnostic line",
+        ],
+    )
+    output = tmp_path / "bundle.zip"
+
+    result = runner.invoke(
+        main,
+        [
+            "support",
+            "bundle",
+            "--output",
+            str(output),
+            "--include-full-log-tail",
+            "--max-lines",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    with zipfile.ZipFile(output) as zf:
+        names = set(zf.namelist())
+        assert "logs/proxy-full-tail.redacted.txt" in names
+        assert "logs/full-log-tail-not-included.txt" not in names
+
+        full_tail = zf.read("logs/proxy-full-tail.redacted.txt").decode()
+        assert "arbitrary non-diagnostic line" in full_tail
+        assert "abcdefghijklmnopqrstuvwxyz" not in full_tail
+        assert "Authorization: Bearer <redacted>" in full_tail


### PR DESCRIPTION
﻿Fixes #267.

This adds a local diagnostics path instead of uploading logs anywhere:

```bash
headroom support bundle
```

The bundle includes:

- `manifest.json` with version/platform/path metadata
- `perf-report.txt` using the existing perf analyzer
- `state/proxy_savings.json` when present
- `state/session_stats_tail.jsonl` when present
- `logs/proxy-diagnostics-tail.txt` with PERF/router/transform/TOIN lines from `proxy.log*`

Full proxy log tails are intentionally not included by default because users can run with full message logging enabled. If a maintainer needs it, the user can opt in explicitly:

```bash
headroom support bundle --include-full-log-tail
```

That full tail is still redacted for obvious API keys, bearer tokens, GitHub tokens, and `sk-*` style keys.

Checked locally:

- `.venv313\\Scripts\\python.exe -m pytest tests\\test_cli_support.py tests\\test_cli\\test_main_help_version.py -q --basetemp .pytest-tmp\\support-cli`
- `.venv313\\Scripts\\ruff.exe check headroom\\cli\\support.py headroom\\cli\\__init__.py headroom\\cli\\main.py tests\\test_cli_support.py`
- `.venv313\\Scripts\\ruff.exe format --check headroom\\cli\\support.py headroom\\cli\\__init__.py headroom\\cli\\main.py tests\\test_cli_support.py`
- `npx fumadocs-mdx`
- `npx next typegen`
- `git diff --check`

Also smoke-tested the installed entrypoint shape with `from headroom.cli import main; main([...])` and verified it creates the zip.
