### PR TITLE
feat(proxy): support upstream endpoint path overrides

### DIFF
--- a/docs/content/docs/proxy.mdx
+++ b/docs/content/docs/proxy.mdx
@@ -44,6 +44,9 @@ Telemetry is enabled by default. Opt out with `HEADROOM_TELEMETRY=off` or `--no-
 | `--openai-api-url` | `https://api.openai.com` | Custom OpenAI API URL |
 | `--anthropic-api-url` | Anthropic default | Custom Anthropic API URL |
 | `--gemini-api-url` | Gemini default | Custom Gemini API URL |
+| `--openai-chat-path` | `/v1/chat/completions` | Upstream path for inbound OpenAI chat requests |
+| `--openai-responses-path` | `/v1/responses` | Upstream path for inbound OpenAI Responses requests |
+| `--anthropic-messages-path` | `/v1/messages` | Upstream path for inbound Anthropic Messages requests |
 | `--backend` | `anthropic` | Backend: `anthropic`, `bedrock`, `openrouter`, `anyllm`, or `litellm-<provider>` |
 | `--no-telemetry` | `false` | Disable anonymous telemetry |
 | `--stateless` | `false` | Disable filesystem writes and keep runtime state in memory |
@@ -258,6 +261,16 @@ export ANTHROPIC_TARGET_API_URL=https://litellm.company.internal
 
 headroom proxy
 ```
+
+If the upstream proxy does not expose OpenAI-compatible routes under `/v1`, keep the client pointed at Headroom's normal paths and override only the upstream target path:
+
+```bash
+headroom proxy \
+  --openai-api-url https://proxy.company.internal \
+  --openai-chat-path /litellm/chat/completions
+```
+
+This makes clients call `http://localhost:8787/v1/chat/completions` while Headroom forwards to `https://proxy.company.internal/litellm/chat/completions`. The same pattern is available for `HEADROOM_OPENAI_RESPONSES_PATH` and `HEADROOM_ANTHROPIC_MESSAGES_PATH`.
 
 ## Production deployment
 

