### PR TITLE
feat: add Qoder CLI init support

### DIFF
--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -53,9 +53,10 @@ _CODEX_PROVIDER_MARKER_START = "# --- Headroom init provider ---"
 _CODEX_PROVIDER_MARKER_END = "# --- end Headroom init provider ---"
 _CODEX_FEATURE_MARKER_START = "# --- Headroom init features ---"
 _CODEX_FEATURE_MARKER_END = "# --- end Headroom init features ---"
-_SUPPORTED_TARGETS = ("claude", "copilot", "codex", "openclaw")
+_QODERCLI_HOOK_MARKER = "headroom-init-qodercli"
+_SUPPORTED_TARGETS = ("claude", "copilot", "codex", "openclaw", "qodercli")
 _LOCAL_TARGETS = {"claude", "codex"}
-_GLOBAL_TARGETS = {"claude", "copilot", "codex", "openclaw"}
+_GLOBAL_TARGETS = {"claude", "copilot", "codex", "openclaw", "qodercli"}
 _STARTUP_READY_TIMEOUT_SECONDS = 15
 _TOML_TABLE_HEADER_RE = re.compile(r"^[ \t]*(?:\[\[[^\]\r\n]+\]\]|\[[^\]\r\n]+\])[ \t]*(?:#.*)?$")
 _TOML_FEATURES_NAME_RE = r"(?:features|\"features\"|'features')"
@@ -139,6 +140,16 @@ def _codex_scope_path(global_scope: bool) -> Path:
     return Path.cwd() / ".codex" / "config.toml"
 
 
+def _qodercli_scope_path(global_scope: bool) -> Path:
+    from headroom.install.paths import qodercli_config_path
+
+    if global_scope:
+        return qodercli_config_path()
+    raise click.ClickException(
+        "Qoder CLI durable init currently requires -g (current-user scope)."
+    )
+
+
 def _json_file(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
@@ -218,6 +229,50 @@ def _ensure_copilot_hooks(path: Path, profile: str) -> None:
             )
         ]
         retained.append({"type": "command", "command": command, "cwd": ".", "timeout": 15})
+        hooks[event] = retained
+    payload["hooks"] = hooks
+    _write_json(path, payload)
+
+
+def _ensure_qodercli_hooks(path: Path, profile: str, port: int) -> None:
+    logger.debug("ensure qodercli hooks: %s (profile=%s, port=%s)", path, profile, port)
+    payload = _json_file(path)
+    hooks = dict(payload.get("hooks") or {}) if isinstance(payload.get("hooks"), dict) else {}
+    command = _hook_command("--profile", profile)
+    for event, matcher in (
+        ("SessionStart", "startup|resume"),
+        ("PreToolUse", _powershell_matcher()),
+    ):
+        entries = list(hooks.get(event) or []) if isinstance(hooks.get(event), list) else []
+        retained: list[dict[str, Any]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                retained.append(entry)
+                continue
+            hook_items = entry.get("hooks")
+            if not isinstance(hook_items, list):
+                retained.append(entry)
+                continue
+            has_headroom = any(
+                isinstance(item, dict)
+                and item.get("command")
+                and _QODERCLI_HOOK_MARKER in str(item.get("command"))
+                for item in hook_items
+            )
+            if not has_headroom:
+                retained.append(entry)
+        retained.append(
+            {
+                "matcher": matcher,
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": f"{command} --marker {_QODERCLI_HOOK_MARKER}",
+                        "timeout": 15,
+                    }
+                ],
+            }
+        )
         hooks[event] = retained
     payload["hooks"] = hooks
     _write_json(path, payload)
@@ -808,6 +863,16 @@ def _init_openclaw(*, global_scope: bool, port: int) -> None:
         raise SystemExit(result.returncode)
 
 
