### PR TITLE
feat(cli): export compression analytics

### DIFF
--- a/docs/content/docs/metrics.mdx
+++ b/docs/content/docs/metrics.mdx
@@ -59,6 +59,16 @@ curl "http://localhost:8787/stats-history?format=csv&series=daily"
 curl "http://localhost:8787/stats-history?format=csv&series=monthly"
 ```
 
+The same local savings history can be exported without a running proxy:
+
+```bash
+headroom analytics
+headroom analytics --format json --export report.json
+headroom analytics --series weekly --export weekly-savings.csv
+```
+
+`headroom analytics` reads `~/.headroom/proxy_savings.json` by default. Use `HEADROOM_SAVINGS_PATH` or `--savings-path` to point it at another proxy savings file.
+
 ### Prometheus Metrics
 
 ```bash

--- a/headroom/cli/__init__.py
+++ b/headroom/cli/__init__.py
@@ -13,6 +13,7 @@ survives that kind of sys.modules mutation.
 """
 
 from . import (  # noqa: F401
+    analytics,
     evals,
     init,
     install,

--- a/headroom/cli/analytics.py
+++ b/headroom/cli/analytics.py
@@ -1,0 +1,209 @@
+"""Compression analytics export CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+
+from .main import main
+
+_FORMATS = ("markdown", "json", "csv")
+_SERIES = ("history", "hourly", "daily", "weekly", "monthly")
+_HISTORY_MODES = ("compact", "full", "none")
+
+
+def _infer_output_format(output_format: str | None, output_path: Path | None) -> str:
+    if output_format:
+        return output_format
+    if output_path is None:
+        return "markdown"
+
+    suffix = output_path.suffix.lower()
+    if suffix == ".json":
+        return "json"
+    if suffix == ".csv":
+        return "csv"
+    if suffix in {".md", ".markdown"}:
+        return "markdown"
+    return "markdown"
+
+
+def _format_usd(value: Any) -> str:
+    try:
+        return f"${float(value):.6f}"
+    except (TypeError, ValueError):
+        return "$0.000000"
+
+
+def _format_int(value: Any) -> str:
+    try:
+        return f"{int(value):,}"
+    except (TypeError, ValueError):
+        return "0"
+
+
+def _lifetime_savings_percent(lifetime: dict[str, Any]) -> float:
+    tokens_saved = int(lifetime.get("tokens_saved") or 0)
+    total_input_tokens = int(lifetime.get("total_input_tokens") or 0)
+    total_before = tokens_saved + total_input_tokens
+    if total_before <= 0:
+        return 0.0
+    return round(tokens_saved / total_before * 100, 2)
+
+
+def _markdown_table(rows: list[dict[str, Any]], *, series: str) -> list[str]:
+    if not rows:
+        return ["No history points recorded yet."]
+
+    if series == "history":
+        headers = [
+            "timestamp",
+            "total_tokens_saved",
+            "compression_savings_usd",
+            "total_input_tokens",
+            "total_input_cost_usd",
+        ]
+    else:
+        headers = [
+            "timestamp",
+            "tokens_saved",
+            "compression_savings_usd_delta",
+            "total_tokens_saved",
+            "total_input_tokens_delta",
+            "total_input_tokens",
+        ]
+
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in rows:
+        values = [str(row.get(header, "")) for header in headers]
+        lines.append("| " + " | ".join(values) + " |")
+    return lines
+
+
+def _render_markdown_report(
+    data: dict[str, Any], rows: list[dict[str, Any]], *, series: str
+) -> str:
+    lifetime = data.get("lifetime", {})
+    display_session = data.get("display_session", {})
+    history_summary = data.get("history_summary", {})
+
+    lines = [
+        "# Headroom Compression Analytics",
+        "",
+        f"- Storage: `{data.get('storage_path', '')}`",
+        f"- Generated: `{data.get('generated_at', '')}`",
+        f"- History points: {history_summary.get('returned_points', 0)} returned / "
+        f"{history_summary.get('stored_points', 0)} stored",
+        "",
+        "## Lifetime",
+        "",
+        f"- Requests: {_format_int(lifetime.get('requests'))}",
+        f"- Tokens saved: {_format_int(lifetime.get('tokens_saved'))}",
+        f"- Input tokens tracked: {_format_int(lifetime.get('total_input_tokens'))}",
+        f"- Compression savings: {_format_usd(lifetime.get('compression_savings_usd'))}",
+        f"- Input spend tracked: {_format_usd(lifetime.get('total_input_cost_usd'))}",
+        f"- Savings percent: {_lifetime_savings_percent(lifetime):.2f}%",
+        "",
+        "## Current Display Session",
+        "",
+        f"- Requests: {_format_int(display_session.get('requests'))}",
+        f"- Tokens saved: {_format_int(display_session.get('tokens_saved'))}",
+        f"- Input tokens tracked: {_format_int(display_session.get('total_input_tokens'))}",
+        f"- Savings percent: {float(display_session.get('savings_percent') or 0.0):.2f}%",
+        "",
+        f"## {series.title()} Series",
+        "",
+        *_markdown_table(rows, series=series),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+@main.command("analytics")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(_FORMATS),
+    default=None,
+    help="Output format. Inferred from --output/--export when omitted.",
+)
+@click.option(
+    "--series",
+    type=click.Choice(_SERIES),
+    default="daily",
+    show_default=True,
+    help="History series used for CSV and Markdown output.",
+)
+@click.option(
+    "--history-mode",
+    type=click.Choice(_HISTORY_MODES),
+    default="compact",
+    show_default=True,
+    help="History detail level for JSON output.",
+)
+@click.option(
+    "--savings-path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Read analytics from a specific proxy_savings.json file.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write the report to a file instead of stdout.",
+)
+@click.option(
+    "--export",
+    "export_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Alias for --output.",
+)
+def analytics(
+    output_format: str | None,
+    series: str,
+    history_mode: str,
+    savings_path: Path | None,
+    output_path: Path | None,
+    export_path: Path | None,
+) -> None:
+    """Export compression analytics from local proxy savings history.
+
+    \b
+    Examples:
+        headroom analytics
+        headroom analytics --format json
+        headroom analytics --series weekly --export savings.csv
+    """
+    from headroom.proxy.savings_tracker import SavingsTracker
+
+    if output_path is not None and export_path is not None:
+        raise click.UsageError("Use either --output or --export, not both.")
+
+    target_path = output_path or export_path
+    resolved_format = _infer_output_format(output_format, target_path)
+    tracker = SavingsTracker(path=str(savings_path) if savings_path is not None else None)
+
+    if resolved_format == "json":
+        payload = json.dumps(tracker.history_response(history_mode=history_mode), indent=2)
+    elif resolved_format == "csv":
+        payload = tracker.export_csv(series=series)
+    else:
+        data = tracker.history_response(history_mode=history_mode)
+        rows = tracker.export_rows(series=series)
+        payload = _render_markdown_report(data, rows, series=series)
+
+    if target_path is None:
+        click.echo(payload.rstrip("\n"))
+        return
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(payload, encoding="utf-8")
+    click.echo(f"Wrote analytics report to {target_path}")

