### PR TITLE
docs: align contribution templates with review gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,13 +10,24 @@ assignees: ''
 
 A clear and concise description of what the bug is.
 
-## To Reproduce
+## Environment
+
+- **Headroom version**: (run `python -c "import headroom; print(headroom.__version__)"`)
+- **Python version**: (run `python --version`)
+- **OS**: (e.g., macOS 14.0, Ubuntu 22.04, Windows 11)
+- **Install mode**: (pip, pipx, Docker, native wrapper, editable checkout)
+- **Client / wrapper**: (e.g., Claude Code, Codex, Cursor, Copilot CLI, direct SDK)
+- **LLM Provider**: (e.g., OpenAI, Anthropic, Bedrock, Copilot subscription)
+
+## Reproduction
 
 Steps to reproduce the behavior:
 
 1. Install headroom with '...'
 2. Run this code '...'
 3. See error
+
+Please include the smallest command, script, request body, config, or log snippet that still reproduces the issue.
 
 ## Expected Behavior
 
@@ -41,12 +52,14 @@ from headroom import HeadroomClient
 Paste any error messages or stack traces here
 ```
 
-## Environment
+## Compatibility Notes
 
-- **Headroom version**: (run `python -c "import headroom; print(headroom.__version__)"`)
-- **Python version**: (run `python --version`)
-- **OS**: (e.g., macOS 14.0, Ubuntu 22.04, Windows 11)
-- **LLM Provider**: (e.g., OpenAI, Anthropic)
+- Does this happen only on a specific OS, shell, provider, model, install mode, wrapper, Docker/native mode, or Python version?
+- Did this work in an older Headroom version?
+
+## Regression Test Idea
+
+If you know where this could be covered, mention the narrowest useful test layer: unit, integration, e2e, docs example, or manual reproduction.
 
 ## Additional Context
 

--- a/.github/ISSUE_TEMPLATE/dependency_change.md
+++ b/.github/ISSUE_TEMPLATE/dependency_change.md
@@ -1,0 +1,44 @@
+---
+name: Dependency or Package Change
+about: Propose adding, removing, or changing a package, lockfile, image, binary, or optional extra
+title: '[DEPENDENCY] '
+labels: enhancement
+assignees: ''
+---
+
+## Change
+
+What package, lockfile, binary, Docker base image, toolchain, or optional extra would change?
+
+## Reason
+
+Why is this needed now?
+
+- [ ] Bug fix
+- [ ] Security patch
+- [ ] Compatibility
+- [ ] Required new functionality
+- [ ] Maintenance / packaging
+
+## Surface
+
+- Runtime / dev-only / docs-only / Docker-only / optional extra:
+- Direct dependency or transitive dependency:
+- Native code, binary download, install-time network, or runtime network:
+- Platforms affected:
+
+## Alternatives Considered
+
+Can this be done with an existing dependency, standard library code, a smaller package, or documentation instead?
+
+## Supply-chain Notes
+
+- Maintainer / publisher:
+- Release activity:
+- License:
+- Known vulnerabilities or advisories checked:
+- Transitive dependency impact:
+
+## Validation Plan
+
+What tests, import checks, install checks, Docker/native wrapper checks, or security tooling should run before merge?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -27,6 +27,43 @@ Explain your use case and why this feature would be valuable:
 
 Describe any alternative solutions or features you've considered.
 
+## Proposed Surface
+
+What would this change expose?
+
+- Public API:
+- CLI flags:
+- Config / env vars:
+- File formats:
+- Network behavior:
+- Telemetry / logging / metrics:
+
+## User Stories
+
+Use Given / When / Then if possible.
+
+- Given ...
+- When ...
+- Then ...
+
+## Failure Modes
+
+What should happen when the provider, network, filesystem, auth, subprocess, Docker runtime, or optional dependency is unavailable?
+
+## Security and Privacy
+
+Does this touch prompts, logs, credentials, telemetry, local files, network routing, or dependencies?
+
+## Core vs Extension
+
+Why should this live in core Headroom instead of a plugin, provider adapter, optional extra, docs recipe, or external integration package?
+
+## Test and Docs Plan
+
+- Tests needed:
+- E2E/manual checks needed:
+- Docs or examples needed:
+
 ## Example API (Optional)
 
 If you have ideas about how the API should look:

--- a/.github/ISSUE_TEMPLATE/process_governance.md
+++ b/.github/ISSUE_TEMPLATE/process_governance.md
@@ -1,0 +1,33 @@
+---
+name: Process or Governance Proposal
+about: Suggest a change to contribution process, review policy, release process, labels, or CI gates
+title: '[PROCESS] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What maintainer or contributor pain does this solve?
+
+## Proposed Change
+
+What should change in docs, templates, labels, CI, release flow, or review policy?
+
+## Smallest Useful Version
+
+What is the lightest version that would help without blocking good contributions?
+
+## Tradeoffs
+
+- What extra work does this add for contributors?
+- What extra work does it remove for maintainers?
+- What could it accidentally block?
+
+## Automation
+
+Should this stay as guidance, or should any part be enforced by CI, labels, CODEOWNERS, or templates?
+
+## Rollback
+
+How would we undo or soften this if it creates too much friction?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,56 +1,77 @@
-## Description
+## Summary
 
-Brief description of changes and motivation.
+What changed, and why?
 
 Fixes #(issue number)
 
-## Type of Change
+## Type
 
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Documentation update
-- [ ] Performance improvement
-- [ ] Code refactoring (no functional changes)
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Tests / CI
+- [ ] Dependency / packaging
+- [ ] Refactor tied to a concrete fix
 
-## Changes Made
+## Scope and risk
 
-- Change 1
-- Change 2
-- Change 3
+- User-facing behavior changed: yes / no
+- Public API, CLI flag, config, env var, file format, or network behavior changed: yes / no
+- Provider / wrapper / installer / Docker behavior changed: yes / no
+- Security, privacy, telemetry, auth, or dependency surface changed: yes / no
 
-## Testing
+Notes:
 
-Describe the tests you ran to verify your changes:
+## Reproduction / spec
 
-- [ ] Unit tests pass (`pytest`)
-- [ ] Linting passes (`ruff check .`)
-- [ ] Type checking passes (`mypy headroom`)
-- [ ] New tests added for new functionality
-- [ ] Manual testing performed
+For bug fixes:
 
-## Test Output
+- Broken behavior before this PR:
+- Minimal repro or failing test:
+- Regression test added:
+
+For features:
+
+- Linked feature request or spec:
+- User story / expected flow:
+- Important failure mode covered:
+- Why this belongs in core rather than a plugin, docs recipe, or provider-specific extension:
+
+For dependency or package changes:
+
+- Why the change is needed:
+- Alternatives considered:
+- Runtime/dev/docs/optional-extra surface:
+- Supply-chain notes (maintainer, activity, license, native code, known advisories):
+
+## Real behavior proof
+
+Unit tests are useful, but please also show the behavior you actually checked.
+
+- Setup tested on:
+- Commands or steps run after the patch:
+- Observed result:
+- What was not tested:
+
+## Tests
+
+- [ ] Targeted tests pass
+- [ ] Relevant integration/e2e checks pass, or not practical and explained above
+- [ ] `ruff check .` for Python changes, or not applicable
+- [ ] `ruff format .` for Python changes, or not applicable
+- [ ] Docs/type checks updated or not applicable
+
+Paste the useful output:
+
+```text
 
 ```
-# Paste relevant test output here
-pytest -v tests/test_your_feature.py
-```
 
