### PR TITLE
fix(ccr): expire proactive contexts by turn distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **ccr:** stop proactive context expansion from re-injecting contexts that are stale by compressing-turn distance.
+
 * **startup:** suppress proxy startup log noise — litellm banner, trafilatura parse errors, HuggingFace Hub unauthenticated warnings, tiktoken fallback warning, and httpx INFO lines from sentence_transformers HEAD checks. Affected files: `headroom/providers/litellm.py`, `headroom/transforms/html_extractor.py`, `headroom/memory/adapters/embedders.py`, `headroom/providers/anthropic.py`, `headroom/providers/registry.py`, `headroom/image/onnx_router.py`, `headroom/transforms/kompress_compressor.py`.
 
 

--- a/headroom/ccr/context_tracker.py
+++ b/headroom/ccr/context_tracker.py
@@ -92,6 +92,9 @@ class ContextTrackerConfig:
     # Maximum items to proactively expand per turn
     max_proactive_expansions: int = 2
 
+    # Maximum number of compressing turns before context is too stale
+    max_turn_distance: int = 10
+
 
 class ContextTracker:
     """Tracks compressed contexts across conversation turns.
@@ -235,6 +238,7 @@ class ContextTracker:
 
         recommendations: list[ExpansionRecommendation] = []
         now = time.time()
+        max_turn_distance = max(1, self.config.max_turn_distance)
 
         for hash_key, context in self._contexts.items():
             # Workspace filter — the cross-project leak gate. Skip
@@ -248,12 +252,26 @@ class ContextTracker:
             if age > self.config.max_context_age_seconds:
                 continue
 
+            if current_turn is not None and context.turn_number is not None:
+                turn_distance = max(0, current_turn - context.turn_number)
+                if turn_distance > max_turn_distance:
+                    continue
+            else:
+                turn_distance = 0
+
             # Calculate relevance
             relevance = self._calculate_relevance(query, context)
 
             # Age discount: older contexts get lower scores
             age_factor = 1.0 - (age / self.config.max_context_age_seconds) * 0.5
-            relevance *= age_factor
+            if current_turn is not None and context.turn_number is not None:
+                turn_factor = max(
+                    0.2,
+                    1.0 - (turn_distance / max_turn_distance) * 0.8,
+                )
+            else:
+                turn_factor = 1.0
+            relevance *= age_factor * turn_factor
 
             if relevance >= self.config.relevance_threshold:
                 # Determine if full expansion or search

--- a/headroom/proxy/models.py
+++ b/headroom/proxy/models.py
@@ -126,6 +126,7 @@ class ProxyConfig:
     ccr_context_tracking: bool = True
     ccr_proactive_expansion: bool = True
     ccr_max_proactive_expansions: int = 2
+    ccr_max_turn_distance: int = 10
 
     # Code-aware compression (disabled by default — use code graph tools instead)
     code_aware_enabled: bool = False

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -565,6 +565,7 @@ class HeadroomProxy(
                     enabled=True,
                     proactive_expansion=config.ccr_proactive_expansion,
                     max_proactive_expansions=config.ccr_max_proactive_expansions,
+                    max_turn_distance=config.ccr_max_turn_distance,
                 )
             )
             if config.ccr_context_tracking

--- a/tests/test_ccr_context_tracker.py
+++ b/tests/test_ccr_context_tracker.py
@@ -17,6 +17,7 @@ from headroom.cache.compression_store import (
     get_compression_store,
     reset_compression_store,
 )
+from headroom.ccr import context_tracker as context_tracker_module
 from headroom.ccr.context_tracker import (
     CompressedContext,
     ContextTracker,
@@ -290,6 +291,141 @@ class TestQueryAnalysis:
 
         # Should not recommend aged-out context
         assert len(recommendations) == 0
+
+    def test_analyze_query_skips_context_beyond_turn_distance(self):
+        """Fresh wall-clock contexts still expire after too many compressing turns."""
+        config = ContextTrackerConfig(max_turn_distance=10)
+        tracker = ContextTracker(config)
+
+        tracker.track_compression(
+            hash_key="stale_turn_context",
+            turn_number=1,
+            tool_name="Bash",
+            original_count=100,
+            compressed_count=10,
+            query_context="investigate proactive context expansion",
+            sample_content="headroom/ccr/context_tracker.py proactive expansion context tracker",
+            workspace_key="ws-test",
+        )
+
+        recommendations = tracker.analyze_query(
+            query="proactive context expansion context_tracker",
+            current_turn=12,
+            workspace_key="ws-test",
+        )
+
+        assert recommendations == []
+
+    def test_analyze_query_keeps_recent_turn_context(self):
+        """Recent turn-distance context still expands when keyword-relevant."""
+        config = ContextTrackerConfig(max_turn_distance=10)
+        tracker = ContextTracker(config)
+
+        tracker.track_compression(
+            hash_key="recent_turn_context",
+            turn_number=9,
+            tool_name="Bash",
+            original_count=100,
+            compressed_count=10,
+            query_context="investigate proactive context expansion",
+            sample_content="headroom/ccr/context_tracker.py proactive expansion context tracker",
+            workspace_key="ws-test",
+        )
+
+        recommendations = tracker.analyze_query(
+            query="proactive context expansion context_tracker",
+            current_turn=11,
+            workspace_key="ws-test",
+        )
+
+        assert [rec.hash_key for rec in recommendations] == ["recent_turn_context"]
+
+    def test_analyze_query_turn_distance_decays_relevance(self):
+        """Turn distance reduces relevance before the hard cutoff."""
+        config = ContextTrackerConfig(relevance_threshold=0.0, max_turn_distance=10)
+        tracker = ContextTracker(config)
+        sample_content = "authentication middleware service routing auth_handler.py"
+
+        tracker.track_compression(
+            hash_key="mid_distance_context",
+            turn_number=5,
+            tool_name="Bash",
+            original_count=100,
+            compressed_count=10,
+            query_context="authentication middleware",
+            sample_content=sample_content,
+            workspace_key="ws-test",
+        )
+        tracker.track_compression(
+            hash_key="recent_context",
+            turn_number=10,
+            tool_name="Bash",
+            original_count=100,
+            compressed_count=10,
+            query_context="authentication middleware",
+            sample_content=sample_content,
+            workspace_key="ws-test",
+        )
+
+        recommendations = tracker.analyze_query(
+            query="authentication middleware",
+            current_turn=10,
+            workspace_key="ws-test",
+        )
+
+        scores = {rec.hash_key: rec.relevance_score for rec in recommendations}
+        assert scores["mid_distance_context"] < scores["recent_context"] * 0.7
+
+    def test_analyze_query_without_current_turn_uses_age_only(self):
+        """Callers without turn data keep the old age-only behavior."""
+        config = ContextTrackerConfig(max_turn_distance=1)
+        tracker = ContextTracker(config)
+
+        tracker.track_compression(
+            hash_key="turn_unknown_context",
+            turn_number=1,
+            tool_name="Bash",
+            original_count=100,
+            compressed_count=10,
+            query_context="authentication middleware",
+            sample_content="authentication middleware auth_handler.py",
+            workspace_key="ws-test",
+        )
+
+        recommendations = tracker.analyze_query(
+            query="authentication middleware",
+            current_turn=None,
+            workspace_key="ws-test",
+        )
+
+        assert [rec.hash_key for rec in recommendations] == ["turn_unknown_context"]
+
+    def test_fast_session_old_turn_is_skipped_even_when_wall_clock_fresh(self, monkeypatch):
+        """Fast sessions should not re-expand many-turn-old contexts inside 300s."""
+        now = 1_000.0
+        monkeypatch.setattr(context_tracker_module.time, "time", lambda: now)
+        config = ContextTrackerConfig(max_context_age_seconds=300.0, max_turn_distance=10)
+        tracker = ContextTracker(config)
+
+        tracker.track_compression(
+            hash_key="fast_session_stale_context",
+            turn_number=1,
+            tool_name="Bash",
+            original_count=100,
+            compressed_count=10,
+            query_context="proactive context expansion",
+            sample_content="headroom/ccr/context_tracker.py proactive expansion context tracker",
+            workspace_key="ws-test",
+        )
+
+        monkeypatch.setattr(context_tracker_module.time, "time", lambda: now + 30.0)
+        recommendations = tracker.analyze_query(
+            query="proactive context expansion context_tracker",
+            current_turn=30,
+            workspace_key="ws-test",
+        )
+
+        assert recommendations == []
 
     def test_analyze_query_max_recommendations(self):
         """Respects max proactive expansions limit."""
@@ -625,6 +761,7 @@ class TestContextTrackerConfig:
         assert config.max_context_age_seconds == 300.0
         assert config.proactive_expansion is True
         assert config.max_proactive_expansions == 2
+        assert config.max_turn_distance == 10
 
     def test_custom_config(self):
         """Custom config values."""
@@ -633,12 +770,14 @@ class TestContextTrackerConfig:
             max_tracked_contexts=50,
             relevance_threshold=0.5,
             max_proactive_expansions=5,
+            max_turn_distance=20,
         )
 
         assert config.enabled is False
         assert config.max_tracked_contexts == 50
         assert config.relevance_threshold == 0.5
         assert config.max_proactive_expansions == 5
+        assert config.max_turn_distance == 20
 
 
 class TestCompressedContextDataClass:

--- a/tests/test_proxy_ccr_context_tracker_config.py
+++ b/tests/test_proxy_ccr_context_tracker_config.py
@@ -1,0 +1,10 @@
+from headroom.proxy.server import HeadroomProxy, ProxyConfig
+
+
+def test_proxy_threads_ccr_max_turn_distance_into_context_tracker() -> None:
+    config = ProxyConfig(ccr_max_turn_distance=3)
+
+    proxy = HeadroomProxy(config)
+
+    assert proxy.ccr_context_tracker is not None
+    assert proxy.ccr_context_tracker.config.max_turn_distance == 3


### PR DESCRIPTION
## Description

Fixes #709.

Fast agentic sessions can produce many compressing turns inside the current 300s wall-clock freshness window. `ContextTracker.analyze_query()` only used wall-clock age, so keyword-overlapping contexts from many turns ago could still be picked for proactive expansion.

This adds a second freshness signal using data the tracker already stores: `CompressedContext.turn_number` and the `current_turn` passed by the proxy. Contexts beyond `max_turn_distance` are skipped, and contexts near the limit get an extra relevance decay. Calls without turn data keep the old age-only behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `ContextTrackerConfig.max_turn_distance` with a default of `10`.
- Skip proactive-expansion candidates when `current_turn - context.turn_number > max_turn_distance`.
- Apply turn-distance decay together with the existing wall-clock age decay.
- Add `ProxyConfig.ccr_max_turn_distance` and thread it into `HeadroomProxy`.
- Add regression coverage for stale turns, recent turns, turn-distance decay, no-turn backward compatibility, the fast-session wall-clock-fresh case, and proxy config wiring.
- Update `CHANGELOG.md`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

## Test Output

```text
$ .\.venv313\Scripts\python.exe -m pytest tests\test_ccr_context_tracker.py tests\test_proxy_ccr_context_tracker_config.py -q --basetemp .tmp-pytest\ccr-turn-pr
============================= test session starts =============================
platform win32 -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0
rootdir: D:\Projects\Cosmic\headroom
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.4.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 44 items

tests\test_ccr_context_tracker.py ...................................... [ 86%]
.....                                                                    [ 97%]
tests\test_proxy_ccr_context_tracker_config.py .                         [100%]

============================= 44 passed in 3.17s ==============================
```

```text
$ .\.venv313\Scripts\ruff.exe check headroom\ccr\context_tracker.py headroom\proxy\models.py headroom\proxy\server.py tests\test_ccr_context_tracker.py tests\test_proxy_ccr_context_tracker_config.py
All checks passed!
```

```text
$ .\.venv313\Scripts\ruff.exe format --check headroom\ccr\context_tracker.py headroom\proxy\models.py headroom\proxy\server.py tests\test_ccr_context_tracker.py tests\test_proxy_ccr_context_tracker_config.py
5 files already formatted
```

```text
$ git diff --check
# no output
```

## Real behavior proof

Setup tested on:

- Windows local checkout
- Python 3.13.13 in `.venv313`
- Current branch: `fix/ccr-turn-distance-staleness`
- Direct `ContextTracker` scenario, using the same `track_compression()` / `analyze_query()` APIs used by the proxy path

Exact command run after the patch:

```text
$ .\.venv313\Scripts\python.exe -c "import json; from headroom.ccr.context_tracker import ContextTracker, ContextTrackerConfig; tracker=ContextTracker(ContextTrackerConfig(relevance_threshold=0.1, max_turn_distance=10, max_context_age_seconds=300.0)); tracker.track_compression(hash_key='stale_ctx', turn_number=1, tool_name='Bash', original_count=100, compressed_count=10, query_context='investigate proactive context expansion', sample_content='headroom/ccr/context_tracker.py proactive expansion context tracker', workspace_key='repo'); stale=tracker.analyze_query('proactive context expansion context_tracker', current_turn=30, workspace_key='repo'); recent=tracker.analyze_query('proactive context expansion context_tracker', current_turn=5, workspace_key='repo'); print(json.dumps({'stale_turn_30_count': len(stale), 'recent_turn_5_count': len(recent), 'recent_hash': recent[0].hash_key if recent else None, 'max_turn_distance': tracker.config.max_turn_distance}, indent=2))"
```

Observed result:

```json
{
  "stale_turn_30_count": 0,
  "recent_turn_5_count": 1,
  "recent_hash": "stale_ctx",
  "max_turn_distance": 10
}
```

This shows the reported failure mode directly: the context is still wall-clock fresh and keyword-relevant, but it no longer gets injected after too many compressing turns. The same context still expands when queried from a nearby turn.

Regression proof:

- The stale-turn regression test first failed before implementation because `ContextTrackerConfig(max_turn_distance=10)` did not exist.
- The proxy wiring test first failed before implementation because `ProxyConfig(ccr_max_turn_distance=3)` did not exist.
- Both are now covered in the passing test run above.

What I did not test:

- A full live Claude Code session through the proxy.
- A long-running multi-client proxy session with real provider traffic.
- Linux/macOS manual smoke runs. The changed behavior is covered by direct tracker tests and should run in CI.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in the targeted test/lint commands above
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

Not applicable.

## Additional Notes

I kept this scoped to the turn-distance freshness bug. Per-session turn counters and live-session telemetry would be useful follow-ups, but they are separate from this fix.