--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -396,6 +396,33 @@ def _selected_context_tool() -> str:
     help="Custom OpenAI API URL for passthrough endpoints (env: OPENAI_TARGET_API_URL)",
 )
 @click.option(
+    "--anthropic-messages-path",
+    default=None,
+    envvar="HEADROOM_ANTHROPIC_MESSAGES_PATH",
+    help=(
+        "Upstream path for inbound /v1/messages requests "
+        "(default: /v1/messages, env: HEADROOM_ANTHROPIC_MESSAGES_PATH)"
+    ),
+)
+@click.option(
+    "--openai-chat-path",
+    default=None,
+    envvar="HEADROOM_OPENAI_CHAT_PATH",
+    help=(
+        "Upstream path for inbound /v1/chat/completions requests "
+        "(default: /v1/chat/completions, env: HEADROOM_OPENAI_CHAT_PATH)"
+    ),
+)
+@click.option(
+    "--openai-responses-path",
+    default=None,
+    envvar="HEADROOM_OPENAI_RESPONSES_PATH",
+    help=(
+        "Upstream path for inbound /v1/responses requests "
+        "(default: /v1/responses, env: HEADROOM_OPENAI_RESPONSES_PATH)"
+    ),
+)
+@click.option(
     "--gemini-api-url",
     default=None,
     help="Custom Gemini API URL for passthrough endpoints (env: GEMINI_TARGET_API_URL)",
@@ -480,6 +507,9 @@ def proxy(
     anyllm_provider: str,
     anthropic_api_url: str | None,
     openai_api_url: str | None,
+    anthropic_messages_path: str | None,
+    openai_chat_path: str | None,
+    openai_responses_path: str | None,
     gemini_api_url: str | None,
     cloudcode_api_url: str | None,
     region: str,
@@ -598,6 +628,9 @@ def proxy(
         openai_api_url=provider_api_overrides.openai,
         gemini_api_url=provider_api_overrides.gemini,
         cloudcode_api_url=provider_api_overrides.cloudcode,
+        anthropic_messages_path=anthropic_messages_path,
+        openai_chat_path=openai_chat_path,
+        openai_responses_path=openai_responses_path,
         mode=effective_mode,
         optimize=not no_optimize,
         cache_enabled=not no_cache,
@@ -693,6 +726,9 @@ def proxy(
     anthropic_url = provider_api_targets.anthropic
     openai_url = provider_api_targets.openai
     cloudcode_url = provider_api_targets.cloudcode
+    anthropic_messages_url = f"{anthropic_url}{config.anthropic_messages_path}"
+    openai_chat_url = f"{openai_url}{config.openai_chat_path}"
+    openai_responses_url = f"{openai_url}{config.openai_responses_path}"
     backend_section = ""
 
     if config.backend == "anyllm" or config.backend.startswith("anyllm-"):
@@ -811,9 +847,9 @@ Starting proxy server...
 {stateless_line}{telemetry_line}
 {backend_section}
 Routing:
-  /v1/messages                    → {anthropic_url}
-  /v1/chat/completions            → {openai_url}
-  /v1/responses                   → {openai_url}  (HTTP + WebSocket)
+  /v1/messages                    → {anthropic_messages_url}
+  /v1/chat/completions            → {openai_chat_url}
+  /v1/responses                   → {openai_responses_url}  (HTTP + WebSocket)
   /v1internal:streamGenerateContent → {cloudcode_url}
 
 Usage:

--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -27,6 +27,14 @@ def _api_target(proxy: Any, provider_name: str) -> str:
     return cast(str, getattr(proxy, legacy_attr, proxy.provider_runtime.api_target(provider_name)))
 
 
+def _endpoint_path(proxy: Any, attr_name: str, default: str) -> str:
+    return cast(str, getattr(proxy.config, attr_name, default) or default)
+
+
+def _join_endpoint_subpath(endpoint_path: str, sub_path: str) -> str:
+    return f"{endpoint_path.rstrip('/')}/{sub_path.lstrip('/')}"
+
+
 def _select_passthrough_base_url(proxy: Any, headers: dict[str, str]) -> str:
     # Codex CLI subscription mode hits a wide surface under
     # `/backend-api/*` (rate-limit polling, agent identity, JWT
@@ -385,7 +393,11 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
         if is_chatgpt_auth:
             url = f"https://chatgpt.com/backend-api/codex/responses/{sub_path}"
         else:
-            url = f"{_api_target(proxy, 'openai')}/v1/responses/{sub_path}"
+            upstream_path = _join_endpoint_subpath(
+                _endpoint_path(proxy, "openai_responses_path", "/v1/responses"),
+                sub_path,
+            )
+            url = f"{_api_target(proxy, 'openai')}{upstream_path}"
 
         if request.url.query:
             url = f"{url}?{request.url.query}"

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1812,7 +1812,8 @@ class AnthropicHandlerMixin:
                     )
 
             # Direct Anthropic API
-            url = f"{self.ANTHROPIC_API_URL}/v1/messages"
+            messages_path = getattr(self.config, "anthropic_messages_path", "/v1/messages")
+            url = f"{self.ANTHROPIC_API_URL}{messages_path}"
 
             try:
                 if stream:

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -2162,8 +2162,11 @@ class OpenAIHandlerMixin:
                     },
                 )
 
-        # Direct OpenAI API (no backend configured)
-        url = build_copilot_upstream_url(self.OPENAI_API_URL, "/v1/chat/completions")
+        # Direct OpenAI-compatible API (no translated backend configured).
+        url = build_copilot_upstream_url(
+            self.OPENAI_API_URL,
+            getattr(self.config, "openai_chat_path", "/v1/chat/completions"),
+        )
 
         try:
             if stream:
@@ -2892,7 +2895,10 @@ class OpenAIHandlerMixin:
         if is_chatgpt_auth:
             url = "https://chatgpt.com/backend-api/codex/responses"
         else:
-            url = build_copilot_upstream_url(self.OPENAI_API_URL, "/v1/responses")
+            url = build_copilot_upstream_url(
+                self.OPENAI_API_URL,
+                getattr(self.config, "openai_responses_path", "/v1/responses"),
+            )
 
         # The standalone Rust proxy has native /v1/responses item handling,
         # but the default CLI runtime is this Python proxy. Compress the
@@ -3435,7 +3441,10 @@ class OpenAIHandlerMixin:
             # API key auth → route to configured OpenAI API URL
             base = self.OPENAI_API_URL
             ws_base = base.replace("https://", "wss://").replace("http://", "ws://")
-            upstream_url = build_copilot_upstream_url(ws_base, "/v1/responses")
+            upstream_url = build_copilot_upstream_url(
+                ws_base,
+                getattr(self.config, "openai_responses_path", "/v1/responses"),
+            )
 
         capture_codex_wire_debug(
             "ws_upstream_handshake",
@@ -5450,7 +5459,10 @@ class OpenAIHandlerMixin:
         if "chatgpt-account-id" in _lower:
             http_url = "https://chatgpt.com/backend-api/codex/responses"
         else:
-            http_url = build_copilot_upstream_url(self.OPENAI_API_URL, "/v1/responses")
+            http_url = build_copilot_upstream_url(
+                self.OPENAI_API_URL,
+                getattr(self.config, "openai_responses_path", "/v1/responses"),
+            )
 
         # Build HTTP body from the WS response.create payload.
         # WS messages use {"type": "response.create", "response": {...}} wrapper.

--- a/headroom/proxy/models.py
+++ b/headroom/proxy/models.py
@@ -18,6 +18,19 @@ from headroom.providers.registry import ProviderApiOverrides
 # =============================================================================
 
 
+def _normalize_endpoint_path(value: str | None, *, default: str) -> str:
+    """Normalize an upstream endpoint path override."""
+    if value is None:
+        return default
+
+    path = str(value).strip()
+    if not path:
+        return default
+    if "://" in path:
+        raise ValueError("endpoint path overrides must be paths, not full URLs")
+    return path if path.startswith("/") else f"/{path}"
+
+
 @dataclass
 class RequestLog:
     """Complete log of a single request."""
@@ -96,6 +109,9 @@ class ProxyConfig:
     openai_api_url: str | None = None  # Custom OpenAI API URL override
     gemini_api_url: str | None = None  # Custom Gemini API URL override
     cloudcode_api_url: str | None = None  # Custom Cloud Code Assist API URL override
+    anthropic_messages_path: str | None = "/v1/messages"
+    openai_chat_path: str | None = "/v1/chat/completions"
+    openai_responses_path: str | None = "/v1/responses"
 
     # Backend: "anthropic" (direct API), "litellm-*" (via LiteLLM), or "anyllm" (via any-llm)
     backend: str = "anthropic"
@@ -314,6 +330,18 @@ class ProxyConfig:
     def __post_init__(self, smart_routing: bool | None = None) -> None:
         if self.retry_enabled and self.retry_max_attempts < 1:
             raise ValueError("retry_max_attempts must be >= 1 when retry_enabled=True")
+        self.anthropic_messages_path = _normalize_endpoint_path(
+            self.anthropic_messages_path,
+            default="/v1/messages",
+        )
+        self.openai_chat_path = _normalize_endpoint_path(
+            self.openai_chat_path,
+            default="/v1/chat/completions",
+        )
+        self.openai_responses_path = _normalize_endpoint_path(
+            self.openai_responses_path,
+            default="/v1/responses",
+        )
 
     @property
     def provider_api_overrides(self) -> ProviderApiOverrides:

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2969,6 +2969,9 @@ def _proxy_config_from_env() -> ProxyConfig:
         port=_get_env_int("HEADROOM_PORT", 8787),
         openai_api_url=os.environ.get("OPENAI_TARGET_API_URL"),
         anthropic_api_url=os.environ.get("ANTHROPIC_TARGET_API_URL"),
+        anthropic_messages_path=os.environ.get("HEADROOM_ANTHROPIC_MESSAGES_PATH"),
+        openai_chat_path=os.environ.get("HEADROOM_OPENAI_CHAT_PATH"),
+        openai_responses_path=os.environ.get("HEADROOM_OPENAI_RESPONSES_PATH"),
         backend=_get_env_str("HEADROOM_BACKEND", "anthropic"),
         bedrock_region=_get_env_str("HEADROOM_BEDROCK_REGION", "us-west-2"),
         bedrock_profile=os.environ.get("AWS_PROFILE"),
@@ -3226,6 +3229,21 @@ if __name__ == "__main__":
         "--anthropic-api-url",
         help=f"Custom Anthropic API URL (default: {DEFAULT_ANTHROPIC_API_URL})",
     )
+    parser.add_argument(
+        "--anthropic-messages-path",
+        help="Upstream path for inbound /v1/messages requests (default: /v1/messages)",
+    )
+    parser.add_argument(
+        "--openai-chat-path",
+        help=(
+            "Upstream path for inbound /v1/chat/completions requests "
+            "(default: /v1/chat/completions)"
+        ),
+    )
+    parser.add_argument(
+        "--openai-responses-path",
+        help="Upstream path for inbound /v1/responses requests (default: /v1/responses)",
+    )
 
     # Backend (anthropic direct, bedrock, openrouter, anyllm, or litellm-<provider>)
     parser.add_argument(
@@ -3377,6 +3395,15 @@ if __name__ == "__main__":
         port=_get_env_int("HEADROOM_PORT", args.port),
         openai_api_url=_get_env_str("OPENAI_TARGET_API_URL", args.openai_api_url),
         anthropic_api_url=_get_env_str("ANTHROPIC_TARGET_API_URL", args.anthropic_api_url),
+        anthropic_messages_path=_get_env_str(
+            "HEADROOM_ANTHROPIC_MESSAGES_PATH",
+            args.anthropic_messages_path,
+        ),
+        openai_chat_path=_get_env_str("HEADROOM_OPENAI_CHAT_PATH", args.openai_chat_path),
+        openai_responses_path=_get_env_str(
+            "HEADROOM_OPENAI_RESPONSES_PATH",
+            args.openai_responses_path,
+        ),
         # Backend settings
         backend=_get_env_str("HEADROOM_BACKEND", args.backend),  # type: ignore[arg-type]
         bedrock_region=_get_env_str("HEADROOM_BEDROCK_REGION", args.bedrock_region),

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -204,6 +204,60 @@ class TestCLIProxyEnvVars:
         assert result.exit_code == 0, result.output
         assert captured_config["config"].openai_api_url == "http://from-cli:4000"
 
+    def test_endpoint_path_overrides_from_env(self, runner):
+        """Endpoint path override env vars should be passed to ProxyConfig."""
+        captured_config = {}
+
+        def mock_run_server(config, **kwargs):
+            captured_config["config"] = config
+
+        with patch("headroom.proxy.server.run_server", mock_run_server):
+            result = runner.invoke(
+                main,
+                ["proxy"],
+                env={
+                    "HEADROOM_ANTHROPIC_MESSAGES_PATH": "anthropic/messages",
+                    "HEADROOM_OPENAI_CHAT_PATH": "/litellm/chat/completions",
+                    "HEADROOM_OPENAI_RESPONSES_PATH": "/litellm/responses",
+                },
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        config = captured_config["config"]
+        assert config.anthropic_messages_path == "/anthropic/messages"
+        assert config.openai_chat_path == "/litellm/chat/completions"
+        assert config.openai_responses_path == "/litellm/responses"
+
+    def test_endpoint_path_cli_flags_override_env_vars(self, runner):
+        """Endpoint path CLI flags should win over env vars."""
+        captured_config = {}
+
+        def mock_run_server(config, **kwargs):
+            captured_config["config"] = config
+
+        with patch("headroom.proxy.server.run_server", mock_run_server):
+            result = runner.invoke(
+                main,
+                [
+                    "proxy",
+                    "--openai-chat-path",
+                    "/cli/chat/completions",
+                    "--openai-responses-path",
+                    "/cli/responses",
+                ],
+                env={
+                    "HEADROOM_OPENAI_CHAT_PATH": "/env/chat/completions",
+                    "HEADROOM_OPENAI_RESPONSES_PATH": "/env/responses",
+                },
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        config = captured_config["config"]
+        assert config.openai_chat_path == "/cli/chat/completions"
+        assert config.openai_responses_path == "/cli/responses"
+
     def test_cli_flag_overrides_env_var(self, runner):
         """CLI flag should take precedence over env var."""
         captured_config = {}

--- a/tests/test_openai_codex_routing.py
+++ b/tests/test_openai_codex_routing.py
@@ -134,6 +134,7 @@ class _DummyOpenAIHandler(OpenAIHandlerMixin):
             retry_base_delay_ms=10,
             retry_max_delay_ms=50,
             connect_timeout_seconds=10,
+            openai_responses_path="/v1/responses",
         )
         self.usage_reporter = None
         self.openai_provider = SimpleNamespace(get_context_limit=lambda model: 128_000)
@@ -268,6 +269,27 @@ def test_handle_openai_responses_routes_api_key_auth_direct_to_openai(monkeypatc
     method, url, headers, body = handler.captured_request
     assert method == "POST"
     assert url == "https://api.openai.com/v1/responses"
+    assert headers.get("ChatGPT-Account-ID") is None
+    assert body["input"] == "hello"
+    assert response.status_code == 200
+
+
+def test_handle_openai_responses_api_key_auth_uses_configured_upstream_path(monkeypatch):
+    request = _build_request(
+        {"model": "gpt-4o-mini", "input": "hello"},
+        {"Authorization": "Bearer sk-test"},
+    )
+    handler = _DummyOpenAIHandler()
+    handler.config.openai_responses_path = "/litellm/responses"
+
+    monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
+
+    response = anyio.run(handler.handle_openai_responses, request)
+
+    assert handler.captured_request is not None
+    method, url, headers, body = handler.captured_request
+    assert method == "POST"
+    assert url == "https://api.openai.com/litellm/responses"
     assert headers.get("ChatGPT-Account-ID") is None
     assert body["input"] == "hello"
     assert response.status_code == 200

--- a/tests/test_provider_proxy_routes.py
+++ b/tests/test_provider_proxy_routes.py
@@ -285,6 +285,42 @@ def test_openai_response_subpath_passthrough_uses_openai_target() -> None:
     assert headers["authorization"] == "Bearer sk-proj-test"
 
 
+def test_openai_response_subpath_passthrough_uses_configured_responses_path() -> None:
+    class FakeAsyncClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str]] = []
+
+        async def request(self, method, url, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls.append((method, url))
+            return httpx.Response(200, json={"url": url})
+
+        async def aclose(self) -> None:
+            return None
+
+    app = create_app(
+        ProxyConfig(
+            optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            openai_api_url="https://api.openai.test",
+            openai_responses_path="/litellm/responses",
+        )
+    )
+
+    with TestClient(app) as client:
+        fake = FakeAsyncClient()
+        client.app.state.proxy.http_client = fake
+        response = client.delete(
+            "/v1/responses/items/resp_123?trace=7",
+            headers={"Authorization": "Bearer sk-proj-test"},
+        )
+
+    assert response.status_code == 200
+    assert fake.calls == [
+        ("DELETE", "https://api.openai.test/litellm/responses/items/resp_123?trace=7")
+    ]
+
+
 def test_openai_response_subpath_aliases_and_chatgpt_auth_use_expected_targets(monkeypatch) -> None:
     monkeypatch.setattr(
         "headroom.providers.proxy_routes._resolve_codex_routing_headers",

--- a/tests/test_proxy_upstream_path_overrides.py
+++ b/tests/test_proxy_upstream_path_overrides.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from headroom.proxy.server import ProxyConfig, create_app
+
+
+class _DummyTokenizer:
+    def count_messages(self, messages):
+        return len(messages)
+
+
+def _config(**overrides) -> ProxyConfig:
+    return ProxyConfig(
+        optimize=False,
+        image_optimize=False,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        log_requests=False,
+        ccr_inject_tool=False,
+        ccr_handle_responses=False,
+        ccr_context_tracking=False,
+        openai_api_url="https://openai-upstream.test",
+        anthropic_api_url="https://anthropic-upstream.test",
+        **overrides,
+    )
+
+
+def test_proxy_config_normalizes_endpoint_path_overrides() -> None:
+    config = _config(
+        anthropic_messages_path="anthropic/messages",
+        openai_chat_path="litellm/chat/completions",
+        openai_responses_path="/custom/responses",
+    )
+
+    assert config.anthropic_messages_path == "/anthropic/messages"
+    assert config.openai_chat_path == "/litellm/chat/completions"
+    assert config.openai_responses_path == "/custom/responses"
+
+
+def test_proxy_config_rejects_full_url_endpoint_path_overrides() -> None:
+    with pytest.raises(ValueError, match="paths, not full URLs"):
+        _config(openai_chat_path="https://proxy.example/v1/chat/completions")
+
+
+def test_proxy_config_from_env_reads_endpoint_path_overrides(monkeypatch) -> None:
+    from headroom.proxy.server import _MULTI_WORKER_CONFIG_ENV, _proxy_config_from_env
+
+    monkeypatch.delenv(_MULTI_WORKER_CONFIG_ENV, raising=False)
+    monkeypatch.setenv("HEADROOM_ANTHROPIC_MESSAGES_PATH", "anthropic/messages")
+    monkeypatch.setenv("HEADROOM_OPENAI_CHAT_PATH", "/litellm/chat/completions")
+    monkeypatch.setenv("HEADROOM_OPENAI_RESPONSES_PATH", "/litellm/responses")
+
+    config = _proxy_config_from_env()
+
+    assert config.anthropic_messages_path == "/anthropic/messages"
+    assert config.openai_chat_path == "/litellm/chat/completions"
+    assert config.openai_responses_path == "/litellm/responses"
+
+
+def test_openai_chat_forwards_to_configured_upstream_path(monkeypatch) -> None:
+    seen: dict[str, str] = {}
+    app = create_app(_config(openai_chat_path="/litellm/chat/completions"))
+
+    with TestClient(app) as client:
+        proxy = client.app.state.proxy
+        monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
+
+        async def _fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
+            seen["url"] = url
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl_1",
+                    "object": "chat.completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+            )
+
+        proxy._retry_request = _fake_retry
+
+        response = client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer sk-test"},
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert response.status_code == 200
+    assert seen["url"] == "https://openai-upstream.test/litellm/chat/completions"
+
+
+def test_openai_responses_forwards_to_configured_upstream_path(monkeypatch) -> None:
+    seen: dict[str, str] = {}
+    app = create_app(_config(openai_responses_path="/litellm/responses"))
+
+    with TestClient(app) as client:
+        proxy = client.app.state.proxy
+        monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
+
+        async def _fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
+            seen["url"] = url
+            return httpx.Response(
+                200,
+                json={
+                    "id": "resp_1",
+                    "object": "response",
+                    "output": [],
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            )
+
+        proxy._retry_request = _fake_retry
+
+        response = client.post(
+            "/v1/responses",
+            headers={"Authorization": "Bearer sk-test"},
+            json={"model": "gpt-4o-mini", "input": "hello"},
+        )
+
+    assert response.status_code == 200
+    assert seen["url"] == "https://openai-upstream.test/litellm/responses"
+
+
+def test_anthropic_messages_forwards_to_configured_upstream_path(monkeypatch) -> None:
+    seen: dict[str, str] = {}
+    app = create_app(_config(anthropic_messages_path="/proxy/anthropic/messages"))
+
+    with TestClient(app) as client:
+        proxy = client.app.state.proxy
+        monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
+
+        async def _fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
+            seen["url"] = url
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            )
+
+        proxy._retry_request = _fake_retry
+
+        response = client.post(
+            "/v1/messages",
+            headers={"x-api-key": "sk-ant-test", "anthropic-version": "2023-06-01"},
+            json={
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 128,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert response.status_code == 200
+    assert seen["url"] == "https://anthropic-upstream.test/proxy/anthropic/messages"


### PR DESCRIPTION
Fixes #352.

This adds endpoint path overrides for the upstream side of the proxy. Clients still call Headroom's normal routes, but Headroom can now forward those requests to a different path on the configured upstream base URL.

What changed:
- added `--anthropic-messages-path`, `--openai-chat-path`, and `--openai-responses-path`
- wired matching `HEADROOM_*` env vars through the Click CLI and the direct server entrypoint
- used the configured paths for Anthropic Messages, OpenAI chat completions, OpenAI Responses HTTP, WebSocket, WS-to-HTTP fallback, and Responses subpath passthrough
- documented the LiteLLM-style proxy case where upstream chat lives outside `/v1`

I kept ChatGPT/Codex subscription routing on the existing `chatgpt.com/backend-api/codex/responses` target. These overrides only affect regular API-key / OpenAI-compatible upstream routing.

Checks run:
- `python -m pytest tests/test_proxy_upstream_path_overrides.py tests/test_provider_proxy_routes.py::test_openai_response_subpath_passthrough_uses_configured_responses_path tests/test_openai_codex_routing.py::test_handle_openai_responses_api_key_auth_uses_configured_upstream_path tests/test_cli_proxy_env.py::TestCLIProxyEnvVars::test_endpoint_path_overrides_from_env tests/test_cli_proxy_env.py::TestCLIProxyEnvVars::test_endpoint_path_cli_flags_override_env_vars -q`
- `python -m pytest tests/test_openai_codex_routing.py tests/test_provider_proxy_routes.py tests/test_cli_proxy_env.py -q`
- `python -m ruff check headroom/proxy/models.py headroom/providers/proxy_routes.py headroom/cli/proxy.py headroom/proxy/server.py headroom/proxy/handlers/anthropic.py headroom/proxy/handlers/openai.py tests/test_proxy_upstream_path_overrides.py tests/test_cli_proxy_env.py tests/test_openai_codex_routing.py tests/test_provider_proxy_routes.py`
- `python -m ruff format --check headroom/proxy/models.py headroom/providers/proxy_routes.py headroom/cli/proxy.py headroom/proxy/server.py headroom/proxy/handlers/anthropic.py headroom/proxy/handlers/openai.py tests/test_proxy_upstream_path_overrides.py tests/test_cli_proxy_env.py tests/test_openai_codex_routing.py tests/test_provider_proxy_routes.py`
- `python -m mypy headroom/proxy/models.py headroom/providers/proxy_routes.py headroom/cli/proxy.py headroom/proxy/server.py --ignore-missing-imports`
- `npx fumadocs-mdx` in `docs/`
- `npx next typegen` in `docs/`
- `git diff --check`