+def _init_qodercli(*, global_scope: bool, profile: str) -> None:
+    if not global_scope:
+        raise click.ClickException(
+            "Qoder CLI durable init currently requires -g (current-user scope)."
+        )
+    _ensure_qodercli_hooks(_qodercli_scope_path(global_scope), profile, port=8787)
+    click.echo("Configured Qoder CLI (user scope).")
+    click.echo("Restart Qoder CLI to activate Headroom hooks.")
+
+
 def _run_init_targets(
     *,
     targets: list[str],
@@ -847,6 +912,8 @@ def _run_init_targets(
             _init_codex(global_scope=global_scope, profile=profile, port=port)
         elif target == "openclaw":
             _init_openclaw(global_scope=global_scope, port=port)
+        elif target == "qodercli":
+            _init_qodercli(global_scope=global_scope, profile=profile)
 
     # Register the headroom MCP server with every targeted agent that has
     # a registrar implemented. Wave 1 covers Claude Code; subsequent waves
@@ -997,6 +1064,21 @@ def init_openclaw(ctx: click.Context) -> None:
     """Install the durable OpenClaw Headroom plugin."""
     _run_init_targets(
         targets=["openclaw"],
+        global_scope=bool(_ctx_value(ctx, "global_scope")),
+        port=int(_ctx_value(ctx, "port") or 8787),
+        backend=str(_ctx_value(ctx, "backend") or "anthropic"),
+        anyllm_provider=_ctx_value(ctx, "anyllm_provider"),
+        region=_ctx_value(ctx, "region"),
+        memory=bool(_ctx_value(ctx, "memory")),
+    )
+
+
+@init.command("qodercli")
+@click.pass_context
+def init_qodercli(ctx: click.Context) -> None:
+    """Install Qoder CLI durable hooks."""
+    _run_init_targets(
+        targets=["qodercli"],
         global_scope=bool(_ctx_value(ctx, "global_scope")),
         port=int(_ctx_value(ctx, "port") or 8787),
         backend=str(_ctx_value(ctx, "backend") or "anthropic"),

--- a/headroom/install/models.py
+++ b/headroom/install/models.py
@@ -56,6 +56,7 @@ class ToolTarget(str, Enum):
     AIDER = "aider"
     CURSOR = "cursor"
     OPENCLAW = "openclaw"
+    QODERCLI = "qodercli"
 
 
 def iso_utc_now() -> str:

--- a/headroom/install/paths.py
+++ b/headroom/install/paths.py
@@ -114,6 +114,12 @@ def codex_config_path() -> Path:
     return Path.home() / ".codex" / "config.toml"
 
 
+def qodercli_config_path() -> Path:
+    """Return the Qoder CLI settings path."""
+
+    return Path.home() / ".qoder" / "settings.json"
+
+
 def openclaw_config_path() -> Path:
     """Return the OpenClaw config path."""
 

--- a/headroom/install/planner.py
+++ b/headroom/install/planner.py
@@ -27,6 +27,7 @@ SUPPORTED_TARGETS = [
     ToolTarget.AIDER,
     ToolTarget.CURSOR,
     ToolTarget.OPENCLAW,
+    ToolTarget.QODERCLI,
 ]
 PROVIDER_SCOPE_TARGETS = [
     ToolTarget.CLAUDE,

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -69,7 +69,7 @@ def test_init_fails_when_auto_detection_empty(monkeypatch) -> None:
     assert "No supported user-scope agents were found on PATH" in result.output
     assert "probed the following agents" in result.output
     # Every in-scope target is listed with its lookup status.
-    for target in ("claude", "codex", "copilot", "openclaw"):
+    for target in ("claude", "codex", "copilot", "openclaw", "qodercli"):
         assert target in result.output
     # The user is told that -g is still valid and given a concrete next step.
     assert "-g" in result.output
@@ -138,7 +138,7 @@ def test_init_verbose_enables_debug_logging_on_stderr(monkeypatch) -> None:
     assert "[headroom init]" in stderr
     assert "detect_init_targets" in stderr
     assert "global_scope=True" in stderr
-    for target in ("claude", "codex", "copilot", "openclaw"):
+    for target in ("claude", "codex", "copilot", "openclaw", "qodercli"):
         assert target in stderr
 
 
@@ -311,16 +311,41 @@ def test_init_openclaw_delegates_to_wrap(monkeypatch) -> None:
     assert calls == [["headroom", "wrap", "openclaw", "--proxy-port", "9999"]]
 
 
+def test_init_qodercli_requires_global(monkeypatch) -> None:
+    _, fake_main = _load_init_module(monkeypatch)
+    runner = CliRunner()
+
+    result = runner.invoke(fake_main, ["init", "qodercli"])
+
+    assert result.exit_code != 0
+    assert "requires -g" in result.output
+
+
+def test_init_qodercli_writes_hooks(monkeypatch, tmp_path: Path) -> None:
+    init_cli, _ = _load_init_module(monkeypatch)
+    monkeypatch.setattr(
+        init_cli, "_qodercli_scope_path", lambda global_scope: tmp_path / "qoder" / "settings.json"
+    )
+
+    init_cli._init_qodercli(global_scope=True, profile="init-user")
+
+    payload = json.loads((tmp_path / "qoder" / "settings.json").read_text(encoding="utf-8"))
+    assert "SessionStart" in payload["hooks"]
+    assert "PreToolUse" in payload["hooks"]
+    assert "--profile init-user" in payload["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+    assert "headroom-init-qodercli" in payload["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+
+
 def test_detect_init_targets_respects_scope(monkeypatch) -> None:
     init_cli, _ = _load_init_module(monkeypatch)
     monkeypatch.setattr(
         init_cli.shutil,
         "which",
-        lambda name: name if name in {"claude", "copilot", "codex", "openclaw"} else None,
+        lambda name: name if name in {"claude", "copilot", "codex", "openclaw", "qodercli"} else None,
     )
 
     assert init_cli.detect_init_targets(False) == ["claude", "codex"]
-    assert init_cli.detect_init_targets(True) == ["claude", "copilot", "codex", "openclaw"]
+    assert init_cli.detect_init_targets(True) == ["claude", "copilot", "codex", "openclaw", "qodercli"]
 
 
 def test_marketplace_source_prefers_env_override(monkeypatch) -> None:
@@ -1264,9 +1289,14 @@ def test_run_init_targets_dispatches_supported_targets(monkeypatch) -> None:
         "_init_openclaw",
         lambda **kwargs: calls.append(("openclaw", (kwargs["global_scope"], kwargs["port"]))),
     )
+    monkeypatch.setattr(
+        init_cli,
+        "_init_qodercli",
+        lambda **kwargs: calls.append(("qodercli", (kwargs["global_scope"], kwargs["profile"]))),
+    )
 
     init_cli._run_init_targets(
-        targets=["claude", "copilot", "codex", "openclaw"],
+        targets=["claude", "copilot", "codex", "openclaw", "qodercli"],
         global_scope=True,
         port=9000,
         backend="openai",
@@ -1280,6 +1310,7 @@ def test_run_init_targets_dispatches_supported_targets(monkeypatch) -> None:
         ("copilot", (True, "init-profile", 9000)),
         ("codex", (True, "init-profile", 9000)),
         ("openclaw", (True, 9000)),
+        ("qodercli", (True, "init-profile")),
     ]
 
 


### PR DESCRIPTION
# feat: add Qoder CLI init support

## Summary
Adds Qoder CLI as a first-class target in `headroom init`, enabling automatic hook installation and Headroom MCP server registration for Qoder CLI users.

## Changes
- New init `qodercli` subcommand — installs durable hooks via `~/.qoder/settings.json` (user scope only, `-g` required)
- Hook injection — adds `SessionStart` and `PreToolUse` hook entries with the `headroom-init-qodercli` marker, following the same pattern as existing Codex/Claude hooks
- Path resolution — adds `qodercli_config_path()` in `install/paths.py`
- Model/planner registration — adds `ToolTarget.QODERCLI` enum and includes it in `SUPPORTED_TARGETS`
- Auto-detection — `qodercli` is included in global-scope target auto-detection alongside existing agents
- Tests — covers global-scope enforcement, hook payload validation, and integration with `_run_init_targets` dispatch

## Usage
```bash
# Install Headroom hooks for Qoder CLI (user scope)
headroom init qodercli -g

# Auto-detect and init all available agents including Qoder CLI
headroom init -g