### PR TITLE
fix(proxy): serve MCP endpoint locally

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -1368,12 +1368,68 @@ def _register_memory_components(proxy: HeadroomProxy, tracker: MemoryTracker) ->
     # registered when the memory system is initialized with specific backends.
 
 
+class _MCPStreamableHTTPApp:
+    def __init__(self, session_manager: Any) -> None:
+        self._session_manager = session_manager
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope.get("type") != "http":
+            response = PlainTextResponse("Not found", status_code=404)
+            await response(scope, receive, send)
+            return
+        await self._session_manager.handle_request(scope, receive, send)
+
+
+class _MCPUnavailableApp:
+    def __init__(self, reason: str) -> None:
+        self._reason = reason
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope.get("type") != "http":
+            response = PlainTextResponse("Not found", status_code=404)
+            await response(scope, receive, send)
+            return
+        response = JSONResponse(
+            status_code=501,
+            content={
+                "error": "Headroom MCP HTTP endpoint is unavailable",
+                "detail": "Install the MCP extra with: pip install 'headroom-ai[mcp]'",
+                "reason": self._reason,
+            },
+        )
+        await response(scope, receive, send)
+
+
+def _build_mcp_streamable_http_app(
+    config: ProxyConfig,
+) -> tuple[Any, Any | None, Any | None, str | None]:
+    proxy_url = f"http://127.0.0.1:{config.port}"
+    try:
+        from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+        from headroom.ccr.mcp_server import create_ccr_mcp_server
+
+        mcp_server = create_ccr_mcp_server(proxy_url=proxy_url)
+        session_manager = StreamableHTTPSessionManager(
+            mcp_server.server,
+            json_response=True,
+            stateless=True,
+        )
+        return _MCPStreamableHTTPApp(session_manager), session_manager, mcp_server, None
+    except Exception as exc:
+        reason = f"{type(exc).__name__}: {exc}"
+        logger.warning("event=mcp_http_unavailable reason=%r", reason)
+        return _MCPUnavailableApp(reason), None, None, reason
+
+
 def create_app(config: ProxyConfig | None = None) -> FastAPI:
     """Create FastAPI application."""
     if not FASTAPI_AVAILABLE:
         raise ImportError("FastAPI required. Install: pip install fastapi uvicorn httpx")
 
     from contextlib import asynccontextmanager
+
+    from starlette.routing import Route
 
     # Always-on file logging to ~/.headroom/logs/ for `headroom perf` analysis.
     # Installed here (not at module import) so importing headroom.proxy.server
@@ -1383,6 +1439,9 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
     config = config or ProxyConfig()
     proxy = HeadroomProxy(config)
+    mcp_http_app, mcp_http_session_manager, mcp_http_server, mcp_http_error = (
+        _build_mcp_streamable_http_app(config)
+    )
 
     # Telemetry beacon (anonymous aggregate stats).
     # With uvicorn workers > 1, each worker runs the lifespan independently.
@@ -1467,6 +1526,9 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         await initialize_context_tool_session_baseline()
 
         try:
+            stack = contextlib.AsyncExitStack()
+            if mcp_http_session_manager is not None:
+                await stack.enter_async_context(mcp_http_session_manager.run())
             try:
                 # Startup
                 await proxy.startup()
@@ -1490,6 +1552,8 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                 raise
         finally:
             app.state.ready = False
+            if "stack" in locals():
+                await stack.aclose()
             # Shutdown
             if _beacon_is_owner[0]:
                 await _beacon.stop()
@@ -1501,6 +1565,8 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
             if proxy.code_graph_watcher:
                 proxy.code_graph_watcher.stop()
             await proxy.shutdown()
+            if mcp_http_server is not None:
+                await mcp_http_server.cleanup()
             shutdown_headroom_tracing()
             shutdown_otel_metrics()
 
@@ -1520,6 +1586,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
     # request) sees an honest "missing" rather than a stale "loaded".
     app.state.rust_core_status = "missing"
     app.state.rust_core_error = None
+    app.state.mcp_http_error = mcp_http_error
 
     def _iso_utc_now() -> str:
         return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -2926,6 +2993,9 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
     @app.post("/v1/compress")
     async def compress_messages(request: Request):
         return await proxy.handle_compress(request)
+
+    app.router.routes.append(Route("/mcp", mcp_http_app, methods=["GET", "POST", "DELETE"]))
+    app.mount("/mcp", mcp_http_app)
 
     register_provider_routes(app, proxy)
 

--- a/tests/test_provider_proxy_routes.py
+++ b/tests/test_provider_proxy_routes.py
@@ -88,6 +88,55 @@ def test_provider_passthrough_routes_forward_expected_targets(monkeypatch) -> No
     assert len(calls) >= 16
 
 
+def test_mcp_endpoint_is_handled_locally_instead_of_passthrough() -> None:
+    calls: list[tuple[str, str]] = []
+
+    async def fake_passthrough(self, request, base_url, sub_path="", provider_name=""):  # type: ignore[no-untyped-def]
+        calls.append((request.url.path, base_url))
+        return JSONResponse({"base_url": base_url, "path": request.url.path})
+
+    initialize_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "1.0"},
+        },
+    }
+    tools_payload = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+
+    with patch.object(HeadroomProxy, "handle_passthrough", fake_passthrough):
+        with TestClient(_app()) as client:
+            response = client.post(
+                "/mcp",
+                json=initialize_payload,
+                headers={"accept": "application/json"},
+            )
+            tools_response = client.post(
+                "/mcp",
+                json=tools_payload,
+                headers={"accept": "application/json"},
+            )
+
+    assert calls == []
+
+    if response.status_code == 501:
+        payload = response.json()
+        assert payload["error"] == "Headroom MCP HTTP endpoint is unavailable"
+        assert "headroom-ai[mcp]" in payload["detail"]
+        assert tools_response.status_code == 501
+        return
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json()["result"]["serverInfo"]["name"] == "headroom"
+    assert tools_response.status_code == 200
+    tool_names = {tool["name"] for tool in tools_response.json()["result"]["tools"]}
+    assert {"headroom_compress", "headroom_retrieve", "headroom_stats"} <= tool_names
+
+
 def test_proxy_route_helpers_prefer_legacy_targets_and_gemini_passthrough() -> None:
     proxy_routes = importlib.import_module("headroom.providers.proxy_routes")
     proxy = type(


### PR DESCRIPTION
## Summary

This adds a local Streamable HTTP MCP endpoint at `/mcp` on the proxy instead of letting the provider catch-all forward that path upstream.

The issue report showed `POST /mcp` being sent to `https://api.openai.com/mcp` and returning 404. The proxy now mounts Headroom's existing MCP server over the MCP SDK's `StreamableHTTPSessionManager`, while still returning a local 501 with an install hint if the MCP extra is unavailable.

This addresses the proxy `/mcp` portion of #600. It does not try to cover the separate Windows direct-compression hang from the same issue.

## Tests

- `python -m pytest tests/test_provider_proxy_routes.py tests/test_ccr_mcp_server.py -q`
- `python -m ruff check headroom/proxy/server.py tests/test_provider_proxy_routes.py`
- `git diff --check`

Note: on my Windows machine I had to set `TMP`/`TEMP` to a local `.tmp-pytest` directory for the MCP server test because the default user temp pytest directory is not writable.