### PR TITLE
chore: relax commitlint footer max line length

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -2,6 +2,7 @@
   "extends": ["@commitlint/config-conventional"],
   "rules": {
     "body-max-line-length": [2, "always", 200],
+    "footer-max-line-length": [2, "always", 200],
     "footer-leading-blank": [0],
     "subject-case": [0],
     "type-enum": [


### PR DESCRIPTION
## Why

Main CI failure in run `27237030606` was in `commitlint`:

> footer's lines must not be longer than 100 characters

The offending commit message includes a long `Co-authored-by`/metadata footer line (`fix: schema compaction ... (#785)`), which exceeded the default limit.

## What

This patch relaxes the commitlint footer length limit:

- `.commitlintrc.json`
  - Added: `"footer-max-line-length": [2, "always", 200]`

## Validation

- PR diff is limited to `.commitlintrc.json` only.
- Current PR check on head commit (`a061cbb6`) shows `GitGuardian Security Checks` passed.
- `mergeStateStatus` is `UNSTABLE` while this PR is cross-repo and appears to require upstream workflow approval (`action_required` check suite state).

Once the check suite is allowed to run, CI should proceed with commitlint using the updated rule.
