### PR TITLE
fix(ci): pin cosign-installer to v3 (v4 does not exist)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -317,7 +317,7 @@ jobs:
 
       - name: Install cosign
         if: steps.manifest.outputs.index_digest != ''
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v3
 
       - name: Sign multi-arch index manifest with cosign
         if: steps.manifest.outputs.index_digest != ''


### PR DESCRIPTION
## Problem
The release pipeline's `docker-manifest` jobs fail at action resolution:
```
Unable to resolve action `sigstore/cosign-installer@v4`, unable to find version `v4`
```
`sigstore/cosign-installer` has no `v4`; its current major is `v3`. This broke the multi-arch manifest assembly and `promote-latest` on the v0.24.0 release run (and would break every release). Per-arch image builds and **PyPI/npm/GitHub-Packages publishing were unaffected**.

## Fix
`.github/workflows/docker.yml`: `sigstore/cosign-installer@v4` → `@v3`.

## Verification
Resolves the only failing jobs in release run [27184823371](https://github.com/chopratejas/headroom/actions/runs/27184823371). After merge, the docker-manifest + promote-latest steps will resolve the action and run.