### PR TITLE
fix(openclaw): declare retrieval tool contract

### DIFF
--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,11 @@
 {
   "id": "headroom",
   "kind": "context-engine",
+  "contracts": {
+    "tools": [
+      "headroom_retrieve"
+    ]
+  },
   "uiHints": {
     "proxyUrl": {
       "label": "Proxy URL",

--- a/plugins/openclaw/package-lock.json
+++ b/plugins/openclaw/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "headroom-openclaw",
-  "version": "0.1.1",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-openclaw",
-      "version": "0.1.1",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "headroom-ai": "^0.1.0"
+        "headroom-ai": "^0.22.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1609,9 +1609,9 @@
       }
     },
     "node_modules/headroom-ai": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/headroom-ai/-/headroom-ai-0.1.0.tgz",
-      "integrity": "sha512-SM5i2kptwsO+KnQqpaLThZVx1ZrmobVw5JRXwF5OvnMvhV/3WbwUI+VvXHTwTCvVq+AAyhkhuVcNXod1piAVuQ==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/headroom-ai/-/headroom-ai-0.22.4.tgz",
+      "integrity": "sha512-9a0rgB/jsWe8gs/ggyUwe6E8DYwKAuBvlUml2ApwlUjb5EfJ611X6X+WG0SiXw3nO6sdyV1/+Ah5uw9P7ecnjw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/plugins/openclaw/src/plugin/index.ts
+++ b/plugins/openclaw/src/plugin/index.ts
@@ -80,11 +80,14 @@ export default function headroomPlugin(api: any) {
   api.registerContextEngine("headroom", () => engine);
 
   // Register CCR retrieval tool (active once proxy is running)
-  api.registerTool((ctx: any) => {
-    const activeProxyUrl = engine.getProxyUrl() ?? proxyUrl;
-    if (!activeProxyUrl) return null;
-    return createHeadroomRetrieveTool({ proxyUrl: activeProxyUrl });
-  });
+  api.registerTool(
+    (ctx: any) => {
+      const activeProxyUrl = engine.getProxyUrl() ?? proxyUrl;
+      if (!activeProxyUrl) return null;
+      return createHeadroomRetrieveTool({ proxyUrl: activeProxyUrl });
+    },
+    { name: "headroom_retrieve" },
+  );
 
   api.on("gateway_start", async () => {
     await ensureGatewayRouting();

--- a/plugins/openclaw/test/plugin-contract.test.ts
+++ b/plugins/openclaw/test/plugin-contract.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("openclaw plugin manifest contracts", () => {
+  it("declares the Headroom retrieval tool registered at runtime", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    );
+
+    expect(manifest.contracts?.tools).toContain("headroom_retrieve");
+  });
+});

--- a/plugins/openclaw/test/plugin-runtime-routing.test.ts
+++ b/plugins/openclaw/test/plugin-runtime-routing.test.ts
@@ -102,6 +102,9 @@ describe("headroomPlugin runtime routing", () => {
 
     expect(mocked.ensureProxyUrl).not.toHaveBeenCalled();
     expect(mocked.ensureProxyStarted).toHaveBeenCalledTimes(1);
+    expect(api.registerTool).toHaveBeenCalledWith(expect.any(Function), {
+      name: "headroom_retrieve",
+    });
     expect(writeConfigFile).not.toHaveBeenCalled();
     expect(loadConfig).not.toHaveBeenCalled();
     expect(api.config.models.providers["openai-codex"]).toBeUndefined();


### PR DESCRIPTION
Addresses the OpenClaw tool-contract part of #419.

OpenClaw 2026.5+ validates plugin-owned tools against `openclaw.plugin.json` before accepting runtime tool registrations. The Headroom OpenClaw plugin registered `headroom_retrieve`, but the manifest did not declare `contracts.tools`, and the factory registration did not pass a static tool name. That matches the warning reported in #419.

What changed:
- declares `headroom_retrieve` in `plugins/openclaw/openclaw.plugin.json`
- registers the retrieval tool factory with `{ name: headroom_retrieve }`
- adds regression coverage for the manifest contract and runtime registration name
- syncs the OpenClaw plugin lockfile with its current `package.json` so `npm ci` works again

This does not claim to solve every OpenClaw failure mode from #419. It is the focused contract/registration fix; proxy startup and long-run robustness can stay separate.

Checks run in `plugins/openclaw`:
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build`

Repo check:
- `git diff --check`