### PR TITLE
ci: run dashboard playwright tests in a dedicated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,48 @@ jobs:
       - name: Run agno tests
         run: pytest tests/test_integrations/agno/ -v
 
+  test-dashboard-ui:
+    needs: [changes, build-wheel]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PY_VERSION }}
+      - name: Download prebuilt wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: headroom-wheel
+          path: dist
+      - name: Install (CPU torch + wheel[dev] + playwright)
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          WHEEL="$(ls dist/*.whl)"
+          pip install "${WHEEL}[dev]" playwright
+          SITE="$(python -c 'import sysconfig; print(sysconfig.get_path("platlib"))')"
+          cp "${SITE}/headroom/"_core*.so headroom/
+      - name: Install chromium
+        run: playwright install --with-deps chromium
+      - name: Run dashboard playwright tests
+        # Stub-based dashboard tests only (routes fully mocked, no network).
+        # tests/test_dashboard/test_live_feed.py needs a live proxy on
+        # localhost:8787 and stays excluded; the main shards keep skipping
+        # these via importorskip since playwright is not installed there.
+        env:
+          HEADROOM_PLAYWRIGHT_ARTIFACT_DIR: ${{ runner.temp }}/playwright-artifacts
+        run: pytest tests/test_dashboard_*_playwright.py -v
+      - name: Upload dashboard screenshots
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dashboard-playwright-artifacts
+          path: ${{ runner.temp }}/playwright-artifacts
+          if-no-files-found: ignore
+          retention-days: 7
+
   commitlint:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/tests/test_dashboard_cache_ttl_playwright.py
+++ b/tests/test_dashboard_cache_ttl_playwright.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -161,21 +162,24 @@ def _install_dashboard_routes(page: Page) -> None:
     dashboard_html = get_dashboard_html()
 
     def handler(route) -> None:  # type: ignore[no-untyped-def]
-        url = route.request.url
-        if url.endswith("/dashboard") or url == "http://headroom.local/":
+        # Match on the URL path only: the dashboard fetches /stats?cached=1,
+        # so suffix checks against the full URL miss it and the request
+        # escapes the harness to the real network.
+        path = urlsplit(route.request.url).path
+        if path in ("/dashboard", "/"):
             route.fulfill(status=200, content_type="text/html", body=dashboard_html)
             return
-        if url.endswith("/stats"):
-            route.fulfill(status=200, content_type="application/json", body=json.dumps(stats))
-            return
-        if "/stats-history" in url:
+        if "/stats-history" in path:
             route.fulfill(
                 status=200,
                 content_type="application/json",
                 body=json.dumps(history),
             )
             return
-        if url.endswith("/health"):
+        if path.endswith("/stats"):
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(stats))
+            return
+        if path.endswith("/health"):
             route.fulfill(status=200, content_type="application/json", body=json.dumps(health))
             return
         route.continue_()


### PR DESCRIPTION
## Summary

Closes #920. Follow-up noted in #915.

The dashboard Playwright tests guard on `pytest.importorskip("playwright...")` and no CI job installs playwright, so they have skipped on every CI run since they were added — which is how the bitrot fixed in #915 went unnoticed.

This adds a `test-dashboard-ui` job to `ci.yml`, same shape as `test-agno`:

- installs the prebuilt wheel `[dev]` + playwright, then `playwright install --with-deps chromium`
- runs `pytest tests/test_dashboard_*_playwright.py` — the stub-based tests only (all routes mocked via `page.route`, no network); the glob also picks up the CVC panel tests from #913 once that merges
- sets `HEADROOM_PLAYWRIGHT_ARTIFACT_DIR` and uploads the captured dashboard screenshots as a workflow artifact (7-day retention), so every CI run leaves a visual record of the rendered dashboard

Deliberately excluded: `tests/test_dashboard/test_live_feed.py` — it navigates to a live proxy on `localhost:8787` and would fail on a runner with nothing listening. The main test shards keep skipping playwright tests (playwright stays uninstalled there), so nothing double-runs.

## Testing

- `yaml.safe_load` parses the workflow; the `workflow-validation` CI job (actionlint + act) runs on this PR since it touches `ci.yml`
- The test this job will run passes locally: `tests/test_dashboard_cache_ttl_playwright.py` — 1 passed (chromium)
- This PR's own CI run exercises the new job end-to-end