--- a/headroom/cli/main.py
+++ b/headroom/cli/main.py
@@ -36,6 +36,7 @@ def main(ctx: click.Context) -> None:
 def _register_commands() -> None:
     """Register all subcommand groups."""
     from . import (
+        analytics,  # noqa: F401
         evals,  # noqa: F401
         init,  # noqa: F401
         install,  # noqa: F401

--- a/tests/cli/test_analytics.py
+++ b/tests/cli/test_analytics.py
@@ -1,0 +1,128 @@
+"""Tests for compression analytics CLI exports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+from headroom.proxy.savings_tracker import SavingsTracker
+
+
+def _populate_savings(path: Path) -> None:
+    tracker = SavingsTracker(path=str(path))
+    tracker.record_request(
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=40,
+        total_input_cost_usd=0.24,
+        timestamp="2026-03-27T09:15:00Z",
+    )
+    tracker.record_request(
+        model="gpt-4o",
+        input_tokens=80,
+        tokens_saved=20,
+        total_input_cost_usd=0.16,
+        timestamp="2026-03-28T10:30:00Z",
+    )
+
+
+def test_analytics_json_export_reads_savings_history(tmp_path: Path) -> None:
+    savings_path = tmp_path / "proxy_savings.json"
+    _populate_savings(savings_path)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "analytics",
+            "--format",
+            "json",
+            "--history-mode",
+            "full",
+            "--savings-path",
+            str(savings_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["storage_path"] == str(savings_path)
+    assert payload["lifetime"]["requests"] == 2
+    assert payload["lifetime"]["tokens_saved"] == 60
+    assert payload["lifetime"]["total_input_tokens"] == 200
+    assert payload["history_summary"]["mode"] == "full"
+    assert len(payload["history"]) == 2
+
+
+def test_analytics_csv_export_uses_selected_rollup_series(tmp_path: Path) -> None:
+    savings_path = tmp_path / "proxy_savings.json"
+    _populate_savings(savings_path)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "analytics",
+            "--format",
+            "csv",
+            "--series",
+            "daily",
+            "--savings-path",
+            str(savings_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().splitlines()
+    assert lines[0] == (
+        "timestamp,tokens_saved,compression_savings_usd_delta,total_tokens_saved,"
+        "compression_savings_usd,total_input_tokens_delta,total_input_tokens,"
+        "total_input_cost_usd_delta,total_input_cost_usd"
+    )
+    assert "2026-03-27T00:00:00Z,40" in lines[1]
+    assert "2026-03-28T00:00:00Z,20" in lines[2]
+
+
+def test_analytics_export_infers_markdown_from_file_extension(tmp_path: Path) -> None:
+    savings_path = tmp_path / "proxy_savings.json"
+    output_path = tmp_path / "reports" / "analytics.md"
+    _populate_savings(savings_path)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "analytics",
+            "--series",
+            "history",
+            "--savings-path",
+            str(savings_path),
+            "--export",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert f"Wrote analytics report to {output_path}" in result.output
+    report = output_path.read_text(encoding="utf-8")
+    assert "# Headroom Compression Analytics" in report
+    assert "- Requests: 2" in report
+    assert "- Tokens saved: 60" in report
+    assert "## History Series" in report
+    assert "| timestamp | total_tokens_saved |" in report
+
+
+def test_analytics_rejects_output_and_export_together(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        main,
+        [
+            "analytics",
+            "--output",
+            str(tmp_path / "one.json"),
+            "--export",
+            str(tmp_path / "two.json"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Use either --output or --export, not both." in result.output


### PR DESCRIPTION
Addresses #599.

## What changed

Adds a `headroom analytics` CLI command for exporting the durable proxy savings history that Headroom already stores in `proxy_savings.json`.

The command can:

- print a Markdown analytics report to stdout by default
- export JSON with the same shape as `/stats-history`
- export CSV for `history`, `hourly`, `daily`, `weekly`, or `monthly` series
- infer the output format from `--export report.json`, `--export report.csv`, or `--export report.md`
- read a custom savings file with `--savings-path`, while still honoring the existing default/`HEADROOM_SAVINGS_PATH` behavior through `SavingsTracker`

This is intentionally built on the existing `SavingsTracker` API instead of adding a second analytics store. It means CLI exports and the dashboard/history endpoint stay aligned.

## Examples

```bash
headroom analytics
headroom analytics --format json --export report.json
headroom analytics --series weekly --export weekly-savings.csv
```

## Tests

- `.venv313\Scripts\python.exe -m pytest tests\cli\test_analytics.py tests\test_proxy_savings_history.py -q --basetemp .tmp-pytest\analytics-final`
- `.venv313\Scripts\ruff.exe check headroom\cli\analytics.py headroom\cli\main.py headroom\cli\__init__.py tests\cli\test_analytics.py`
- `.venv313\Scripts\ruff.exe format --check headroom\cli\analytics.py headroom\cli\main.py headroom\cli\__init__.py tests\cli\test_analytics.py`
- `git diff --check`