### PR TITLE
chore(compression): handler cleanups from review

### DIFF
--- a/headroom/compression/handlers/code_handler.py
+++ b/headroom/compression/handlers/code_handler.py
@@ -20,7 +20,6 @@ import logging
 import re
 import threading
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any
 
 from headroom.compression.handlers.base import BaseStructureHandler, HandlerResult
@@ -105,19 +104,6 @@ def _ts_children(node: Any) -> list[Any]:
     if children is not None and not callable(children):
         return list(children)
     return [node.child(i) for i in range(node.child_count())]
-
-
-class CodeLanguage(Enum):
-    """Supported programming languages."""
-
-    PYTHON = "python"
-    JAVASCRIPT = "javascript"
-    TYPESCRIPT = "typescript"
-    GO = "go"
-    RUST = "rust"
-    JAVA = "java"
-    C = "c"
-    CPP = "cpp"
 
 
 @dataclass
@@ -235,6 +221,16 @@ _CONTAINER_BODY_TYPES: frozenset[str] = frozenset(
         "enum_body",  # java enum body
     }
 )
+
+# Language-detection markers for _detect_language
+_LANGUAGE_MARKERS: dict[str, list[str]] = {
+    "python": ["def ", "import ", "from ", "class ", "async def"],
+    "javascript": ["function ", "const ", "let ", "var ", "=>"],
+    "typescript": ["interface ", "type ", ": string", ": number"],
+    "go": ["func ", "package ", "import (", "type "],
+    "rust": ["fn ", "let mut", "impl ", "pub fn", "use "],
+    "java": ["public class", "private ", "protected ", "void "],
+}
 
 # Import patterns for fallback
 _IMPORT_PATTERNS: dict[str, re.Pattern[str]] = {
@@ -567,8 +563,10 @@ class CodeStructureHandler(BaseStructureHandler):
 
         for span in spans:
             if span.is_structural:
-                for i in range(span.start, min(span.end, length)):
-                    mask[i] = True
+                start = min(span.start, length)
+                end = min(span.end, length)
+                if start < end:
+                    mask[start:end] = [True] * (end - start)
 
         return mask
 
@@ -581,18 +579,8 @@ class CodeStructureHandler(BaseStructureHandler):
         Returns:
             Language name (lowercase).
         """
-        # Check for language-specific markers
-        markers = {
-            "python": ["def ", "import ", "from ", "class ", "async def"],
-            "javascript": ["function ", "const ", "let ", "var ", "=>"],
-            "typescript": ["interface ", "type ", ": string", ": number"],
-            "go": ["func ", "package ", "import (", "type "],
-            "rust": ["fn ", "let mut", "impl ", "pub fn", "use "],
-            "java": ["public class", "private ", "protected ", "void "],
-        }
-
         scores: dict[str, int] = {}
-        for lang, patterns in markers.items():
+        for lang, patterns in _LANGUAGE_MARKERS.items():
             scores[lang] = sum(1 for p in patterns if p in content)
 
         if not scores or max(scores.values()) == 0:

--- a/headroom/compression/handlers/json_handler.py
+++ b/headroom/compression/handlers/json_handler.py
@@ -183,11 +183,8 @@ class JSONStructureHandler(BaseStructureHandler):
                 for i in range(token.start, min(token.end, len(mask))):
                     mask[i] = True
 
-        # Convert to character tokens if needed
-        char_tokens = list(content) if tokens == list(content) else tokens
-
         return HandlerResult(
-            mask=StructureMask(tokens=char_tokens, mask=mask),
+            mask=StructureMask(tokens=tokens, mask=mask),
             handler_name=self.name,
             confidence=1.0,
             metadata={
@@ -323,7 +320,9 @@ class JSONStructureHandler(BaseStructureHandler):
                 i += 1
                 while i < n and content[i] != '"':
                     if content[i] == "\\":
-                        i += 2  # Skip escaped character
+                        # Clamp: a trailing backslash at EOF must not
+                        # step past the buffer.
+                        i = min(i + 2, n)
                     else:
                         i += 1
                 i += 1  # Include closing quote


### PR DESCRIPTION
## Description

Mechanical cleanups flagged in the review, no behaviour changes. Final PR of the 7-PR series; merges both the json and code chains.

Closes # <!-- compression-handler review -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)

## Changes Made

- `headroom/compression/handlers/json_handler.py`: remove a dead no-op (`list(content) if tokens == list(content) else tokens` returned `tokens` in both branches); clamp the string-escape scan so a trailing backslash at EOF can't overrun.
- `headroom/compression/handlers/code_handler.py`: remove the unused `CodeLanguage` enum and its import; slice-assign in `_spans_to_mask` instead of a per-char loop; hoist `_detect_language` markers to a module constant.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_compression/ -q
111 passed, 8 skipped
```

## Real Behavior Proof

- Environment: local macOS, Python 3.11, tree-sitter-language-pack 1.8.1, branch `chore/handler-cleanups` (merges both chains).
- Exact command / steps: `pytest tests/test_compression/ -q`.
- Observed result: Full compression suite passes (111) with no behaviour change; dead code removed and the escape scan no longer risks overrunning the buffer.
- Not tested: No new behaviour to test — cleanups only, covered by the existing suite.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A — cleanup only. See Test Output.

## Additional Notes

Depends on all of #887/#889/#890/#892/#893/#895 — review the top commit. PR 7 of 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
