### PR TITLE
docs: fix dead contact links in issue templates and troubleshooting guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Questions & Discussions
-    url: https://github.com/headroom-sdk/headroom/discussions
+    url: https://github.com/chopratejas/headroom/discussions
     about: Ask questions and discuss ideas in GitHub Discussions
   - name: Documentation
-    url: https://headroom.dev/docs
+    url: https://headroom-docs.vercel.app/docs
     about: Check out the documentation for guides and API reference

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -421,4 +421,4 @@ print(f"Tokens: {result.tokens_before} -> {result.tokens_after}")
 1. Enable debug logging and check the output
 2. Use `simulate()` to see what transforms would apply
 3. Run `validate_setup()` for configuration issues
-4. File an issue at [github.com/headroom-sdk/headroom](https://github.com/headroom-sdk/headroom/issues) with your Headroom version, Python version, provider, debug log output, and minimal reproduction code
+4. File an issue at [github.com/chopratejas/headroom](https://github.com/chopratejas/headroom/issues) with your Headroom version, Python version, provider, debug log output, and minimal reproduction code


### PR DESCRIPTION
## Summary

The side note in #855 reports that the **Issues → Question** contact link points to a non-existing page. Confirmed, plus two more dead links of the same class:

- `.github/ISSUE_TEMPLATE/config.yml` — "Questions & Discussions" points at `github.com/headroom-sdk/headroom/discussions` (the `headroom-sdk` org 404s); now points at this repo's Discussions (live, Discussions are enabled here).
- `.github/ISSUE_TEMPLATE/config.yml` — "Documentation" points at `headroom.dev/docs` (404); now points at the repo homepage docs site `headroom-docs.vercel.app/docs` (200).
- `docs/content/docs/troubleshooting.mdx` — "File an issue at github.com/headroom-sdk/headroom" same dead org; now points at this repo.

`.github/FUNDING.yml` also references `headroom-sdk` but that's a sponsorship target choice, so left untouched.

## Testing

Link targets verified by HTTP status: old URLs return 404, new URLs return 200. Docs-only change, no code paths affected.

Fixes the side note in #855.