-## Checklist
+## Docs and release notes
 
-- [ ] My code follows the project's style guidelines
-- [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] I have updated the CHANGELOG.md if applicable
+- [ ] Docs, CLI help, examples, or migration notes updated where needed
+- [ ] `CHANGELOG.md` updated for user-facing changes, or not applicable
 
-## Screenshots (if applicable)
+## Reviewer notes
 
-Add screenshots to help explain your changes.
-
-## Additional Notes
-
-Any additional information that reviewers should know.
+Anything reviewers should look at first, known tradeoffs, or follow-up work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,13 @@ A human maintainer reviews every dep change. PRs that add or bump a package must
 
 **Review:** CI green, one maintainer review, coverage held/improved.
 
+## Process and automation changes
+
+Review gates start as templates and reviewer guidance. If you want to add a hard CI check,
+label rule, CODEOWNERS rule, dependency-diff gate, or required PR-body validation, open a
+process/governance issue first and describe the smallest useful version, expected maintainer
+time saved, contributor friction added, and rollback plan.
+
 ## Development setup
 
 ```bash


### PR DESCRIPTION
﻿Closes #650.

This takes the first, low-friction step from the governance proposal: make the expected evidence visible in the templates contributors already touch.

Changes:

- refreshes the PR template around scope/risk, reproduction/spec, real behavior proof, dependency notes, tests, docs, and reviewer notes
- expands the bug template with install/client/provider details, minimal repro guidance, compatibility notes, and a regression-test prompt
- expands the feature template with proposed surface, user stories, failure modes, security/privacy, core-vs-extension, and test/docs plan
- adds dedicated issue templates for dependency/package changes and process/governance proposals
- adds a short CONTRIBUTING note that hard automation or label/CODEOWNERS gates should start as a process issue first

I kept this deliberately template-first. The issue lists possible automation, but adding hard CI checks before maintainers tune the policy could create noise. This gives reviewers better input immediately and leaves stricter enforcement as an explicit follow-up.

Checks run locally:

- `git diff --check`
- small front matter validation over `.github/ISSUE_TEMPLATE/*.md`
