### PR TITLE
Add PHP AST compression support

### DIFF
--- a/headroom/transforms/code_compressor.py
+++ b/headroom/transforms/code_compressor.py
@@ -16,7 +16,7 @@ Supported Languages (Tier 1):
 - Python, JavaScript, TypeScript
 
 Supported Languages (Tier 2):
-- Go, Rust, Java, C, C++
+- Go, Rust, Java, PHP, C, C++
 
 Compression Strategy:
 1. Parse code into AST using tree-sitter
@@ -129,7 +129,7 @@ def _get_parser(language: str) -> Any:
         except Exception as e:
             raise ValueError(
                 f"Language '{language}' is not supported by tree-sitter. "
-                f"Supported: python, javascript, typescript, go, rust, java, c, cpp. "
+                f"Supported: python, javascript, typescript, go, rust, java, php, c, cpp. "
                 f"Error: {e}"
             ) from e
 
@@ -181,6 +181,7 @@ class CodeLanguage(Enum):
     GO = "go"
     RUST = "rust"
     JAVA = "java"
+    PHP = "php"
     C = "c"
     CPP = "cpp"
     UNKNOWN = "unknown"
@@ -294,6 +295,31 @@ _LANG_CONFIGS: dict[CodeLanguage, LangConfig] = {
         uses_colon_after_signature=False,
         package_node="package_declaration",
         detection_hints=("public ", "private ", "protected ", "class ", "interface "),
+    ),
+    CodeLanguage.PHP: LangConfig(
+        import_nodes=frozenset(
+            {
+                "php_tag",
+                "declare_statement",
+                "namespace_definition",
+                "namespace_use_declaration",
+            }
+        ),
+        function_nodes=frozenset({"function_definition", "method_declaration"}),
+        class_nodes=frozenset(
+            {
+                "class_declaration",
+                "interface_declaration",
+                "trait_declaration",
+                "enum_declaration",
+            }
+        ),
+        type_nodes=frozenset(),
+        body_node_types=frozenset({"compound_statement", "declaration_list"}),
+        decorator_node=None,
+        comment_prefix="//",
+        uses_colon_after_signature=False,
+        detection_hints=("<?php", "namespace ", "use ", "function ", "$this->"),
     ),
     CodeLanguage.C: LangConfig(
         import_nodes=frozenset({"preproc_include"}),
@@ -495,6 +521,21 @@ _LANGUAGE_PREFILTER: dict[CodeLanguage, list[re.Pattern[str]]] = {
     CodeLanguage.JAVA: [
         re.compile(r"^\s*(public|private|protected)\s+(class|interface|enum)", re.MULTILINE),
         re.compile(r"^\s*package\s+[\w.]+;", re.MULTILINE),
+    ],
+    CodeLanguage.PHP: [
+        re.compile(r"^\s*<\?php\b", re.MULTILINE),
+        re.compile(r"^\s*declare\s*\(", re.MULTILINE),
+        re.compile(r"^\s*namespace\s+[\w\\]+;", re.MULTILINE),
+        re.compile(r"^\s*use\s+[\w\\]+(?:\s+as\s+\w+)?;", re.MULTILINE),
+        re.compile(
+            r"^\s*(?:final\s+|abstract\s+)?(?:class|interface|trait|enum)\s+\w+",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*(?:public|private|protected)?\s*(?:static\s+)?function\s+\w+\s*\(",
+            re.MULTILINE,
+        ),
+        re.compile(r"\$this->\w+", re.MULTILINE),
     ],
     CodeLanguage.C: [
         re.compile(r"^\s*#include\s*[<\"]", re.MULTILINE),
@@ -1585,11 +1626,24 @@ class CodeAwareCompressor(Transform):
         sig_end = body_start_line - node_start_line
         header_lines = node_lines[:sig_end] if sig_end > 0 else [node_lines[0]]
 
+        body_end_line = body_node.end_point[0]
+        body_lines = code_lines[body_start_line : body_end_line + 1]
+        opening_brace_line = None
+        closing_brace_line = None
+        if not lang_config.uses_colon_after_signature and body_lines:
+            if body_lines[0].strip().startswith("{"):
+                opening_brace_line = body_lines[0]
+            if body_lines[-1].strip().endswith("}"):
+                closing_brace_line = body_lines[-1]
+
         # Process each child of the class body individually
         body_parts: list[str] = []
         processed_ranges: list[tuple[int, int]] = []
 
         for child in body_node.children:
+            if not child.is_named and child.type in {"{", "}", ";", ","}:
+                continue
+
             # Use line-based extraction for children too
             child_start = child.start_point[0]
             child_end = child.end_point[0]
@@ -1636,14 +1690,17 @@ class CodeAwareCompressor(Transform):
 
         # Reconstruct class with proper indentation
         result_parts = list(header_lines)
+        if opening_brace_line is not None and not result_parts[-1].strip().endswith("{"):
+            result_parts.append(opening_brace_line)
         for part in body_parts:
             result_parts.append(part)
 
         # Handle closing brace for brace-delimited languages
-        body_end_line = body_node.end_point[0]
         body_end_rel = body_end_line - node_start_line + 1
         after_lines = node_lines[body_end_rel:]
-        if after_lines:
+        if closing_brace_line is not None:
+            result_parts.append(closing_brace_line)
+        elif after_lines:
             result_parts.extend(after_lines)
         elif not lang_config.uses_colon_after_signature:
             # Ensure closing brace

--- a/headroom/transforms/content_detector.py
+++ b/headroom/transforms/content_detector.py
@@ -95,6 +95,15 @@ _CODE_PATTERNS = {
         re.compile(r"^\s*@\w+"),  # annotations
         re.compile(r"^\s*package\s+[\w.]+;"),
     ],
+    "php": [
+        re.compile(r"^\s*<\?php\b"),
+        re.compile(r"^\s*declare\s*\("),
+        re.compile(r"^\s*namespace\s+[\w\\]+;"),
+        re.compile(r"^\s*use\s+[\w\\]+(?:\s+as\s+\w+)?;"),
+        re.compile(r"^\s*(final\s+|abstract\s+)?(class|interface|trait|enum)\s+\w+"),
+        re.compile(r"^\s*(public|private|protected)?\s*(static\s+)?function\s+\w+\s*\("),
+        re.compile(r"\$this->\w+"),
+    ],
 }
 
 # Log/build output patterns

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -1647,6 +1647,7 @@ class ContentRouter(Transform):
                             "go",
                             "rust",
                             "java",
+                            "php",
                             "c",
                             "cpp",
                         ]

--- a/tests/test_transforms/test_code_compressor.py
+++ b/tests/test_transforms/test_code_compressor.py
@@ -207,6 +207,46 @@ def generate_go_code(n_functions: int = 3) -> str:
     return "\n".join(lines)
 
 
+def generate_php_code() -> str:
+    """Generate PHP code for testing."""
+    return """<?php
+
+declare(strict_types=1);
+
+namespace App\\Service;
+
+use App\\Repository\\OrderRepository;
+use RuntimeException;
+
+final class OrderService
+{
+    public function __construct(private OrderRepository $orders) {}
+
+    public function totalForUser(int $userId): int
+    {
+        $total = 0;
+        foreach ($this->orders->findByUser($userId) as $order) {
+            $total += $order->amount();
+        }
+        if ($total < 0) {
+            throw new RuntimeException('invalid total');
+        }
+        return $total;
+    }
+}
+
+function normalize_order_id(string $id): string
+{
+    $normalized = strtolower($id);
+    $normalized = trim($normalized);
+    if ($normalized === '') {
+        return 'unknown';
+    }
+    return $normalized;
+}
+"""
+
+
 # =============================================================================
 # TestCodeCompressorConfig
 # =============================================================================
@@ -382,6 +422,13 @@ func main() {
         assert lang == CodeLanguage.GO
         assert confidence > 0.3
 
+    def test_detect_php_language(self):
+        """PHP language is detected from code patterns."""
+        lang, confidence = detect_language(generate_php_code())
+
+        assert lang == CodeLanguage.PHP
+        assert confidence > 0.5
+
 
 # =============================================================================
 # TestCodeAwareCompressor
@@ -476,6 +523,12 @@ func main() {
 """
         result = compressor.compress(code)
         assert result.language in (CodeLanguage.GO, CodeLanguage.UNKNOWN)
+
+    def test_compress_auto_detects_php(self, compressor):
+        """PHP code is auto-detected during compression."""
+        result = compressor.compress(generate_php_code())
+
+        assert result.language in (CodeLanguage.PHP, CodeLanguage.UNKNOWN)
 
 
 # =============================================================================
@@ -768,6 +821,27 @@ class TestTreeSitterIntegration:
         assert result.syntax_valid is True
         assert result.language == CodeLanguage.GO
         assert result.compressed  # Some output is produced
+
+    def test_actual_php_compression(self):
+        """Test actual compression of PHP code."""
+        config = CodeCompressorConfig(
+            min_tokens_for_compression=10,
+            enable_ccr=False,
+        )
+        compressor = CodeAwareCompressor(config)
+
+        result = compressor.compress(generate_php_code(), language="php")
+
+        assert result.compression_ratio < 1.0
+        assert result.syntax_valid is True
+        assert result.language == CodeLanguage.PHP
+        assert "<?php" in result.compressed
+        assert "declare(strict_types=1);" in result.compressed
+        assert "namespace App\\Service;" in result.compressed
+        assert "use App\\Repository\\OrderRepository;" in result.compressed
+        assert "final class OrderService" in result.compressed
+        assert "public function totalForUser(int $userId): int" in result.compressed
+        assert "function normalize_order_id(string $id): string" in result.compressed
 
     def test_imports_preserved(self):
         """Imports are preserved in compressed output."""

--- a/tests/test_transforms_content_detection.py
+++ b/tests/test_transforms_content_detection.py
@@ -168,6 +168,36 @@ def test_code_detection_identifies_language_and_thresholds() -> None:
     assert _try_detect_code("\n\n") is None
 
 
+def test_code_detection_identifies_php() -> None:
+    php_code = "\n".join(
+        [
+            "<?php",
+            "",
+            "declare(strict_types=1);",
+            "",
+            "namespace App\\Service;",
+            "",
+            "use App\\Repository\\OrderRepository;",
+            "use RuntimeException;",
+            "",
+            "final class OrderService",
+            "{",
+            "    public function totalForUser(int $userId): int",
+            "    {",
+            "        return $this->orders->totalForUser($userId);",
+            "    }",
+            "}",
+        ]
+    )
+
+    result = _try_detect_code(php_code)
+
+    assert result is not None
+    assert result.content_type is ContentType.SOURCE_CODE
+    assert result.metadata == {"language": "php", "pattern_matches": 7}
+    assert detect_content_type(php_code).content_type is ContentType.SOURCE_CODE
+
+
 def test_detect_content_type_respects_priority_order() -> None:
     diff_like_search = "\n".join(
         [


### PR DESCRIPTION
Closes #201.

This adds PHP to the code-aware compressor instead of letting PHP snippets fall through as TypeScript and then fail syntax validation.

What changed:
- adds `php` to `CodeLanguage` and the tree-sitter language config
- preserves PHP top-of-file structure: `<?php`, `declare`, `namespace`, and `use` declarations
- compresses PHP functions and class methods while keeping valid brace structure
- teaches the content detector and parser warmup path about PHP
- adds regression coverage for PHP language detection, source-code routing, and AST compression

Verification:
- `python -m pytest tests/test_transforms/test_code_compressor.py tests/test_transforms_content_detection.py`
- `python -m pytest tests/test_code_compressor_thread_safety.py tests/test_proxy_warmup.py` with local `TMP`/`TEMP` because the default Windows temp dir was not writable in my environment
- `python -m ruff check headroom/transforms/code_compressor.py headroom/transforms/content_detector.py headroom/transforms/content_router.py tests/test_transforms/test_code_compressor.py tests/test_transforms_content_detection.py`
- `git diff --check`