### PR TITLE
fix(tests): stub dashboard routes by URL path in TTL playwright test

### DIFF
--- a/tests/test_dashboard_cache_ttl_playwright.py
+++ b/tests/test_dashboard_cache_ttl_playwright.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -161,21 +162,24 @@ def _install_dashboard_routes(page: Page) -> None:
     dashboard_html = get_dashboard_html()
 
     def handler(route) -> None:  # type: ignore[no-untyped-def]
-        url = route.request.url
-        if url.endswith("/dashboard") or url == "http://headroom.local/":
+        # Match on the URL path only: the dashboard fetches /stats?cached=1,
+        # so suffix checks against the full URL miss it and the request
+        # escapes the harness to the real network.
+        path = urlsplit(route.request.url).path
+        if path in ("/dashboard", "/"):
             route.fulfill(status=200, content_type="text/html", body=dashboard_html)
             return
-        if url.endswith("/stats"):
-            route.fulfill(status=200, content_type="application/json", body=json.dumps(stats))
-            return
-        if "/stats-history" in url:
+        if "/stats-history" in path:
             route.fulfill(
                 status=200,
                 content_type="application/json",
                 body=json.dumps(history),
             )
             return
-        if url.endswith("/health"):
+        if path.endswith("/stats"):
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(stats))
+            return
+        if path.endswith("/health"):
             route.fulfill(status=200, content_type="application/json", body=json.dumps(health))
             return
         route.continue_()


### PR DESCRIPTION
## Summary

Closes #914.

`tests/test_dashboard_cache_ttl_playwright.py` fails when playwright is actually installed: the dashboard fetches `/stats?cached=1`, so the harness's `url.endswith("/stats")` check misses it, the request escapes the stub to the real network, Alpine init lands in the Error state, and the TTL section never renders. The failure is invisible in CI because playwright isn't installed there — `pytest.importorskip` skips the whole module.

Fix: match stubbed routes on the URL **path** (`urlsplit(...).path`), with `/stats-history` checked before the `/stats` suffix. Same harness pattern as the new test in #913.

Correction to #914 as filed: the text assertions are NOT stale — "Observed TTL Buckets" still exists in the markup. They only appeared stale because the section never rendered without stats. The route handler was the single root cause.

## Testing

```
tests/test_dashboard_cache_ttl_playwright.py .    1 passed in 3.47s
```

Run locally under chromium (`pip install playwright && playwright install chromium`). `ruff check` and `ruff format --check` clean.

Follow-up worth considering (not in this PR): install playwright in a CI job so the dashboard playwright tests stop skipping forever.
