### PR TITLE
docs: clarify Claude Desktop MCP support

### DIFF
--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -37,6 +37,42 @@ headroom proxy
 ANTHROPIC_BASE_URL=http://127.0.0.1:8787 claude
 ```
 
+## Claude Desktop (Claude.app)
+
+Claude Desktop can use Headroom's MCP tools when you configure Headroom as a local stdio MCP server. This gives Claude Desktop on-demand access to `headroom_compress`, `headroom_retrieve`, and `headroom_stats`.
+
+Add Headroom to your Claude Desktop `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "headroom": {
+      "type": "stdio",
+      "command": "headroom",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+If Claude Desktop cannot find `headroom`, replace `"command": "headroom"` with the full executable path from `which headroom` or `where headroom`.
+
+If you also run a persistent Headroom proxy, pass its URL so retrieval and stats come from that proxy:
+
+```json
+{
+  "mcpServers": {
+    "headroom": {
+      "type": "stdio",
+      "command": "headroom",
+      "args": ["mcp", "serve", "--proxy-url", "http://127.0.0.1:8788"]
+    }
+  }
+}
+```
+
+This is not the same as transparent proxy mode. `ANTHROPIC_BASE_URL=http://127.0.0.1:8788` is for Claude Code and other API clients that honor Anthropic API base URL settings. Headroom does not currently provide a supported way to route the normal Claude Desktop chat app through the HTTP proxy layer or through system-level network interception.
+
 ## Tools
 
 ### headroom_compress
@@ -159,6 +195,7 @@ Do not assume that a running proxy exposes an HTTP MCP endpoint at `/mcp`. If `h
 | Tool | MCP Support | Setup |
 |------|-------------|-------|
 | Claude Code | Native | `headroom mcp install` |
+| Claude Desktop | Manual | Add `headroom mcp serve` to `claude_desktop_config.json` |
 | Cursor | Supported | Add to Cursor MCP settings |
 | Codex | If supported | Configure MCP server |
 | Any MCP host | Yes | Point to `headroom mcp serve` |

--- a/docs/content/docs/proxy.mdx
+++ b/docs/content/docs/proxy.mdx
@@ -1,9 +1,9 @@
 ---
 title: Proxy Server
-description: Run the Headroom proxy to compress LLM traffic for any client — Claude Code, Cursor, OpenAI SDK, or custom apps.
+description: Run the Headroom proxy to compress LLM traffic for API clients that support custom base URLs.
 ---
 
-The Headroom proxy is a standalone HTTP server that compresses all LLM traffic passing through it. Point any client at the proxy and get automatic context optimization.
+The Headroom proxy is a standalone HTTP server that compresses LLM API traffic passing through it. Point a compatible API client at the proxy and get automatic context optimization.
 
 ## Starting the proxy
 
@@ -226,6 +226,10 @@ ANTHROPIC_BASE_URL=http://localhost:8787 claude
 # Cursor / any OpenAI-compatible client
 OPENAI_BASE_URL=http://localhost:8787/v1 cursor
 ```
+
+<Callout type="info" title="Claude Desktop is different">
+Claude Desktop (Claude.app) is not launched through `headroom wrap` and Headroom does not currently provide a supported way to route its normal chat traffic through the HTTP proxy. Use Headroom with Claude Desktop through the stdio MCP server (`headroom mcp serve`) instead; see [MCP Tools](/docs/mcp).
+</Callout>
 
 ## Cloud providers
 

--- a/headroom/mcp_registry/claude.py
+++ b/headroom/mcp_registry/claude.py
@@ -2,10 +2,11 @@
 
 Claude Code 2.x stores MCP server configuration in ``~/.claude/.claude.json``
 and ships a CLI (``claude mcp add/remove/list/get``) that owns the file.
-Older Claude Code releases (and the Claude Desktop app) read
-``~/.claude/mcp.json``. This registrar prefers the CLI for writes when
-available, and reads the underlying JSON files directly for compare /
-``get_server`` so it is robust to CLI output format changes.
+Older Claude Code releases can read ``~/.claude/mcp.json``. Claude Desktop
+uses its own ``claude_desktop_config.json`` path and is documented separately.
+This registrar prefers the CLI for writes when available, and reads the
+underlying JSON files directly for compare / ``get_server`` so it is robust to
+CLI output format changes.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
﻿Closes #528.

This clarifies the supported Claude Desktop path without implying that the desktop chat app can be routed through Headroom's HTTP proxy:

- adds a Claude Desktop section to the MCP docs with a `claude_desktop_config.json` stdio server example
- notes that `ANTHROPIC_BASE_URL` proxy routing is for Claude Code/API clients that honor base URL settings
- updates the proxy docs so "any client" means compatible API clients, not desktop apps without a configurable API base URL
- removes a stale code comment that grouped Claude Desktop with Claude Code's legacy config path

Checks run locally:

- `npx fumadocs-mdx` from `docs/`
- `npx next typegen` from `docs/`
- `python -m ruff check headroom/mcp_registry/claude.py`
- `python -m pytest tests/test_mcp_registry/test_claude_registrar.py -q --basetemp .pytest-tmp/claude-desktop-docs`
- `git diff --check`
