### PR TITLE
fix: resolve HEADROOM_MIN_TOKENS/MAX_ITEMS/EXCLUDE_TOOLS env vars in ProxyConfig

### DIFF
--- a/headroom/proxy/models.py
+++ b/headroom/proxy/models.py
@@ -6,6 +6,7 @@ Extracted from server.py to keep the codebase maintainable.
 
 from __future__ import annotations
 
+import os
 from dataclasses import InitVar, dataclass, field
 from datetime import datetime
 from typing import Any, Literal
@@ -85,6 +86,46 @@ class RateLimitState:
     last_update: float
 
 
+def _env_int(name: str, default: int) -> int:
+    """Return *name* parsed as int, or *default* when unset/empty/invalid."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        return default
+
+
+def _env_min_tokens_to_crush() -> int:
+    """Return ``HEADROOM_MIN_TOKENS`` or the ``500`` default."""
+    return _env_int("HEADROOM_MIN_TOKENS", 500)
+
+
+def _env_max_items_after_crush() -> int:
+    """Return ``HEADROOM_MAX_ITEMS`` or the ``50`` default."""
+    return _env_int("HEADROOM_MAX_ITEMS", 50)
+
+
+def _env_exclude_tools() -> set[str] | None:
+    """Return tool names from ``HEADROOM_EXCLUDE_TOOLS``, or ``None`` if unset.
+
+    Comma-separated. Each name is added in both original and lowercase form
+    for case-insensitive matching, mirroring ``_parse_exclude_tools`` in the
+    legacy server entrypoint.
+    """
+    raw = os.environ.get("HEADROOM_EXCLUDE_TOOLS")
+    if not raw:
+        return None
+    names: set[str] = set()
+    for entry in raw.split(","):
+        name = entry.strip()
+        if name:
+            names.add(name)
+            names.add(name.lower())
+    return names or None
+
+
 @dataclass
 class ProxyConfig:
     """Proxy configuration."""
@@ -111,8 +152,10 @@ class ProxyConfig:
     # Optimization
     optimize: bool = True
     image_optimize: bool = True
-    min_tokens_to_crush: int = 500
-    max_items_after_crush: int = 50
+    # Resolved from HEADROOM_MIN_TOKENS / HEADROOM_MAX_ITEMS when the caller
+    # does not pass an explicit value (same pattern as memory_qdrant_* below).
+    min_tokens_to_crush: int = field(default_factory=_env_min_tokens_to_crush)
+    max_items_after_crush: int = field(default_factory=_env_max_items_after_crush)
     keep_last_turns: int = 4
 
     # CCR Tool Injection
@@ -157,7 +200,7 @@ class ProxyConfig:
     # Extra tool names whose outputs are never compressed, merged with the
     # built-in DEFAULT_EXCLUDE_TOOLS. None means built-in defaults only.
     # CLI: --exclude-tools <name1,name2>; env: HEADROOM_EXCLUDE_TOOLS=<name1,name2>
-    exclude_tools: set[str] | None = None
+    exclude_tools: set[str] | None = field(default_factory=_env_exclude_tools)
 
     # Read lifecycle management
     read_lifecycle: bool = True

--- a/tests/test_proxy_config_env_knobs.py
+++ b/tests/test_proxy_config_env_knobs.py
@@ -1,0 +1,92 @@
+"""ProxyConfig resolves compression knobs from env vars (issue #825).
+
+HEADROOM_MIN_TOKENS / HEADROOM_MAX_ITEMS / HEADROOM_EXCLUDE_TOOLS are
+documented on the ProxyConfig fields but were only parsed by the legacy
+argparse entrypoint in server.py — the Click entrypoint (`headroom proxy`,
+used by `headroom install agent run` deployments) builds ProxyConfig without
+reading them, so they were silently inert. The fields now resolve the env
+vars via field(default_factory=...), same pattern as memory_qdrant_*.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from headroom.proxy.models import ProxyConfig
+
+_ENV_VARS = ("HEADROOM_MIN_TOKENS", "HEADROOM_MAX_ITEMS", "HEADROOM_EXCLUDE_TOOLS")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch):
+    """Ensure ambient env vars never leak into these tests."""
+    for name in _ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_defaults_when_env_unset() -> None:
+    config = ProxyConfig()
+
+    assert config.min_tokens_to_crush == 500
+    assert config.max_items_after_crush == 50
+    assert config.exclude_tools is None
+
+
+def test_env_vars_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEADROOM_MIN_TOKENS", "8000")
+    monkeypatch.setenv("HEADROOM_MAX_ITEMS", "200")
+    monkeypatch.setenv("HEADROOM_EXCLUDE_TOOLS", "read_file,WebSearch")
+
+    config = ProxyConfig()
+
+    assert config.min_tokens_to_crush == 8000
+    assert config.max_items_after_crush == 200
+    # Names are kept in original and lowercase form for case-insensitive
+    # matching, mirroring DEFAULT_EXCLUDE_TOOLS.
+    assert config.exclude_tools == {"read_file", "WebSearch", "websearch"}
+
+
+def test_explicit_arguments_win_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEADROOM_MIN_TOKENS", "8000")
+    monkeypatch.setenv("HEADROOM_MAX_ITEMS", "200")
+    monkeypatch.setenv("HEADROOM_EXCLUDE_TOOLS", "read_file")
+
+    config = ProxyConfig(
+        min_tokens_to_crush=1234,
+        max_items_after_crush=42,
+        exclude_tools={"MyTool"},
+    )
+
+    assert config.min_tokens_to_crush == 1234
+    assert config.max_items_after_crush == 42
+    assert config.exclude_tools == {"MyTool"}
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "abc", "8e3"])
+def test_invalid_int_values_fall_back_to_defaults(
+    monkeypatch: pytest.MonkeyPatch, bad: str
+) -> None:
+    monkeypatch.setenv("HEADROOM_MIN_TOKENS", bad)
+    monkeypatch.setenv("HEADROOM_MAX_ITEMS", bad)
+
+    config = ProxyConfig()
+
+    assert config.min_tokens_to_crush == 500
+    assert config.max_items_after_crush == 50
+
+
+@pytest.mark.parametrize("raw", ["", " ,, ", ","])
+def test_empty_exclude_tools_means_none(monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+    monkeypatch.setenv("HEADROOM_EXCLUDE_TOOLS", raw)
+
+    config = ProxyConfig()
+
+    assert config.exclude_tools is None
+
+
+def test_exclude_tools_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEADROOM_EXCLUDE_TOOLS", " read_file , terminal ")
+
+    config = ProxyConfig()
+
+    assert config.exclude_tools == {"read_file", "terminal"}


### PR DESCRIPTION
Fixes #825

## Problem

`HEADROOM_MIN_TOKENS`, `HEADROOM_MAX_ITEMS`, and `HEADROOM_EXCLUDE_TOOLS` are documented on the `ProxyConfig` fields, but only the legacy argparse entrypoint in `proxy/server.py` actually parses them. The Click entrypoint (`headroom proxy` — which is what `headroom install agent run` deployments spawn) builds `ProxyConfig` without reading them, so for deployed proxies these env vars are silently inert: the proxy always runs with the defaults (500 / 50 / built-in exclude list), no matter what the user sets.

Confirmed on 0.23.0 and 0.24.0 (see #825, including @pzfreo's report on 0.24.0).

## Fix

Resolve the env vars in `ProxyConfig` itself via `field(default_factory=...)` — the same pattern already used for the `memory_qdrant_*` fields, and the semantics the `cli/proxy.py` comments already promise ("when omitted we let ProxyConfig's default_factory resolve env vars. Explicit CLI values win over env"):

- `min_tokens_to_crush` ← `HEADROOM_MIN_TOKENS` (invalid/empty → default 500, mirroring `_get_env_int`)
- `max_items_after_crush` ← `HEADROOM_MAX_ITEMS` (default 50)
- `exclude_tools` ← `HEADROOM_EXCLUDE_TOOLS` (comma-separated; each name kept in original + lowercase form for case-insensitive matching, mirroring `_parse_exclude_tools`)

Explicit constructor arguments still win over env vars. No changes to the legacy server entrypoint — it keeps working as before; this just makes the Click path honor the same env vars.

## Tests

`tests/test_proxy_config_env_knobs.py` — 11 tests covering: defaults when unset, env resolution, explicit-args-win-over-env, invalid int fallback (`""`/whitespace/`"abc"`/`"8e3"`), empty/comma-only exclude lists → `None`, whitespace stripping.

All pass locally along with the adjacent suites (`test_cli_proxy_env.py`, `test_models.py`, `test_config.py`, `test_proxy_modes.py` — 118 total). `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)