### PR TITLE
feat(wrap): add Grok Build CLI support

### DIFF
--- a/headroom/cli/install.py
+++ b/headroom/cli/install.py
@@ -14,6 +14,7 @@ from headroom.install.models import (
     ProviderSelectionMode,
     RuntimeKind,
     SupervisorKind,
+    ToolTarget,
 )
 from headroom.install.planner import build_manifest
 from headroom.install.providers import apply_mutations, revert_mutations
@@ -134,7 +135,7 @@ def _reject_task_lifecycle(manifest: DeploymentManifest, action: str) -> None:
     "--target",
     "targets",
     multiple=True,
-    type=click.Choice(["claude", "copilot", "codex", "aider", "cursor", "openclaw"]),
+    type=click.Choice([target.value for target in ToolTarget]),
     help="Tool target to configure when --providers manual is used.",
 )
 @click.option("--profile", default="default", show_default=True, help="Deployment profile name.")

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -4,6 +4,7 @@ Usage:
     headroom wrap claude                    # Start proxy + context tool + claude
     headroom wrap copilot -- --model ...    # Start proxy + launch GitHub Copilot CLI
     headroom wrap codex                     # Start proxy + OpenAI Codex CLI
+    headroom wrap grok                      # Start proxy + Grok Build CLI
     headroom wrap aider                     # Start proxy + aider
     headroom wrap cursor                    # Start proxy + print Cursor config instructions
     headroom wrap openclaw                  # Install + configure OpenClaw plugin
@@ -68,6 +69,7 @@ from headroom.providers.copilot import (
     validate_configuration as _validate_copilot_configuration,
 )
 from headroom.providers.cursor import render_setup_lines as _render_cursor_setup_lines
+from headroom.providers.grok import build_launch_env as _build_grok_launch_env
 from headroom.providers.openclaw import (
     build_plugin_entry as _build_openclaw_plugin_entry_impl,
 )
@@ -2111,6 +2113,7 @@ def wrap() -> None:
     Supported tools (one Click subcommand per tool):
         headroom wrap claude              # Claude Code (Anthropic)
         headroom wrap codex               # OpenAI Codex CLI
+        headroom wrap grok                # Grok Build CLI
         headroom wrap copilot -- --model claude-sonnet-4-20250514
         headroom wrap aider               # Aider
         headroom wrap cursor              # Cursor (prints config instructions)
