### PR TITLE
test(compression): fill code handler coverage gaps

### DIFF
--- a/tests/test_compression/test_code_handler.py
+++ b/tests/test_compression/test_code_handler.py
@@ -53,6 +53,96 @@ class TestRegexFallback:
         assert all(result.mask.mask[i] for i in range(len("import os")))
 
 
+class TestLanguageDetection:
+    @pytest.fixture
+    def handler(self):
+        return CodeStructureHandler()
+
+    def test_detects_python(self, handler):
+        code = "import os\n\nclass Foo:\n    def method(self):\n        pass\n"
+        assert handler._detect_language(code) == "python"
+
+    def test_detects_go(self, handler):
+        code = 'package main\n\nimport (\n\t"fmt"\n)\n\nfunc main() {\n}\n'
+        assert handler._detect_language(code) == "go"
+
+    def test_detects_rust(self, handler):
+        code = "use std::io;\n\npub fn main() {\n    let mut x = 1;\n}\n"
+        assert handler._detect_language(code) == "rust"
+
+    def test_falls_back_to_default(self):
+        handler = CodeStructureHandler(default_language="javascript")
+        assert handler._detect_language("plain words only here") == "javascript"
+
+
+class TestRegexFallbackLanguages:
+    """Signature/import preservation on the regex path across languages."""
+
+    @pytest.fixture
+    def handler(self):
+        return CodeStructureHandler(use_tree_sitter=False)
+
+    def test_go_func_signature_preserved(self, handler):
+        code = "func Add(a int, b int) int {\n\treturn a + b\n}\n"
+        result = handler.get_mask(code, language="go")
+        sig = "func Add(a int, b int)"
+        start = code.index(sig)
+        assert all(result.mask.mask[i] for i in range(start, start + len(sig)))
+
+    def test_rust_fn_signature_preserved(self, handler):
+        code = "pub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n"
+        result = handler.get_mask(code, language="rust")
+        sig = "pub fn add(a: i32, b: i32)"
+        start = code.index(sig)
+        assert all(result.mask.mask[i] for i in range(start, start + len(sig)))
+
+    def test_typescript_interface_preserved(self, handler):
+        code = "interface Shape {\n  area(): number;\n}\n\nconst x = 1;\n"
+        result = handler.get_mask(code, language="typescript")
+        sig = "interface Shape"
+        start = code.index(sig)
+        assert all(result.mask.mask[i] for i in range(start, start + len(sig)))
+
+    def test_javascript_arrow_function_preserved(self, handler):
+        code = "const add = (a, b) => {\n  return a + b;\n};\n"
+        result = handler.get_mask(code, language="javascript")
+        sig = "const add = (a, b) =>"
+        start = code.index(sig)
+        assert all(result.mask.mask[i] for i in range(start, start + len(sig)))
+
+    def test_regex_confidence_lower_than_tree_sitter(self, handler):
+        result = handler.get_mask("def f():\n    pass\n", language="python")
+        assert result.confidence == 0.7
+
+
+class TestEdgeCases:
+    @pytest.fixture
+    def handler(self):
+        return CodeStructureHandler()
+
+    def test_empty_content(self, handler):
+        result = handler.get_mask("")
+        assert result.confidence == 0.0
+        assert result.metadata.get("empty") is True
+
+    def test_whitespace_only_content(self, handler):
+        result = handler.get_mask("   \n\n  ")
+        assert result.metadata.get("empty") is True
+
+    def test_unknown_language_regex_no_patterns(self):
+        """A language with no regex patterns yields an all-compressible
+        mask rather than raising."""
+        handler = CodeStructureHandler(use_tree_sitter=False)
+        code = "BEGIN\n  WRITELN('hello')\nEND.\n"
+        result = handler.get_mask(code, language="pascal")
+        assert not any(result.mask.mask)
+
+    def test_mask_length_matches_content(self, handler):
+        code = "def f():\n    return 1\n"
+        result = handler.get_mask(code, language="python")
+        assert len(result.mask.mask) == len(code)
+
+
 @requires_tree_sitter
 class TestTreeSitterContainers:
     """Container bodies must stay compressible (signature-only spans).


### PR DESCRIPTION
## Description

`CodeStructureHandler` had zero dedicated tests before this series — which is exactly why the P0 bugs in #890/#892/#893 went unnoticed. This fills the remaining coverage gaps beyond the per-fix regression tests. Stacked on #893.

Closes # <!-- compression-handler review -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)

## Changes Made

- `tests/test_compression/test_code_handler.py`: language detection (python/go/rust + default fallback); regex-path signature/import preservation across go/rust/typescript/javascript; regex confidence value; empty/whitespace content; unknown language; mask-length invariant.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_compression/test_code_handler.py -q
25 passed
```

## Real Behavior Proof

- Environment: local macOS, Python 3.11, tree-sitter-language-pack 1.8.1, branch `test/code-handler-coverage` (stacked on #893).
- Exact command / steps: `pytest tests/test_compression/test_code_handler.py -q`.
- Observed result: 25 tests pass; tree-sitter classes skip cleanly when the pack is absent, regex-path tests always run.
- Not tested: N/A — this PR is tests only.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A — tests only. See Test Output.

## Additional Notes

Stacked on #893 — review the top commit until that merges. PR 6 of 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
