### PR TITLE
ci: limit commitlint to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
         run: pytest tests/test_integrations/agno/ -v
 
   commitlint:
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'Merge pull request ')
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -69,11 +69,10 @@ def test_macos_native_wrapper_dependency_install_retries_pypi_downloads() -> Non
     assert "python -m pip install --retries 10 --timeout 60 pytest" in content
 
 
-def test_ci_commitlint_skips_default_github_merge_commits() -> None:
+def test_ci_commitlint_runs_only_for_pull_requests() -> None:
     content = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
-    assert "github.event_name != 'push'" in content
-    assert "!startsWith(github.event.head_commit.message, 'Merge pull request ')" in content
+    assert "github.event_name == 'pull_request'" in content
 
 
 def test_no_openssl_sys_in_wheel_build_tree() -> None:


### PR DESCRIPTION
## Summary
- limit the CI commitlint job to pull request events
- prevent squash-merge commit subjects on `main` from failing post-merge CI
- keep commitlint as a pre-merge PR gate

## Context
- fixes the main-branch CI failure from https://github.com/chopratejas/headroom/actions/runs/27320913096/job/80711562040

## Validation
- `diff --check`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/release-please.yml .github/workflows/docker.yml`
- `act workflow_dispatch -W .github/workflows/release.yml -e .github/act/dry-run.json -n`
- `act release -W .github/workflows/release.yml -e .github/act/release-published.json -n`
- `act push -W .github/workflows/release-please.yml -e .github/act/push-feat.json -n`
- `act workflow_dispatch -W .github/workflows/docker.yml -e .github/act/docker-version.json -n`