@@ -2935,6 +2938,76 @@ def aider(
         memory=memory,
         agent_type="aider",
         code_graph=code_graph,
+        backend=backend,
+        anyllm_provider=anyllm_provider,
+        region=region,
+    )
+
+
+# =============================================================================
+# Grok Build
+# =============================================================================
+
+
+@wrap.command(context_settings={"ignore_unknown_options": True})
+@click.option("--port", "-p", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option(
+    "--learn", is_flag=True, help="Enable live traffic learning (patterns saved to MEMORY.md)"
+)
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--backend", default=None, help="API backend: 'anthropic', 'anyllm', 'litellm-vertex', etc."
+)
+@click.option("--anyllm-provider", default=None, help="Provider for any-llm backend")
+@click.option("--region", default=None, help="Cloud region for Bedrock/Vertex")
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+@click.argument("grok_args", nargs=-1, type=click.UNPROCESSED)
+def grok(
+    port: int,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    backend: str | None,
+    anyllm_provider: str | None,
+    region: str | None,
+    verbose: bool,
+    grok_args: tuple,
+) -> None:
+    """Launch Grok Build through Headroom proxy.
+
+    \b
+    Sets GROK_CLI_CHAT_PROXY_BASE_URL so Grok routes cli-chat-proxy traffic
+    through Headroom for context compression.
+
+    \b
+    Examples:
+        headroom wrap grok                         # Start proxy + grok TUI
+        headroom wrap grok -- -p "fix the bug"     # Headless prompt
+        headroom wrap grok --port 9999             # Custom proxy port
+        headroom wrap grok --backend anyllm --anyllm-provider groq
+    """
+    del verbose
+
+    grok_bin = shutil.which("grok")
+    if not grok_bin:
+        click.echo("Error: 'grok' not found in PATH.")
+        click.echo("Install Grok Build: https://grok.com/build")
+        raise SystemExit(1)
+
+    env, env_vars_display = _build_grok_launch_env(port, os.environ)
+
+    _launch_tool(
+        binary=grok_bin,
+        args=grok_args,
+        env=env,
+        port=port,
+        no_proxy=no_proxy,
+        tool_label="GROK",
+        env_vars_display=env_vars_display,
+        learn=learn,
+        memory=memory,
+        agent_type="grok",
         backend=backend,
         anyllm_provider=anyllm_provider,
         region=region,

--- a/headroom/install/models.py
+++ b/headroom/install/models.py
@@ -53,6 +53,7 @@ class ToolTarget(str, Enum):
     CLAUDE = "claude"
     COPILOT = "copilot"
     CODEX = "codex"
+    GROK = "grok"
     AIDER = "aider"
     CURSOR = "cursor"
     OPENCLAW = "openclaw"

--- a/headroom/install/planner.py
+++ b/headroom/install/planner.py
@@ -24,6 +24,7 @@ SUPPORTED_TARGETS = [
     ToolTarget.CLAUDE,
     ToolTarget.COPILOT,
     ToolTarget.CODEX,
+    ToolTarget.GROK,
     ToolTarget.AIDER,
     ToolTarget.CURSOR,
     ToolTarget.OPENCLAW,

--- a/headroom/providers/grok/__init__.py
+++ b/headroom/providers/grok/__init__.py
@@ -1,0 +1,5 @@
+"""Grok-specific provider helpers."""
+
+from .runtime import DEFAULT_API_URL, build_launch_env, proxy_base_url
+
+__all__ = ["DEFAULT_API_URL", "build_launch_env", "proxy_base_url"]

--- a/headroom/providers/grok/install.py
+++ b/headroom/providers/grok/install.py
@@ -1,0 +1,12 @@
+"""Grok install-time helpers."""
+
+from __future__ import annotations
+
+from .runtime import build_launch_env
+
+
+def build_install_env(*, port: int, backend: str) -> dict[str, str]:
+    """Build the persistent install environment for Grok Build."""
+    del backend
+    env, _lines = build_launch_env(port=port, environ={})
+    return {"GROK_CLI_CHAT_PROXY_BASE_URL": env["GROK_CLI_CHAT_PROXY_BASE_URL"]}

--- a/headroom/providers/grok/runtime.py
+++ b/headroom/providers/grok/runtime.py
@@ -1,0 +1,24 @@
+"""Runtime helpers for Grok Build CLI integrations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+DEFAULT_API_URL = "https://cli-chat-proxy.grok.com/v1"
+_PROXY_ENV = "GROK_CLI_CHAT_PROXY_BASE_URL"
+
+
+def proxy_base_url(port: int) -> str:
+    """Return the local Headroom proxy base URL for Grok."""
+    return f"http://127.0.0.1:{port}/v1"
+
+
+def build_launch_env(
+    port: int, environ: Mapping[str, str] | None = None
+) -> tuple[dict[str, str], list[str]]:
+    """Build environment variables for Grok through the local Headroom proxy."""
+    env = dict(environ or os.environ)
+    base_url = proxy_base_url(port)
+    env[_PROXY_ENV] = base_url
+    return env, [f"{_PROXY_ENV}={base_url}"]

--- a/headroom/providers/install_registry.py
+++ b/headroom/providers/install_registry.py
@@ -26,6 +26,7 @@ from headroom.providers.copilot.install import (
     build_install_env as _build_copilot_install_env,
 )
 from headroom.providers.cursor.install import build_install_env as _build_cursor_install_env
+from headroom.providers.grok.install import build_install_env as _build_grok_install_env
 from headroom.providers.openclaw.install import (
     apply_provider_scope as _apply_openclaw_provider_scope,
 )
@@ -41,6 +42,7 @@ _ENV_BUILDERS: dict[str, _InstallEnvBuilder] = {
     "claude": _build_claude_install_env,
     "copilot": _build_copilot_install_env,
     "codex": _build_codex_install_env,
+    "grok": _build_grok_install_env,
     "aider": _build_aider_install_env,
     "cursor": _build_cursor_install_env,
 }

--- a/tests/test_cli/test_wrap_grok.py
+++ b/tests/test_cli/test_wrap_grok.py
@@ -1,0 +1,50 @@
+"""Tests for `headroom wrap grok` command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_wrap_grok_sets_proxy_env(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value="grok"):
+        with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
+            result = runner.invoke(main, ["wrap", "grok", "--", "-p", "fix the bug"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:8787/v1"
+    assert captured["tool_label"] == "GROK"
+    assert captured["agent_type"] == "grok"
+    assert captured["args"] == ("-p", "fix the bug")
+
+
+def test_wrap_grok_missing_binary(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value=None):
+        result = runner.invoke(main, ["wrap", "grok"])
+
+    assert result.exit_code == 1
+    assert "grok" in result.output.lower()

--- a/tests/test_install/test_planner.py
+++ b/tests/test_install/test_planner.py
@@ -51,7 +51,7 @@ def test_build_manifest_uses_provider_slice_env_builders_for_all_supported_targe
         runtime_kind="python",
         scope="user",
         provider_mode="manual",
-        targets=["claude", "copilot", "codex", "aider", "cursor"],
+        targets=["claude", "copilot", "codex", "grok", "aider", "cursor"],
         port=9999,
         backend="anyllm",
         anyllm_provider="groq",
@@ -64,6 +64,7 @@ def test_build_manifest_uses_provider_slice_env_builders_for_all_supported_targe
 
     assert manifest.tool_envs["claude"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9999"
     assert manifest.tool_envs["codex"]["OPENAI_BASE_URL"] == "http://127.0.0.1:9999/v1"
+    assert manifest.tool_envs["grok"]["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:9999/v1"
     assert manifest.tool_envs["aider"] == {
         "OPENAI_API_BASE": "http://127.0.0.1:9999/v1",
         "ANTHROPIC_BASE_URL": "http://127.0.0.1:9999",

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -16,6 +16,7 @@ from headroom.providers.codex.install import apply_provider_scope as apply_codex
 from headroom.providers.codex.install import build_install_env as build_codex_install_env
 from headroom.providers.codex.install import revert_provider_scope as revert_codex_provider_scope
 from headroom.providers.copilot.install import build_install_env as build_copilot_install_env
+from headroom.providers.grok.install import build_install_env as build_grok_install_env
 
 
 def _manifest(tmp_path: Path) -> DeploymentManifest:
@@ -84,6 +85,12 @@ def test_codex_build_install_env_returns_proxy_base_url() -> None:
     env = build_codex_install_env(port=5566, backend="ignored")
 
     assert env == {"OPENAI_BASE_URL": "http://127.0.0.1:5566/v1"}
+
+
+def test_grok_build_install_env_returns_proxy_base_url() -> None:
+    env = build_grok_install_env(port=5566, backend="ignored")
+
+    assert env == {"GROK_CLI_CHAT_PROXY_BASE_URL": "http://127.0.0.1:5566/v1"}
 
 
 def test_apply_codex_provider_scope_skips_non_provider_scope(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_providers/test_grok_runtime.py
+++ b/tests/test_providers/test_grok_runtime.py
@@ -1,0 +1,22 @@
+"""Tests for Grok provider runtime helpers."""
+
+from headroom.providers.grok.runtime import (
+    DEFAULT_API_URL,
+    build_launch_env,
+    proxy_base_url,
+)
+
+
+def test_proxy_base_url() -> None:
+    assert proxy_base_url(8787) == "http://127.0.0.1:8787/v1"
+
+
+def test_default_api_url() -> None:
+    assert DEFAULT_API_URL == "https://cli-chat-proxy.grok.com/v1"
+
+
+def test_build_launch_env_sets_grok_proxy_override() -> None:
+    env, display = build_launch_env(9999, {"HOME": "/tmp"})
+    assert env["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:9999/v1"
+    assert env["HOME"] == "/tmp"
+    assert display == ["GROK_CLI_CHAT_PROXY_BASE_URL=http://127.0.0.1:9999/v1"]

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -32,6 +32,7 @@ This page is the authoritative reference for the **Python Headroom CLI** exposed
 | `headroom wrap claude` | Start proxy and launch Claude Code | **host-bridged** |
 | `headroom wrap copilot` | Start proxy and launch GitHub Copilot CLI | **python-native only** |
 | `headroom wrap codex` | Start proxy and launch Codex CLI | **host-bridged** |
+| `headroom wrap grok` | Start proxy and launch Grok Build CLI | **host-bridged** |
 | `headroom wrap aider` | Start proxy and launch Aider | **host-bridged** |
 | `headroom wrap cursor` | Start proxy and print Cursor config guidance | **host-bridged** |
 | `headroom wrap openclaw` | Install and configure the OpenClaw plugin | **host-bridged** |
@@ -590,7 +591,7 @@ Options:
                                   [default: user]
   --providers [auto|all|manual]   Target selection mode for direct tool
                                   configuration.  [default: auto]
-  --target [claude|copilot|codex|aider|cursor|openclaw]
+  --target [claude|copilot|codex|grok|aider|cursor|openclaw]
                                   Tool target to configure when --providers
                                   manual is used.
   --profile TEXT                  Deployment profile name.  [default: default]
@@ -738,6 +739,28 @@ headroom wrap codex --backend anyllm --anyllm-provider groq
 | `codex_args...` | passthrough | Additional Codex CLI arguments |
 
 Requires the `codex` binary on the host.
+
+### `headroom wrap grok`
+
+```bash
+headroom wrap grok
+headroom wrap grok -- -p "fix the bug"
+headroom wrap grok --backend anyllm --anyllm-provider groq
+```
+
+| Option / arg | Default | Meaning |
+|---|---|---|
+| `--port`, `-p` | `8787` | Proxy port |
+| `--no-proxy` | off | Reuse an existing proxy |
+| `--learn` | off | Enable live traffic learning |
+| `--memory` | off | Enable persistent cross-session memory |
+| `--backend` | unset | Proxy backend override |
+| `--anyllm-provider` | unset | `anyllm` provider override |
+| `--region` | unset | Cloud region override |
+| `--verbose`, `-v` | off | Verbose output |
+| `grok_args...` | passthrough | Additional Grok Build CLI arguments |
+
+Sets `GROK_CLI_CHAT_PROXY_BASE_URL` so Grok routes cli-chat-proxy traffic through Headroom. Requires the `grok` binary on the host.
 
 ### `headroom wrap copilot`
 


### PR DESCRIPTION
## Summary

Adds first-class Grok Build support to Headroom's wrap and persistent-install flows.

- New `headroom wrap grok` command sets `GROK_CLI_CHAT_PROXY_BASE_URL` and launches the Grok CLI through the local Headroom proxy
- Grok provider slice (`headroom/providers/grok/`) mirrors the Codex env-var pattern
- Registers `grok` as an auto-detectable persistent-install target when `grok` is on PATH
- Allows `headroom install apply --providers manual --target grok`

## Why this env var

Grok Build documents `GROK_CLI_CHAT_PROXY_BASE_URL` for overriding cli-chat-proxy (default `https://cli-chat-proxy.grok.com/v1`). Headroom points it at `http://127.0.0.1:{port}/v1`.

## Test plan

- [x] `UV_SKIP_WHEEL_FILENAME_CHECK=1 uv run --extra dev pytest tests/test_providers/test_grok_runtime.py tests/test_cli/test_wrap_grok.py tests/test_install/test_planner.py tests/test_install/test_providers.py`
- [x] `UV_SKIP_WHEEL_FILENAME_CHECK=1 uv run --extra dev ruff check headroom/cli/install.py headroom/cli/wrap.py headroom/providers/install_registry.py headroom/providers/grok tests/test_cli/test_wrap_grok.py tests/test_providers/test_grok_runtime.py tests/test_install/test_planner.py tests/test_install/test_providers.py`
- [x] `UV_SKIP_WHEEL_FILENAME_CHECK=1 uv run --extra dev ruff format --check headroom/cli/install.py headroom/cli/wrap.py headroom/providers/install_registry.py headroom/providers/grok tests/test_cli/test_wrap_grok.py tests/test_providers/test_grok_runtime.py tests/test_install/test_planner.py tests/test_install/test_providers.py`

Note: `UV_SKIP_WHEEL_FILENAME_CHECK=1` is needed on a fresh worktree because the current `uv.lock` contains an existing malformed `gitpython` wheel filename/version entry.

## Usage

```bash
headroom wrap grok
headroom wrap grok -- -p "fix the bug"
headroom install apply --providers manual --target grok
```
